### PR TITLE
P/stieg/osx support

### DIFF
--- a/include/util/mod_string.h
+++ b/include/util/mod_string.h
@@ -50,7 +50,7 @@ char *strcat(char * s1, const char * s2);
 
 char *strstr (const char *phaystack, const char *pneedle);
 
-char * strchr(char *s, const int c);
+//char * strchr(const char *s, const int c);
 
 END_C
 

--- a/src/devices/bluetooth.c
+++ b/src/devices/bluetooth.c
@@ -66,7 +66,7 @@ static int sendCommand(DeviceConfig *config, const char * cmd) {
     return sendBtCommandWait(config, cmd, COMMAND_WAIT);
 }
 
-static char * baudConfigCmdForRate(unsigned int baudRate) {
+static const char * baudConfigCmdForRate(unsigned int baudRate) {
     switch (baudRate) {
         case 9600:
             return "AT+BAUD4";

--- a/src/gps/geopoint.c
+++ b/src/gps/geopoint.c
@@ -9,7 +9,9 @@
 #include "gps.h"
 #include <math.h>
 
+#ifndef M_PI
 #define M_PI 3.14159265358979323846
+#endif
 
 /**
  * Converts a given value to radians.

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -643,7 +643,7 @@ int api_getAnalogConfig(Serial *serial, const jsmntok_t * json){
 			startIndex = endIndex = modp_atoi(json->data);
 		}
 	}
-	if (startIndex >= 0 && startIndex <= CONFIG_ADC_CHANNELS){
+	if (startIndex <= CONFIG_ADC_CHANNELS){
 		sendAnalogConfig(serial, startIndex, endIndex);
 		return API_SUCCESS_NO_RETURN;
 	}
@@ -705,7 +705,7 @@ int api_getImuConfig(Serial *serial, const jsmntok_t *json){
 			startIndex = endIndex = modp_atoi(json->data);
 		}
 	}
-	if (startIndex >= 0 && startIndex <= CONFIG_IMU_CHANNELS){
+	if (startIndex <= CONFIG_IMU_CHANNELS){
 		sendImuConfig(serial, startIndex, endIndex);
 		return API_SUCCESS_NO_RETURN;
 	}
@@ -885,7 +885,7 @@ int api_getPwmConfig(Serial *serial, const jsmntok_t *json){
 			startIndex = endIndex = modp_atoi(json->data);
 		}
 	}
-	if (startIndex >= 0 && startIndex <= CONFIG_PWM_CHANNELS){
+	if (startIndex <= CONFIG_PWM_CHANNELS){
 		sendPwmConfig(serial, startIndex, endIndex);
 		return API_SUCCESS_NO_RETURN;
 	}
@@ -960,7 +960,7 @@ int api_getGpioConfig(Serial *serial, const jsmntok_t *json){
 			startIndex = endIndex = modp_atoi(json->data);
 		}
 	}
-	if (startIndex >= 0 && startIndex <= CONFIG_GPIO_CHANNELS){
+	if (startIndex <= CONFIG_GPIO_CHANNELS){
 		sendGpioConfig(serial, startIndex, endIndex);
 		return API_SUCCESS_NO_RETURN;
 	}
@@ -1026,7 +1026,7 @@ int api_getTimerConfig(Serial *serial, const jsmntok_t *json){
 			startIndex = endIndex = modp_atoi(json->data);
 		}
 	}
-	if (startIndex >= 0 && startIndex <= CONFIG_TIMER_CHANNELS){
+	if (startIndex <= CONFIG_TIMER_CHANNELS){
 		sendTimerConfig(serial, startIndex, endIndex);
 		return API_SUCCESS_NO_RETURN;
 	}

--- a/src/util/mod_string.c
+++ b/src/util/mod_string.c
@@ -273,17 +273,15 @@ ret0:
   return 0;
 }
 
-char * strchr(char *s, const int c)
+/*
+char * strchr(const char *s, int c)
 {
         do {
                 if (*s == (char)c) {
-                        return s;     /* silence the warning */
+                        return s;     // silence the warning
                 }
         } while (*s++);
 
         return NULL;
 }
