### PR TITLE
Remove all usage of { 0 } from the code

### DIFF
--- a/include/logger/fileWriter.h
+++ b/include/logger/fileWriter.h
@@ -25,7 +25,6 @@ struct logging_status
 
 
 void startFileWriterTask( int priority );
-void fileWriterTask(void *params);
 portBASE_TYPE queue_logfile_record(LoggerMessage * sr);
 
 #endif /* FILEWRITER_H_ */

--- a/src/devices/cellModem.c
+++ b/src/devices/cellModem.c
@@ -15,8 +15,8 @@
 #define IMEI_NUMBER_LENGTH 16
 
 static cellmodem_status_t g_cellmodem_status = CELLMODEM_STATUS_NOT_INIT;
-static char g_subscriber_number[MAX_SUBSCRIBER_NUMBER_LENGTH] = {0};
-static char g_IMEI_number[IMEI_NUMBER_LENGTH] = {0};
+static char g_subscriber_number[MAX_SUBSCRIBER_NUMBER_LENGTH];
+static char g_IMEI_number[IMEI_NUMBER_LENGTH];
 
 static char *g_cellBuffer;
 static size_t g_bufferLen;


### PR DESCRIPTION
Removing all usage of zeroing out by using empty types as this seems
to cause the compiler to use much more ROM space than is necessary
(likely because it is creating a large 0 space in ROM and then copying
it in).

Replace these with the memset function, which is much smaller.  This
yeilds over 1K difference in code size in MK1.