### PR TITLE
GeoTrigger support to replace the cool off timer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 ===2.8.0===
-* Refactor stage logic to support multiple stage runs without restarting Race Capture
-* Add support for predictive timing in stage runs (same restrictions & rules apply as in circuit racing).
+* Refactor stage logic to support multiple stage runs without restarting unit.
+* Add support for predictive timing in stage runs (same restrictions & rules
+  apply as in circuit racing).
+* Replace start/finish cool off timer with geoTrigger to prevent false start/finish
+  events when driver is stuck at start/finish for whatever reason.
 
 ===2.7.9===
 * Improved GPS processing performance, reduced chances of dropped packets from module.

--- a/SAM7s_base/Makefile
+++ b/SAM7s_base/Makefile
@@ -178,6 +178,7 @@ $(LOGGER_SRC_DIR)/loggerTaskEx.c \
 $(LOGGER_SRC_DIR)/connectivityTask.c \
 $(GPS_SRC_DIR)/gps.c \
 $(GPS_SRC_DIR)/geoCircle.c \
+$(GPS_SRC_DIR)/geoTrigger.c \
 $(GPS_SRC_DIR)/gpsTask.c \
 $(GPS_SRC_DIR)/dateTime.c \
 $(LOGGER_SRC_DIR)/loggerConfig.c \

--- a/include/gps/geoTrigger.h
+++ b/include/gps/geoTrigger.h
@@ -1,0 +1,58 @@
+/**
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2014 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should have received a copy of the GNU
+ * General Public License along with this code. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors: Stieg
+ */
+
+#ifndef _GEOTRIGGER_H_
+#define _GEOTRIGGER_H_
+
+#include "geoCircle.h"
+#include "geopoint.h"
+#include "mod_string.h"
+
+#include <stdbool.h>
+
+struct GeoTrigger {
+        struct GeoCircle gc;
+        bool tripped;
+};
+
+/**
+ * Creates a new #GeoTrigger object.
+ */
+struct GeoTrigger createGeoTrigger(const struct GeoCircle *gc);
+
+/**
+ * Used to update the state of the object by providing a current
+ * #GpsPoint.
+ * @return true if tripped, false otherwise.
+ */
+bool updateGeoTrigger(struct GeoTrigger *gt, const GeoPoint *point);
+
+/**
+ * Resets the tripped variable on the #GeoTrigger without destroying the
+ * other data.
+ */
+void resetGeoTrigger(struct GeoTrigger *gt);
+
+/**
+ * @return true if the trigger has been tripped, false otherwise.
+ */
+bool isGeoTriggerTripped(const struct GeoTrigger *gt);
+
+#endif /* _GEOTRIGGER_H_ */

--- a/src/gps/geoTrigger.c
+++ b/src/gps/geoTrigger.c
@@ -1,0 +1,49 @@
+/**
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2014 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should have received a copy of the GNU
+ * General Public License along with this code. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors: Stieg
+ */
+
+#include "geoCircle.h"
+#include "geoTrigger.h"
+#include "gps.h"
+#include "mod_string.h"
+
+#include <stdbool.h>
+
+struct GeoTrigger createGeoTrigger(const struct GeoCircle *gc) {
+        struct GeoTrigger gt;
+
+        memcpy(&gt.gc, gc, sizeof(struct GeoCircle));
+        resetGeoTrigger(&gt);
+
+        return gt;
+}
+
+bool updateGeoTrigger(struct GeoTrigger *gt, const GeoPoint *gp) {
+        if (gt->tripped) return true;
+        if (gc_isPointInGeoCircle(gp, gt->gc)) return false;
+        return gt->tripped = true;
+}
+
+void resetGeoTrigger(struct GeoTrigger *gt) {
+        gt->tripped = false;
+}
+
+bool isGeoTriggerTripped(const struct GeoTrigger *gt) {
+        return gt->tripped;
+}

--- a/stm32_base/config.mk
+++ b/stm32_base/config.mk
@@ -68,6 +68,7 @@ APP_SRC = 	$(APP_PATH)/main.c \
 			$(RCP_SRC)/gps/dateTime.c \
 			$(RCP_SRC)/gps/geopoint.c \
 			$(RCP_SRC)/gps/geoCircle.c \
+			$(RCP_SRC)/gps/geoTrigger.c \
 			$(RCP_SRC)/gps/gpsTask.c \
 			$(RCP_SRC)/predictive_timer/predictive_timer_2.c \
 			$(RCP_SRC)/filter/filter.c \

--- a/test/Makefile
+++ b/test/Makefile
@@ -98,6 +98,7 @@ T_SRC = loggerApi_test.cpp \
 		loggerData_test.cpp \
 		virtualChannel_test.cpp \
 		$(GPS_DIR)/gps_test.cpp \
+		$(GPS_DIR)/geoTriggerTest.cpp \
 		$(UTIL_DIR)/numtoa_test.cpp \
 		$(UTIL_DIR)/atonum_test.cpp
 
@@ -156,6 +157,7 @@ SRC =		mock_uart.c \
 		$(RCP_SRC)/gps/dateTime.c \
 		$(RCP_SRC)/gps/geopoint.c \
 		$(RCP_SRC)/gps/geoCircle.c \
