### PR TITLE
Replace strncpy with strlcpy in our Lua Bindings

### DIFF
--- a/src/logger/luaLoggerBinding.c
+++ b/src/logger/luaLoggerBinding.c
@@ -547,19 +547,21 @@ int Lua_FlashLoggerConfig(lua_State *L){
 }
 
 int Lua_AddVirtualChannel(lua_State *L){
-	size_t args = lua_gettop(L);
-	if (args >= 2){
-		ChannelConfig chCfg;
-		strncpy(chCfg.label, lua_tostring(L, 1), DEFAULT_LABEL_LENGTH);
-		chCfg.sampleRate = encodeSampleRate((unsigned short) lua_tointeger(L, 2));
-		chCfg.precision = args >= 3 ? lua_tointeger(L, 3) : DEFAULT_CHANNEL_LOGGING_PRECISION;
-		chCfg.min = args >= 4 ? lua_tointeger(L, 4) : DEFAULT_CHANNEL_MIN;
-		chCfg.max = args >= 5 ? lua_tointeger(L, 5) : DEFAULT_CHANNEL_MAX;
-		strncpy(chCfg.units, args >=6 ? lua_tostring(L, 6) : DEFAULT_CHANNEL_UNITS, DEFAULT_UNITS_LENGTH);
-		lua_pushinteger(L, create_virtual_channel(chCfg));
-		return 1;
-	}
-	return 0;
+        size_t args = lua_gettop(L);
+        if (args < 2) return 0;
+
+        ChannelConfig cc;
+        strlcpy(cc.label, lua_tostring(L, 1), DEFAULT_LABEL_LENGTH);
+        cc.sampleRate = encodeSampleRate((unsigned short) lua_tointeger(L, 2));
+        cc.precision = args >= 3 ? lua_tointeger(L, 3) :
+                DEFAULT_CHANNEL_LOGGING_PRECISION;
+        cc.min = args >= 4 ? lua_tointeger(L, 4) : DEFAULT_CHANNEL_MIN;
+        cc.max = args >= 5 ? lua_tointeger(L, 5) : DEFAULT_CHANNEL_MAX;
+        strlcpy(cc.units, args >=6 ? lua_tostring(L, 6) : DEFAULT_CHANNEL_UNITS,
+                DEFAULT_UNITS_LENGTH);
+        lua_pushinteger(L, create_virtual_channel(cc));
+
+        return 1;
 }
 
 int Lua_SetVirtualChannelValue(lua_State *L){


### PR DESCRIPTION
User reported error that our Lua_Bindings will copy and not
null terminate a string.  This was because we were using strncpy,
which is unsafe around user input.

https://github.com/autosportlabs/RaceCapture-Pro_firmware/issues/39