### PR TITLE
Configure PWM ClockFrequency (fix towards V2.7.7 release)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 ===2.7.7===
 * Allow cell module to connect to roaming network (roaming charges may apply)
 * MK1: fix RPM stuck at zero if RPM signal is applied before RCP unit is powered up
+* PWM clock frequency now settable via Lua script, was fixed at 20KHz before.
  
 ===2.7.6===
 * Ensure timestamps show on every sample, regardless of sample rate combinations

--- a/SAM7s_base/PWM_at91/PWM_device_at91.c
+++ b/SAM7s_base/PWM_at91/PWM_device_at91.c
@@ -148,7 +148,7 @@ static void PWM_configure_ports(){
 			AT91C_PIO_PA7); // mux funtion B
 }
 
-void PWM_device_configure_clock(unsigned short clockFrequency){
+void PWM_device_set_clock_frequency(unsigned short clockFrequency){
 	PWM_ConfigureClocks(clockFrequency * MAX_DUTY_CYCLE, 0, BOARD_MCK);
 }
 

--- a/include/PWM/PWM.h
+++ b/include/PWM/PWM.h
@@ -14,6 +14,7 @@
 
 int PWM_init(LoggerConfig *loggerConfig);
 
+void PWM_set_clock_frequency(uint16_t clockFrequency);
 void PWM_set_duty_cycle(unsigned int channel, unsigned short duty);
 unsigned short PWM_get_duty_cycle(unsigned short channel);
 

--- a/include/PWM/PWM_device.h
+++ b/include/PWM/PWM_device.h
@@ -12,7 +12,7 @@
 
 int PWM_device_init(void);
 void PWM_device_channel_init(unsigned int channel, unsigned short period, unsigned short dutyCycle);
-void PWM_device_configure_clock(unsigned short clockFrequency);
+void PWM_device_set_clock_frequency(unsigned short clockFrequency);
 
 void PWM_device_set_duty_cycle(unsigned int channel, unsigned short duty);
 unsigned short PWM_device_get_duty_cycle(unsigned int channel);

--- a/include/PWM/PWM_device.h
+++ b/include/PWM/PWM_device.h
@@ -12,7 +12,7 @@
 
 int PWM_device_init(void);
 void PWM_device_channel_init(unsigned int channel, unsigned short period, unsigned short dutyCycle);
-void PWM_device_set_clock_frequency(unsigned short clockFrequency);
+void PWM_device_set_clock_frequency(uint16_t clockFrequency);
 
 void PWM_device_set_duty_cycle(unsigned int channel, unsigned short duty);
 unsigned short PWM_device_get_duty_cycle(unsigned int channel);

--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -260,9 +260,9 @@ typedef struct _PWMConfig{
 } PWMConfig;
 
 /// PWM frequency in Hz.
-#define MAX_PWM_CLOCK_FREQUENCY             200000
-#define MIN_PWM_CLOCK_FREQUENCY	 	10
-#define DEFAULT_PWM_CLOCK_FREQUENCY			10000
+#define MAX_PWM_CLOCK_FREQUENCY             65000
+#define MIN_PWM_CLOCK_FREQUENCY	 			10
+#define DEFAULT_PWM_CLOCK_FREQUENCY			20000
 
 /// Maximum duty cycle value.
 #define MAX_PWM_DUTY_CYCLE              	100
@@ -527,7 +527,7 @@ char filterPwmLoggingMode(int config);
 unsigned short filterPwmDutyCycle(int dutyCycle);
 unsigned short filterPwmPeriod(int period);
 int filterImuRawValue(int accelRawValue);
-int filterPwmClockFrequency(int frequency);
+uint16_t filterPwmClockFrequency(uint16_t frequency);
 char filterTimerMode(int config);
 unsigned char filterPulsePerRevolution(unsigned char pulsePerRev);
 unsigned short filterTimerDivider(unsigned short divider);

--- a/src/PWM/PWM.c
+++ b/src/PWM/PWM.c
@@ -7,7 +7,8 @@ static void init_pwm_channel(size_t channelId, PWMConfig *pc){
 
 int PWM_init(LoggerConfig *loggerConfig){
 	PWM_device_init();
-	PWM_device_configure_clock(loggerConfig->PWMClockFrequency);
+	PWM_set_clock_frequency(loggerConfig->PWMClockFrequency);
+
 	for (size_t i = 0; i < CONFIG_PWM_CHANNELS; i++)
 	{
 		PWMConfig *pwmConfig = &(loggerConfig->PWMConfigs[i]);
@@ -21,6 +22,10 @@ int PWM_init(LoggerConfig *loggerConfig){
 	}
 	PWM_update_config(loggerConfig);
 	return 1;
+}
+
+void PWM_set_clock_frequency(uint16_t clockFrequency){
+	PWM_device_set_clock_frequency(clockFrequency);
 }
 
 int PWM_update_config(LoggerConfig *loggerConfig){

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -420,7 +420,7 @@ unsigned short filterPwmPeriod(int period){
 	return period;
 }
 
-int filterPwmClockFrequency(int freq){
+uint16_t filterPwmClockFrequency(uint16_t freq){
 	if (freq > MAX_PWM_CLOCK_FREQUENCY){
 		freq = MAX_PWM_CLOCK_FREQUENCY;
 	} else if (freq < MIN_PWM_CLOCK_FREQUENCY){

--- a/src/logger/luaLoggerBinding.c
+++ b/src/logger/luaLoggerBinding.c
@@ -128,7 +128,11 @@ int Lua_GetAtSplit(lua_State *L){
 
 int Lua_SetPWMClockFrequency(lua_State *L){
 	if (lua_gettop(L) >= 1){
-		getWorkingLoggerConfig()->PWMClockFrequency = filterPwmClockFrequency(lua_tointeger(L,1));
+		LoggerConfig *loggerConfig = getWorkingLoggerConfig();
+
+		uint16_t clock_frequency = filterPwmClockFrequency(lua_tointeger(L,1));
+		loggerConfig->PWMClockFrequency = clock_frequency;
+		PWM_set_clock_frequency(clock_frequency);
 	}
 	return 0;
 }

--- a/stm32_base/hal/PWM_stm32/PWM_device_stm32.c
+++ b/stm32_base/hal/PWM_stm32/PWM_device_stm32.c
@@ -155,7 +155,8 @@ unsigned short PWM_device_channel_get_period(unsigned int channel){
 }
 
 void PWM_device_set_duty_cycle(unsigned int channel, unsigned short duty){
-	uint32_t CCR_period = (g_currentClockPeriod * 100) / (1000/duty) / 10;
+	duty = duty > MAX_DUTY_CYCLE ? MAX_DUTY_CYCLE : duty;
+	uint32_t CCR_period = (g_currentClockPeriod * 100) / (1000 / duty) / 10;
 	switch(channel){
 		case 0:
 			TIM4->CCR4 = CCR_period;

--- a/stm32_base/hal/PWM_stm32/PWM_device_stm32.c
+++ b/stm32_base/hal/PWM_stm32/PWM_device_stm32.c
@@ -83,8 +83,8 @@ int PWM_device_init(){
 
 void PWM_device_set_clock_frequency(uint16_t clockFrequency){
 
-	uint32_t period = (1000 * ((CLOCK_FREQUENCY_PERIOD_SCALING * 10000)/clockFrequency)) / 10000;
-	uint16_t prescaler = (uint16_t) ((SystemCoreClock) / CLOCK_FREQUENCY_PRESCALER_SCALING) - 1;
+	const uint32_t period = (1000 * ((CLOCK_FREQUENCY_PERIOD_SCALING * 10000)/clockFrequency)) / 10000;
+	const uint16_t prescaler = (uint16_t) ((SystemCoreClock) / CLOCK_FREQUENCY_PRESCALER_SCALING) - 1;
 
 	TIM_TimeBaseInitTypeDef timerInitStructure;
 	timerInitStructure.TIM_Prescaler = prescaler;

--- a/stm32_base/hal/PWM_stm32/PWM_device_stm32.c
+++ b/stm32_base/hal/PWM_stm32/PWM_device_stm32.c
@@ -10,8 +10,6 @@
 #define MAX_DUTY_CYCLE 100
 #define PWM_CHANNEL_COUNT 4
 
-#define DEFAULT_PERIOD 1000
-
 typedef struct _pwm {
 	uint32_t pin;
 	uint16_t pinSource;
@@ -36,6 +34,8 @@ static gpio analogCtrlGpios[] = {
 	{ RCC_AHB1Periph_GPIOE, GPIOE, GPIO_Pin_0},
 	{ RCC_AHB1Periph_GPIOE, GPIOE, GPIO_Pin_1}
 };
+
+static uint16_t g_currentClockPeriod = 0;
 
 static void setAnalogControlGpio(size_t port, uint8_t state){
 	if (port < PWM_CHANNEL_COUNT){
@@ -69,14 +69,18 @@ static void initAnalogControlGpios(){
 int PWM_device_init(){
 
 	initAnalogControlGpios();
-
-	uint32_t period = DEFAULT_PERIOD;
-
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM4, ENABLE);
 	RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOD, ENABLE);
 
-	uint16_t prescaler = (uint16_t) ((SystemCoreClock) / 210000) - 1;
-	prescaler = 4 - 1;
+	return 1;
+}
+
+void PWM_device_set_clock_frequency(unsigned short clockFrequency){
+
+	//magic numbers follow 20970 = trimmmed value.
+	//adjust to calibrate further.
+	uint32_t period = (1000 * ((20970 * 10000)/clockFrequency)) / 10000;
+	uint16_t prescaler = (uint16_t) ((SystemCoreClock) / 42000000) - 1;
 
 	TIM_TimeBaseInitTypeDef timerInitStructure;
 	timerInitStructure.TIM_Prescaler = prescaler;
@@ -87,13 +91,8 @@ int PWM_device_init(){
 	TIM_TimeBaseInit(TIM4, &timerInitStructure);
 	TIM_ARRPreloadConfig(TIM4, ENABLE);
 	TIM_Cmd(TIM4, ENABLE);
-	return 1;
+	g_currentClockPeriod = period;
 }
-
-void PWM_device_configure_clock(unsigned short clockFrequency){
-
-}
-
 
 void PWM_device_channel_init(unsigned int channel, unsigned short period, unsigned short dutyCycle){
 
@@ -156,7 +155,7 @@ unsigned short PWM_device_channel_get_period(unsigned int channel){
 }
 
 void PWM_device_set_duty_cycle(unsigned int channel, unsigned short duty){
-	uint32_t CCR_period = (duty * (DEFAULT_PERIOD * 10)) / DEFAULT_PERIOD;
+	uint32_t CCR_period = (g_currentClockPeriod * 100) / (1000/duty) / 10;
 	switch(channel){
 		case 0:
 			TIM4->CCR4 = CCR_period;

--- a/stm32_base/hal/PWM_stm32/PWM_device_stm32.c
+++ b/stm32_base/hal/PWM_stm32/PWM_device_stm32.c
@@ -10,6 +10,12 @@
 #define MAX_DUTY_CYCLE 100
 #define PWM_CHANNEL_COUNT 4
 
+#define CLOCK_FREQUENCY_PRESCALER_SCALING 42000000
+
+//magic number 20970 = trimmmed value.
+//adjust to calibrate further (if using a more accurate scope)
+#define CLOCK_FREQUENCY_PERIOD_SCALING 20970
+
 typedef struct _pwm {
 	uint32_t pin;
 	uint16_t pinSource;
@@ -77,10 +83,8 @@ int PWM_device_init(){
 
 void PWM_device_set_clock_frequency(unsigned short clockFrequency){
 
-	//magic numbers follow 20970 = trimmmed value.
-	//adjust to calibrate further.
-	uint32_t period = (1000 * ((20970 * 10000)/clockFrequency)) / 10000;
-	uint16_t prescaler = (uint16_t) ((SystemCoreClock) / 42000000) - 1;
+	uint32_t period = (1000 * ((CLOCK_FREQUENCY_PERIOD_SCALING * 10000)/clockFrequency)) / 10000;
+	uint16_t prescaler = (uint16_t) ((SystemCoreClock) / CLOCK_FREQUENCY_PRESCALER_SCALING) - 1;
 
 	TIM_TimeBaseInitTypeDef timerInitStructure;
 	timerInitStructure.TIM_Prescaler = prescaler;

--- a/stm32_base/hal/PWM_stm32/PWM_device_stm32.c
+++ b/stm32_base/hal/PWM_stm32/PWM_device_stm32.c
@@ -81,7 +81,7 @@ int PWM_device_init(){
 	return 1;
 }
 
-void PWM_device_set_clock_frequency(unsigned short clockFrequency){
+void PWM_device_set_clock_frequency(uint16_t clockFrequency){
 
 	uint32_t period = (1000 * ((CLOCK_FREQUENCY_PERIOD_SCALING * 10000)/clockFrequency)) / 10000;
 	uint16_t prescaler = (uint16_t) ((SystemCoreClock) / CLOCK_FREQUENCY_PRESCALER_SCALING) - 1;

--- a/test/logger_mock/PWM_device_mock.c
+++ b/test/logger_mock/PWM_device_mock.c
@@ -13,7 +13,7 @@ void PWM_device_channel_init(unsigned int channel, unsigned short period, unsign
 
 }
 
-void PWM_device_set_clock_frequency(unsigned short clockFrequency){
+void PWM_device_set_clock_frequency(uint16_t clockFrequency){
 
 }
 

--- a/test/logger_mock/PWM_device_mock.c
+++ b/test/logger_mock/PWM_device_mock.c
@@ -13,7 +13,7 @@ void PWM_device_channel_init(unsigned int channel, unsigned short period, unsign
 
 }
 
-void PWM_device_configure_clock(unsigned short clockFrequency){
+void PWM_device_set_clock_frequency(unsigned short clockFrequency){
 
 }
 


### PR DESCRIPTION
turns out that the V2 firmware had no way of changing the PWM clock frequency. reported by customer. Default PWM clock frequency is 20KHz.

Fixed so PWM clock frequency can be updated via Lua Script. Later, clock frequency setting will be configurable via PWM configuration screen in app. 

Some code cleanup in areas that were touched.

Bench tested on MK1 and MK2