+		$(RCP_SRC)/gps/geoTrigger.c \
 		$(RCP_SRC)/lap_stats/lap_stats.c \
 		$(RCP_SRC)/logger/sampleRecord.c \
 		$(RCP_SRC)/logger/loggerSampleData.c \

--- a/test/gps/geoTriggerTest.cpp
+++ b/test/gps/geoTriggerTest.cpp
@@ -1,0 +1,73 @@
+/**
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2014 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should have received a copy of the GNU
+ * General Public License along with this code. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors: Stieg
+ */
+
+#include "geoCircle.h"
+#include "geoTrigger.h"
+#include "geoTriggerTest.h"
+#include "geopoint.h"
+
+// Registers the fixture into the 'registry'
+CPPUNIT_TEST_SUITE_REGISTRATION( GeoTriggerTest );
+
+void GeoTriggerTest::setUp() {}
+
+void GeoTriggerTest::tearDown() {}
+
+void GeoTriggerTest::testShouldTrigger() {
+        const GeoPoint gp = { 43.074859, -89.386336 }; // 100 State
+        const struct GeoCircle gc = gc_createGeoCircle(gp, 10);
+        struct GeoTrigger gt = createGeoTrigger(&gc);
+
+        CPPUNIT_ASSERT(!isGeoTriggerTripped(&gt));
+
+        const GeoPoint gp2 = { 43.075255, -89.385590 }; // > 10 M from 100 State
+        const bool status = updateGeoTrigger(&gt, &gp2);
+        CPPUNIT_ASSERT(status);
+        CPPUNIT_ASSERT(isGeoTriggerTripped(&gt));
+}
+
+void GeoTriggerTest::testNoTrigger() {
+        const GeoPoint gp = { 43.074897, -89.386077 }; // 100 State
+        const struct GeoCircle gc = gc_createGeoCircle(gp, 15);
+        struct GeoTrigger gt = createGeoTrigger(&gc);
+
+        CPPUNIT_ASSERT(!isGeoTriggerTripped(&gt));
+
+        const GeoPoint gp2 = { 43.074918, -89.386037 }; // < 10 M from 100 State
+        const bool status = updateGeoTrigger(&gt, &gp2);
+        CPPUNIT_ASSERT(!status);
+        CPPUNIT_ASSERT(!isGeoTriggerTripped(&gt));
+}
+
+void GeoTriggerTest::testReset() {
+        const GeoPoint gp = { 43.074859, -89.386336 }; // 100 State
+        const struct GeoCircle gc = gc_createGeoCircle(gp, 10);
+        struct GeoTrigger gt = createGeoTrigger(&gc);
+
+        CPPUNIT_ASSERT(!isGeoTriggerTripped(&gt));
+
+        const GeoPoint gp2 = { 43.075255, -89.385590 }; // > 10 M from 100 State
+        const bool status = updateGeoTrigger(&gt, &gp2);
+        CPPUNIT_ASSERT(status);
+        CPPUNIT_ASSERT(isGeoTriggerTripped(&gt));
+
+        resetGeoTrigger(&gt);
+        CPPUNIT_ASSERT(!isGeoTriggerTripped(&gt));
+}

--- a/test/gps/geoTriggerTest.h
+++ b/test/gps/geoTriggerTest.h
@@ -1,0 +1,42 @@
+/**
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2014 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should have received a copy of the GNU
+ * General Public License along with this code. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors: Stieg
+ */
+
+#ifndef _GEOTRIGGERTEST_H_
+#define _GEOTRIGGERTEST_H_
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class GeoTriggerTest : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE( GeoTriggerTest );
+  CPPUNIT_TEST( testShouldTrigger );
+  CPPUNIT_TEST( testNoTrigger );
+  CPPUNIT_TEST( testReset );
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp();
+  void tearDown();
+  void testShouldTrigger();
+  void testNoTrigger();
+  void testReset();
+};
+
+
+#endif /* _GEOTRIGGERTEST_H_ */

--- a/test/sector_test.h
+++ b/test/sector_test.h
@@ -1,7 +1,7 @@
 #ifndef PREDICTIVE_TIME_TEST_H_
 #define PREDICTIVE_TIME_TEST_H_
 
-#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/extensions/HelperMacros.h>w
 #include <string>
 using std::string;
 using std::vector;

--- a/test/sector_test.h
+++ b/test/sector_test.h
@@ -1,7 +1,7 @@
 #ifndef PREDICTIVE_TIME_TEST_H_
 #define PREDICTIVE_TIME_TEST_H_
 
-#include <cppunit/extensions/HelperMacros.h>w
+#include <cppunit/extensions/HelperMacros.h>
 #include <string>
 using std::string;
 using std::vector;


### PR DESCRIPTION
Since we have had actual customer complaints about the cool off period being insufficient on a real race scenario, we needed a better solution.  This patch introduces the geoTrigger, a simple device that  triggers once you leave its geoCircle.  Using these objects we can replace the concept of the timer and have better results.

This patch adds in the geoTrigger use and removes the timer.  All tests pass. 