### PR TITLE
V2.8.1 bt provision fix

### DIFF
--- a/src/auto_config/auto_track.c
+++ b/src/auto_config/auto_track.c
@@ -47,21 +47,18 @@ static const Track* findClosestTrack(const Tracks *tracks, const GeoPoint *locat
 
 const Track* auto_configure_track(const Track *defaultCfg, const GeoPoint *gp)
 {
-    pr_info("tracks: detecting...");
-
     const Tracks *tracks = get_tracks();
     if (!tracks || tracks->count <= 0) {
         // Well shit!
-        pr_info("No tracks\r\n");
         return defaultCfg;
     }
 
     const Track *foundTrack = findClosestTrack(tracks, gp);
     if (!foundTrack) {
-        pr_info("no ");
         foundTrack = defaultCfg;
     }
-
-    pr_info("track found\r\n");
+    else{
+        pr_info_int_msg("tracks: found ", foundTrack->trackId);
+    }
     return foundTrack;
 }

--- a/src/auto_config/auto_track.c
+++ b/src/auto_config/auto_track.c
@@ -56,8 +56,7 @@ const Track* auto_configure_track(const Track *defaultCfg, const GeoPoint *gp)
     const Track *foundTrack = findClosestTrack(tracks, gp);
     if (!foundTrack) {
         foundTrack = defaultCfg;
-    }
-    else{
+    } else {
         pr_info_int_msg("tracks: found ", foundTrack->trackId);
     }
     return foundTrack;

--- a/src/devices/bluetooth.c
+++ b/src/devices/bluetooth.c
@@ -22,6 +22,7 @@
 #include "mod_string.h"
 #include "printk.h"
 #include "task.h"
+#include "taskUtil.h"
 
 #define COMMAND_WAIT 	600
 
@@ -94,7 +95,7 @@ static const char * baudConfigCmdForRate(unsigned int baudRate)
 
 static int configureBt(DeviceConfig *config, unsigned int targetBaud, const char * deviceName)
 {
-    pr_debug_int_msg("BT: Configuring baud Rate", targetBaud);
+    pr_info_int_msg("BT: Configuring baud Rate", targetBaud);
     //set baud rate
     if (!sendCommand(config, baudConfigCmdForRate(targetBaud)))
         return -1;
@@ -104,7 +105,7 @@ static int configureBt(DeviceConfig *config, unsigned int targetBaud, const char
     char btName[30];
     strcpy(btName, "AT+NAME");
     strcat(btName, deviceName);
-    pr_debug_str_msg("BT: Configuring name", btName);
+    pr_info_str_msg("BT: Configuring name", btName);
     if (!sendBtCommandWaitResponse(config, btName, "OK", COMMAND_WAIT))
         return -2;
     return 0;
@@ -113,7 +114,7 @@ static int configureBt(DeviceConfig *config, unsigned int targetBaud, const char
 static int bt_probe_config(unsigned int probeBaud, unsigned int targetBaud, const char * deviceName,
                            DeviceConfig *config)
 {
-    pr_debug_int_msg("BT: Probing baud", probeBaud);
+    pr_info_int_msg("BT: Probing baud ", probeBaud);
     config->serial->init(8, 0, 1, probeBaud);
     int rc;
     if (sendCommand(config, "AT")
@@ -122,7 +123,7 @@ static int bt_probe_config(unsigned int probeBaud, unsigned int targetBaud, cons
     } else {
         rc = DEVICE_INIT_FAIL;
     }
-    pr_info_str_msg("BT: Provision", rc == DEVICE_INIT_SUCCESS ? "win" : "fail");
+    pr_info_str_msg("BT: Provision ", rc == DEVICE_INIT_SUCCESS ? "win" : "fail");
     return rc;
 }
 
@@ -131,6 +132,9 @@ int bt_init_connection(DeviceConfig *config)
     BluetoothConfig *btConfig = &(getWorkingLoggerConfig()->ConnectivityConfigs.bluetoothConfig);
     unsigned int targetBaud = btConfig->baudRate;
     const char *deviceName = btConfig->deviceName;
+
+    //give a chance for BT module to init
+    delayMs(500);
 
     // Zero terminated
     const int rates[] = { 115200, 9600, 230400, 0 };
@@ -142,13 +146,13 @@ int bt_init_connection(DeviceConfig *config)
     }
 
     if (*rate > 0) {
-        config->serial->init(8, 0, 1, targetBaud);
         pr_info("BT: Init complete\r\n");
         g_bluetooth_status = BT_STATUS_PROVISIONED;
     } else {
         pr_info("BT: Failed to provision module. Assuming already connected.\r\n");
         g_bluetooth_status = BT_STATUS_ERROR;
     }
+    config->serial->init(8, 0, 1, targetBaud);
 
     return DEVICE_INIT_SUCCESS;
 }

--- a/src/devices/bluetooth.c
+++ b/src/devices/bluetooth.c
@@ -25,6 +25,7 @@
 #include "taskUtil.h"
 
 #define COMMAND_WAIT 	600
+#define BT_INIT_DELAY   100
 
 static bluetooth_status_t g_bluetooth_status = BT_STATUS_NOT_INIT;
 
@@ -134,7 +135,7 @@ int bt_init_connection(DeviceConfig *config)
     const char *deviceName = btConfig->deviceName;
 
     //give a chance for BT module to init
-    delayMs(500);
+    delayMs(BT_INIT_DELAY);
 
     // Zero terminated
     const int rates[] = { 115200, 9600, 230400, 0 };

--- a/stm32_base/libs/STM32F4xx_DSP_StdPeriph_Lib_V1.0.1/Libraries/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_cryp_des.c
+++ b/stm32_base/libs/STM32F4xx_DSP_StdPeriph_Lib_V1.0.1/Libraries/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_cryp_des.c
@@ -116,7 +116,8 @@ ErrorStatus CRYP_DES_ECB(uint8_t Mode, uint8_t Key[8], uint8_t *Input,
     /* Crypto Init for Encryption process */
     if( Mode == MODE_ENCRYPT ) { /* DES encryption */
         DES_CRYP_InitStructure.CRYP_AlgoDir  = CRYP_AlgoDir_Encrypt;
-    } else/* if( Mode == MODE_DECRYPT )*/ { /* DES decryption */
+    } else { /* if( Mode == MODE_DECRYPT )*/
+        /* DES decryption */
         DES_CRYP_InitStructure.CRYP_AlgoDir  = CRYP_AlgoDir_Decrypt;
     }
 
@@ -205,7 +206,8 @@ ErrorStatus CRYP_DES_CBC(uint8_t Mode, uint8_t Key[8], uint8_t InitVectors[8],
     /* Crypto Init for Encryption process */
     if(Mode == MODE_ENCRYPT) { /* DES encryption */
         DES_CRYP_InitStructure.CRYP_AlgoDir  = CRYP_AlgoDir_Encrypt;
-    } else /*if(Mode == MODE_DECRYPT)*/ { /* DES decryption */
+    } else { /*if(Mode == MODE_DECRYPT)*/
+        /* DES decryption */
         DES_CRYP_InitStructure.CRYP_AlgoDir  = CRYP_AlgoDir_Decrypt;
     }
 

--- a/stm32_base/libs/STM32F4xx_DSP_StdPeriph_Lib_V1.0.1/Libraries/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_cryp_tdes.c
+++ b/stm32_base/libs/STM32F4xx_DSP_StdPeriph_Lib_V1.0.1/Libraries/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_cryp_tdes.c
@@ -118,7 +118,8 @@ ErrorStatus CRYP_TDES_ECB(uint8_t Mode, uint8_t Key[24], uint8_t *Input,
     /* Crypto Init for Encryption process */
     if(Mode == MODE_ENCRYPT) { /* TDES encryption */
         TDES_CRYP_InitStructure.CRYP_AlgoDir = CRYP_AlgoDir_Encrypt;
-    } else /*if(Mode == MODE_DECRYPT)*/ { /* TDES decryption */
+    } else { /*if(Mode == MODE_DECRYPT)*/
+        /* TDES decryption */
         TDES_CRYP_InitStructure.CRYP_AlgoDir = CRYP_AlgoDir_Decrypt;
     }
 


### PR DESCRIPTION
* insert delay before attempting Bluetooth provisioning, allowing BT module to initialize

* set the desired baud rate regardless if we can talk to the BT module. (this was the real culprit)
(when we can't send AT commands, it could be b/c the bt is connected to app. if that's the case, BT module is in transparent mode and won't respond  to AT commands. We have to assume it might already be correctly provisioned in these cases)

* reduce the logging noise when we haven't found a trackmap yet

* astyle formatting