### PR TITLE
make connectivity task have programmable timeouts based on type of telem...

### DIFF
--- a/include/logger/connectivityTask.h
+++ b/include/logger/connectivityTask.h
@@ -16,6 +16,7 @@ typedef struct _ConnParams{
 	int (*check_connection_status)(DeviceConfig *config);
 	serial_id_t serial;
 	size_t periodicMeta;
+	uint32_t connection_timeout;
 	xQueueHandle sampleQueue;
 } ConnParams;
 


### PR DESCRIPTION
...etry task

Wireless type telemetry tasks don't have a timeout... until we sunset the android specific app