### PR TITLE
switched logging since and telemetry active-since to duration

### DIFF
--- a/include/devices/sim900.h
+++ b/include/devices/sim900.h
@@ -23,7 +23,7 @@ typedef enum {
 } telemetry_status_t;
 
 telemetry_status_t sim900_get_connection_status();
-int32_t sim900_active_since();
+int32_t sim900_active_time();
 int sim900_init_connection(DeviceConfig *config);
 int sim900_check_connection_status(DeviceConfig *config);
 

--- a/include/logger/logger.h
+++ b/include/logger/logger.h
@@ -30,7 +30,7 @@ bool logging_is_active();
 logging_status_t logging_get_status( void );
 void logging_set_status( logging_status_t status );
 
-int32_t logging_get_logging_start( void );
+int32_t logging_active_time( void );
 void logging_set_logging_start( int32_t start );
 
 #endif /* LOGGER_H_ */

--- a/src/devices/sim900.c
+++ b/src/devices/sim900.c
@@ -16,8 +16,13 @@ telemetry_status_t sim900_get_connection_status(){
 	return g_connection_status;
 }
 
-int32_t sim900_active_since(){
-	return g_active_since;
+int32_t sim900_active_time(){
+    if (g_active_since) {
+        int uptime = getUptimeAsInt();
+        int duration = uptime - g_active_since;
+        return duration;
+    }
+    return 0;
 }
 
 static int writeAuthJSON(Serial *serial, const char *deviceId){

--- a/src/launch_control.c
+++ b/src/launch_control.c
@@ -34,7 +34,7 @@
 
 static tiny_millis_t g_startTime = -1;
 static struct GeoCircle g_geoCircle;
-static bool g_hasLaunched = false;
+static bool g_hasLaunched;
 
 static bool isValidStartTime() {
         return g_startTime != -1;

--- a/src/launch_control.c
+++ b/src/launch_control.c
@@ -32,9 +32,9 @@
  */
 #define LC_SPEED_THRESHOLD 3.0
 
-static tiny_millis_t g_startTime;
+static tiny_millis_t g_startTime = -1;
 static struct GeoCircle g_geoCircle;
-static bool g_hasLaunched;
+static bool g_hasLaunched = false;
 
 static bool isValidStartTime() {
         return g_startTime != -1;

--- a/src/logger/logger.c
+++ b/src/logger/logger.c
@@ -16,9 +16,10 @@
  * General Public License along with this code. If not, see <http://www.gnu.org/licenses/>.
  */
 #include "logger.h"
+#include "dateTime.h"
 
 static logging_status_t g_logging_status = LOGGING_STATUS_IDLE;
-static int g_logging_start = 0;
+static int g_logging_since = 0;
 
 void logging_set_status(logging_status_t status) {
     g_logging_status = status;
@@ -29,14 +30,19 @@ logging_status_t logging_get_status( void ) {
 }
 
 void logging_set_logging_start( int32_t start ) {
-    g_logging_start = start;
+    g_logging_since = start;
 }
 
-int32_t logging_get_logging_start( void ) {
-    return g_logging_start;
+int32_t logging_active_time( void ) {
+    if (g_logging_since) {
+        int uptime = getUptimeAsInt();
+        int duration = uptime - g_logging_since;
+        return duration;
+    }
+    return 0;
 }
 
 bool logging_is_active() {
-    return g_logging_start > 0;
+    return g_logging_since > 0;
 }
 

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -254,7 +254,7 @@ int api_getStatus(Serial *serial, const jsmntok_t *json){
 
 	json_objStartString(serial, "logging");
 	json_int(serial, "status", (int)logging_get_status(), 1);
-	json_int(serial, "started", logging_get_logging_start(), 0);
+	json_int(serial, "dur", logging_active_time(), 0);
 	json_objEnd(serial, 1);
 
 	json_objStartString(serial, "track");
@@ -266,7 +266,7 @@ int api_getStatus(Serial *serial, const jsmntok_t *json){
 
 	json_objStartString(serial, "telemetry");
 	json_int(serial, "status", (int)sim900_get_connection_status(), 1);
-	json_int(serial, "started", sim900_active_since(), 0);
+	json_int(serial, "dur", sim900_active_time(), 0);
 	json_objEnd(serial, 0);
 
 	json_objEnd(serial, 0);


### PR DESCRIPTION
as it describes - a more useful value for users of the status API. 