-
-
-
-
+*/

--- a/test/Makefile
+++ b/test/Makefile
@@ -70,8 +70,8 @@ INCLUDES = 	-I. \
 # set up compiler and options
 CXX = g++
 CC = g++
-CXXFLAGS = -m32 -g $(INCLUDES) -DRCP_TESTING -DMAJOR_REV=$(MAJOR) -DMINOR_REV=$(MINOR) -DBUGFIX_REV=$(BUGFIX)
-CPPFLAGS = -m32 -g $(INCLUDES) -DRCP_TESTING -DMAJOR_REV=$(MAJOR) -DMINOR_REV=$(MINOR) -DBUGFIX_REV=$(BUGFIX)
+CXXFLAGS = -g $(INCLUDES) -DRCP_TESTING -DMAJOR_REV=$(MAJOR) -DMINOR_REV=$(MINOR) -DBUGFIX_REV=$(BUGFIX)
+CPPFLAGS = -g $(INCLUDES) -DRCP_TESTING -DMAJOR_REV=$(MAJOR) -DMINOR_REV=$(MINOR) -DBUGFIX_REV=$(BUGFIX)
 
 #-----Suffix Rules---------------------------
 # set up C++ suffixes and relationship between .cc and .o files

--- a/test/RCPSim.cpp
+++ b/test/RCPSim.cpp
@@ -52,11 +52,11 @@ int main(int argc, char* argv[])
 			}
 		}
 
-		printf("rx: (%d): %s\r\n",strlen(line), line);
+		printf("rx: (%zu): %s\r\n", strlen(line), line);
 		mock_resetTxBuffer();
 		process_api(getMockSerial(), line, strlen(line));
 		char *txBuffer = mock_getTxBuffer();
-		printf("tx: (%d) %s\r\n", strlen(txBuffer), txBuffer);
+		printf("tx:(%zu) %s\r\n", strlen(txBuffer), txBuffer);
 		write(pt, txBuffer, strlen(txBuffer));
 		pr_info_int(++messageCount);
 		pr_info(" messages\r\n");

--- a/test/date_time_test.cpp
+++ b/test/date_time_test.cpp
@@ -94,68 +94,68 @@ void DateTimeTest::testDaysInMonth()
 void DateTimeTest::testGetMillisSinceEpoch() {
    // Invalid date.  Should be 0.
    const DateTime invalid = {};
-   CPPUNIT_ASSERT_EQUAL(0ll,
+   CPPUNIT_ASSERT_EQUAL( (millis_t) 0,
                         getMillisecondsSinceUnixEpoch(invalid));
 
 
    // 1970, Jan 1 @ 00:00:00.000 == 0
    const DateTime epoch = {0, 0, 0, 0, 1, 1, 1970};
-   CPPUNIT_ASSERT_EQUAL(0ll,
+   CPPUNIT_ASSERT_EQUAL( (millis_t) 0,
                         getMillisecondsSinceUnixEpoch(epoch));
 
    // 1970, Jan 1 @ 00:16:40.000 == 1000000
    const DateTime d1000000 = {0, 40, 16, 0, 1, 1, 1970};
-   CPPUNIT_ASSERT_EQUAL(1000000ll,
+   CPPUNIT_ASSERT_EQUAL( (millis_t) 1000000ll,
                         getMillisecondsSinceUnixEpoch(d1000000));
 
    // 1970, Jan 1 @ 12:00:00.000 == 43200000
    const DateTime d43200000 = {0, 0, 0, 12, 1, 1, 1970};
-   CPPUNIT_ASSERT_EQUAL(43200000ll,
+   CPPUNIT_ASSERT_EQUAL( (millis_t) 43200000ll,
                         getMillisecondsSinceUnixEpoch(d43200000));
 
    // 1970, Jan 2 @ 12:00:00.000 == 129600000
    const DateTime d129600000 = {0, 0, 0, 12, 2, 1, 1970};
-   CPPUNIT_ASSERT_EQUAL(129600000ll,
+   CPPUNIT_ASSERT_EQUAL( (millis_t) 129600000ll,
                         getMillisecondsSinceUnixEpoch(d129600000));
 
    // 1970, Jan 31 @ 12:00:00.000 == 2635200000
    const DateTime d2635200000 = {0, 0, 0, 12, 31, 1, 1970};
-   CPPUNIT_ASSERT_EQUAL(2635200000ll,
+   CPPUNIT_ASSERT_EQUAL( (millis_t) 2635200000ll,
                         getMillisecondsSinceUnixEpoch(d2635200000));
 
    // 1970, Feb 1 @ 12:00:00.000 == 2721600000
    const DateTime d2721600000 = {0, 0, 0, 12, 1, 2, 1970};
-   CPPUNIT_ASSERT_EQUAL(2721600000ll,
+   CPPUNIT_ASSERT_EQUAL( (millis_t) 2721600000ll,
                         getMillisecondsSinceUnixEpoch(d2721600000));
 
    // 1970, Feb 28 @ 12:00:00.000 == 5054400000
    const DateTime d5054400000 = {0, 0, 0, 12, 28, 2, 1970};
-   CPPUNIT_ASSERT_EQUAL(5054400000ll,
+   CPPUNIT_ASSERT_EQUAL( (millis_t) 5054400000ll,
                         getMillisecondsSinceUnixEpoch(d5054400000));
 
    // 1970, Mar 1 @ 12:00:00.000 == 5140800000
    const DateTime d5140800000 = {0, 0, 0, 12, 1, 3, 1970};
-   CPPUNIT_ASSERT_EQUAL(5140800000ll,
+   CPPUNIT_ASSERT_EQUAL( (millis_t) 5140800000ll,
                         getMillisecondsSinceUnixEpoch(d5140800000));
 
    // 1970, Apr 1 @ 12:00:00.000 == 7819200000
    const DateTime d7819200000 = {0, 0, 0, 12, 1, 4, 1970};
-   CPPUNIT_ASSERT_EQUAL(7819200000ll,
+   CPPUNIT_ASSERT_EQUAL( (millis_t) 7819200000ll,
                         getMillisecondsSinceUnixEpoch(d7819200000));
 
    // 1971, Jan 1 @ 12:00:00.000 == 31579200000
    const DateTime d31579200000 = {0, 0, 0, 12, 1, 1, 1971};
-   CPPUNIT_ASSERT_EQUAL(31579200000ll,
+   CPPUNIT_ASSERT_EQUAL( (millis_t) 31579200000ll,
                         getMillisecondsSinceUnixEpoch(d31579200000));
 
    // 1984, Mar 17 @ 10:08:00.000 == 448366080000.  My birth timestamp.
    const DateTime d448366080000 = {0, 0, 8, 10, 17, 3, 1984};
-   CPPUNIT_ASSERT_EQUAL(448366080000ll,
+   CPPUNIT_ASSERT_EQUAL( (millis_t) 448366080000ll,
                         getMillisecondsSinceUnixEpoch(d448366080000));
 
    // 2013, January 1 @ 00:00:00.000 == 1356998400000 milliseconds since epoch.
    const DateTime jan_1_2013 = {0, 0, 0, 0, 1, 1, 2013};
-   CPPUNIT_ASSERT_EQUAL(1356998400000ll,
+   CPPUNIT_ASSERT_EQUAL( (millis_t) 1356998400000ll,
                         getMillisecondsSinceUnixEpoch(jan_1_2013));
 
 }
@@ -163,9 +163,9 @@ void DateTimeTest::testGetMillisSinceEpoch() {
 void DateTimeTest::testGetDeltaInMillis() {
   const DateTime epoch = {0, 0, 0, 0, 1, 1, 1970};
   const DateTime d1000000 = {0, 40, 16, 0, 1, 1, 1970};
-  CPPUNIT_ASSERT_EQUAL(0ll, getTimeDeltaInMillis(epoch, epoch));
-  CPPUNIT_ASSERT_EQUAL(1000000ll, getTimeDeltaInMillis(d1000000, epoch));
-  CPPUNIT_ASSERT_EQUAL(-1000000ll, getTimeDeltaInMillis(epoch, d1000000));
+  CPPUNIT_ASSERT_EQUAL( (millis_t) 0ll, getTimeDeltaInMillis(epoch, epoch));
+  CPPUNIT_ASSERT_EQUAL( (millis_t) 1000000ll, getTimeDeltaInMillis(d1000000, epoch));
+  CPPUNIT_ASSERT_EQUAL( (millis_t) -1000000ll, getTimeDeltaInMillis(epoch, d1000000));
 }
 
 void DateTimeTest::testMillisToMinutes() {
@@ -222,11 +222,11 @@ void DateTimeTest::testUptime() {
 
 void DateTimeTest::testMillisSinceEpoch() {
   CPPUNIT_ASSERT_EQUAL(0, (int) xTaskGetTickCount());
-  CPPUNIT_ASSERT_EQUAL(0ll, (long long) getMillisSinceEpoch());
+  CPPUNIT_ASSERT_EQUAL( (millis_t) 0ll, getMillisSinceEpoch());
 
   incrementTick();
   CPPUNIT_ASSERT_EQUAL(1, (int) xTaskGetTickCount());
-  CPPUNIT_ASSERT_EQUAL(0ll, (long long) getMillisSinceEpoch());
+  CPPUNIT_ASSERT_EQUAL( (millis_t) 0ll, getMillisSinceEpoch());
 
   incrementTick();
   const DateTime d448366080000 = {0, 0, 8, 10, 17, 3, 1984};
@@ -237,11 +237,11 @@ void DateTimeTest::testMillisSinceEpoch() {
   GPS_sample_update(&sample);
 
   CPPUNIT_ASSERT_EQUAL(2, (int) xTaskGetTickCount());
-  CPPUNIT_ASSERT_EQUAL(448366080000ll + 0 * MS_PER_TICK, (long long) getMillisSinceEpoch());
+  CPPUNIT_ASSERT_EQUAL( (millis_t) 448366080000ll + 0 * MS_PER_TICK, getMillisSinceEpoch());
 
   incrementTick();
   CPPUNIT_ASSERT_EQUAL(3, (int) xTaskGetTickCount());
-  CPPUNIT_ASSERT_EQUAL(448366080000ll + 1 * MS_PER_TICK, (long long) getMillisSinceEpoch());
+  CPPUNIT_ASSERT_EQUAL( (millis_t) 448366080000ll + 1 * MS_PER_TICK, getMillisSinceEpoch());
 }
 
 void DateTimeTest::testDateTimeFromEpochMillis(){
@@ -310,4 +310,3 @@ void DateTimeTest::testDateTimeFromEpochMillis(){
     CPPUNIT_ASSERT_EQUAL(3, (int)dt.month);
     CPPUNIT_ASSERT_EQUAL(2015, (int)dt.year);
 }
-

--- a/test/include/rcp_cpp_unit.hh
+++ b/test/include/rcp_cpp_unit.hh
@@ -24,8 +24,7 @@
 #define _RCP_CPP_UNIT_H_
 
 #include <cppunit/extensions/HelperMacros.h>
-#include <stdlib.h>
 
-#define CPPUNIT_ASSERT_CLOSE_ENOUGH(ACTUAL, EXPECTED) CPPUNIT_ASSERT((abs((ACTUAL - EXPECTED)) < 0.00001))
+#define CPPUNIT_ASSERT_CLOSE_ENOUGH(ACTUAL, EXPECTED) CPPUNIT_ASSERT((ACTUAL - EXPECTED) < 0.00001 && (ACTUAL - EXPECTED) > -0.00001)
 
 #endif /* _RCP_CPP_UNIT_H_ */

--- a/test/launch_control_test.cpp
+++ b/test/launch_control_test.cpp
@@ -69,10 +69,10 @@ void LaunchControlTest::testCircuitLaunch() {
 
    GpsSnapshot snap;
    const GeoPoint *pt = pts;
-   for (; isValidPoint(pt); ++pt) {
+   for (tiny_millis_t i = 0; isValidPoint(pt); ++pt, ++i) {
       snap.sample.point = *pt;
       // Use the address of the point as the sample time.
-      snap.deltaFirstFix = (tiny_millis_t) pt;
+      snap.deltaFirstFix = i * 100;
       snap.sample.speed = 40; // Speed well above the threshold.
 
       lc_supplyGpsSnapshot(&snap);
@@ -83,7 +83,7 @@ void LaunchControlTest::testCircuitLaunch() {
 
    CPPUNIT_ASSERT_EQUAL(true, lc_hasLaunched());
    CPPUNIT_ASSERT_EQUAL(false, lc_is_armed());
-   CPPUNIT_ASSERT_EQUAL((tiny_millis_t) (pts + 1), lc_getLaunchTime());
+   CPPUNIT_ASSERT_EQUAL(100, lc_getLaunchTime()); // Should be point 1.
 }
 
 void LaunchControlTest::testStageSimpleLaunch() {
@@ -115,8 +115,8 @@ void LaunchControlTest::testStageSimpleLaunch() {
    GpsSnapshot snap;
    const GeoPoint *pt = pts;
    for (unsigned indx = 0; isValidPoint(pt); ++pt, ++indx) {
-      // Use the address of the point as the sample time.
-      snap.deltaFirstFix = (tiny_millis_t) pt;
+      // Generate a fake time
+      snap.deltaFirstFix = (tiny_millis_t) indx * 100;
 
       snap.sample.point = *pt;
       snap.sample.speed = pt < (pts + 7) ? 0: 10;
@@ -134,7 +134,7 @@ void LaunchControlTest::testStageSimpleLaunch() {
 
    CPPUNIT_ASSERT_EQUAL(true, lc_hasLaunched());
    CPPUNIT_ASSERT_EQUAL(false, lc_is_armed());
-   CPPUNIT_ASSERT_EQUAL((tiny_millis_t) (pts + 6), lc_getLaunchTime());
+   CPPUNIT_ASSERT_EQUAL(600, lc_getLaunchTime());
 }
 
 
@@ -170,10 +170,10 @@ void LaunchControlTest::testStageTrickyLaunch() {
 
    GpsSnapshot snap;
    const GeoPoint *pt = pts;
-   for (; isValidPoint(pt); ++pt) {
+   for (tiny_millis_t i = 0; isValidPoint(pt); ++pt, i += 100) {
       snap.sample.point = *pt;
-      // Use the address of the point as the sample time.
-      snap.deltaFirstFix = (tiny_millis_t) pt;
+      // Fake time
+      snap.deltaFirstFix = i;
 
       // Set speed to 0 at 5th reading.  This triggers launch time set.
       snap.sample.speed = pt == (pts + 4)? 0 : 5;
@@ -184,5 +184,5 @@ void LaunchControlTest::testStageTrickyLaunch() {
    }
 
    CPPUNIT_ASSERT_EQUAL(true, lc_hasLaunched());
-   CPPUNIT_ASSERT_EQUAL((tiny_millis_t) (pts + 4), lc_getLaunchTime());
+   CPPUNIT_ASSERT_EQUAL(400, lc_getLaunchTime());
 }

--- a/test/loggerApi_test.cpp
+++ b/test/loggerApi_test.cpp
@@ -887,7 +887,7 @@ void LoggerApiTest::testSetTrackCfgCircuit(){
 	assertGenericResponse(txBuffer, "setTrackCfg", API_SUCCESS);
 
 	CPPUNIT_ASSERT_EQUAL(0, (int)cfg->track.track_type);
-    CPPUNIT_ASSERT_EQUAL(6674, cfg->track.trackId);
+        CPPUNIT_ASSERT_EQUAL(6674, cfg->track.trackId);
 	CPPUNIT_ASSERT_CLOSE_ENOUGH(0.0001F, cfg->radius);
 	CPPUNIT_ASSERT_EQUAL(0, (int)cfg->auto_detect);
 	CPPUNIT_ASSERT_CLOSE_ENOUGH(1.0F, cfg->track.circuit.startFinish.latitude);

--- a/test/loggerData_test.cpp
+++ b/test/loggerData_test.cpp
@@ -3,6 +3,7 @@
 #include "loggerApi.h"
 #include "mod_string.h"
 #include "mock_serial.h"
+#include "rcp_cpp_unit.hh"
 #include "imu_mock.h"
 #include "imu.h"
 #include <stdlib.h>
@@ -43,6 +44,6 @@ void LoggerDataTest::testMappedValue()
 		float expected = (float)i / 100.0f;
 		if (i <= 100) expected = 1.0f;
 		else if (i >= 500) expected = 5.0f;
-		CPPUNIT_ASSERT(( abs((scaled - expected)) < 0.00001));
+		CPPUNIT_ASSERT_CLOSE_ENOUGH(scaled, expected);
 	}
 }

--- a/test/logger_mock/ADC_device_mock.c
+++ b/test/logger_mock/ADC_device_mock.c
@@ -9,7 +9,9 @@
 
 static unsigned int g_adc[CONFIG_ADC_CHANNELS] = {0,0,0,0,0,0};
 
-int ADC_device_init(void){}
+int ADC_device_init(void) {
+        return 1;
+}
 
 //Read specified ADC channel
 unsigned int ADC_device_sample(unsigned int channel){

--- a/test/logger_mock/CAN_device_mock.c
+++ b/test/logger_mock/CAN_device_mock.c
@@ -1,7 +1,7 @@
 #include "CAN_device.h"
 
 int CAN_device_init(uint8_t channel, uint32_t baud){
-
+        return 1;
 }
 
 int CAN_device_tx_msg(uint8_t channel, CAN_msg *msg, unsigned int timeoutMs){

--- a/test/logger_mock/LED_device_mock.c
+++ b/test/logger_mock/LED_device_mock.c
@@ -3,7 +3,7 @@
 static int g_leds[3] = {0,0,0};
 
 int LED_device_init(void){
-
+        return 1;
 }
 
 void LED_device_enable(unsigned int Led){

--- a/test/logger_mock/PWM_device_mock.c
+++ b/test/logger_mock/PWM_device_mock.c
@@ -6,7 +6,7 @@ static int g_pwmPeriod[PWM_CHANNELS] = {0,0,0,0};
 static int g_pwmDuty[PWM_CHANNELS] = {0,0,0,0};
 
 int PWM_device_init(void){
-
+        return 1;
 }
 
 void PWM_device_channel_init(unsigned int channel, unsigned short period, unsigned short dutyCycle){
@@ -52,4 +52,3 @@ void PWM_device_channel_stop_all(){
 void PWM_device_channel_enable_analog(size_t channel, uint8_t enabled){
 
 }
-


### PR DESCRIPTION
Adds the ability for us to compile the unit test from OSX.  Achieves this by moving our unit tests to a 64bit platform and by adding support to work with the clang compiler on OSX.

Next I want to move our unit tests over to clang and begin to use their static analyzer on our code so that we are able to find bugs in the firmware.  Plus moving to clang will make it easier not to break the mac environment.