### PR TITLE
Support validation of LogMessages and fix several bugs

### DIFF
--- a/include/logger/loggerApi.h
+++ b/include/logger/loggerApi.h
@@ -111,7 +111,8 @@ int api_runScript(Serial *serial, const jsmntok_t *json);
 //messages
 void api_sendLogStart(Serial *serial);
 void api_sendLogEnd(Serial *serial);
-void api_sendSampleRecord(Serial *serial, ChannelSample *sr, size_t channelCount, unsigned int tick, int sendMeta);
+void api_send_sample_record(Serial *serial, struct sample *sample,
+                            unsigned int tick, int sendMeta);
 
 //Utility functions
 void unescapeTextField(char *data);

--- a/include/logger/loggerSampleData.h
+++ b/include/logger/loggerSampleData.h
@@ -14,15 +14,14 @@
 #include "sampleRecord.h"
 
 /**
- * Checks that the interval time in the LoggerMessage struct matches that within the ChannelSample
- * buffer.
- * @param lm The LoggerMessage to validate
- * @return true if its valid, false otherwise.
+ * Populates a struct sample object with channel data.  Note this does not
+ * handle the timestamping.  That is done by creation and association of
+ * a LoggerMessage object.
  */
-int checkSampleTimestamp(LoggerMessage *lm);
+int populate_sample_buffer(struct sample *s, size_t logTick);
 
-int populate_sample_buffer(LoggerMessage *lm,  size_t count, size_t currentTicks);
-void init_channel_sample_buffer(LoggerConfig *loggerConfig, ChannelSample * samples, size_t channelCount);
+void init_channel_sample_buffer(LoggerConfig *loggerConfig,
+                                struct sample *s);
 
 float get_mapped_value(float value, ScalingMap *scalingMap);
 

--- a/include/logger/sampleRecord.h
+++ b/include/logger/sampleRecord.h
@@ -8,11 +8,13 @@
 #ifndef SAMPLERECORD_H_
 #define SAMPLERECORD_H_
 
+#include "dateTime.h"
+#include "FreeRTOS.h"
+#include "loggerConfig.h"
+#include "queue.h"
+
 #include <stdbool.h>
 #include <stddef.h>
-
-#include "dateTime.h"
-#include "loggerConfig.h"
 
 enum LoggerMessageType {
     LoggerMessageType_Sample,
@@ -62,22 +64,72 @@ typedef struct _ChannelSample {
     };
 } ChannelSample;
 
+struct sample {
+   size_t ticks;
+   size_t channel_count;
+   ChannelSample *channel_samples;
+};
+
 typedef struct _LoggerMessage {
     enum LoggerMessageType type;
-    size_t sampleCount;
     size_t ticks;
-    ChannelSample *channelSamples;
+    struct sample *sample;
 } LoggerMessage;
 
-ChannelSample* create_channel_sample_buffer(LoggerConfig *loggerConfig, size_t channelCount);
+/**
+ * Initializes the struct sample channel_sample buffer for use.  May be called
+ * again to re-initialize the space.
+ * @param s Pointer to the struct sample to initialize.
+ * @param count Number of channels that we are logging.
+ * @return The amount of space allocated.
+ */
+size_t init_sample_buffer(struct sample *s, const size_t count);
 
 /**
- * Checks to ensure that the LoggerMessage object is not older than 10 milliseconds.  If it is then
- * we may read an old buffer and send bad data.  There is a special case where if ticks are zero
- * we consider that to be a time insensitive message.
- * @param lm The LoggerMessage object.
- * @return True if its not older than 10ms, false otherwise.
+ * Frees the channel_sample buffer assocaited with the struct sample.  Also
+ * clears out the struct sample buffer values to indicated that the buffer has
+ * been released.  Call this like you would use a free method.
+ * @param s Pointer to the struct sample to reap.
  */
-int isValidLoggerMessageAge(LoggerMessage *lm);
+void free_sample_buffer(struct sample *s);
+
+/**
+ * Creates a LoggerMessage for use in the messaging between threads.
+ * @param t The messaget type.
+ * @param s The associated sample object (if any).
+ */
+LoggerMessage create_logger_message(const enum LoggerMessageType t,
+                                    struct sample *s);
+
+/**
+ * Tests if the given LoggerMessage points to valid data by comparing
+ * timestamps.
+ * @param lm The LoggerMessage to validate
+ * @return true if valid, false otherwise
+ */
+bool is_sample_data_valid(const LoggerMessage *lm);
+
+/**
+ * Receives and validates a LoggerMessage from the provided queue.  If the
+ * LoggerMessage is invalid, then it is ignored.
+ * @param queue The Queue containing the message
+ * @param lm The LoggerMessage structure to populate.
+ * @param timeout The amount of time to wait before timing out.
+ * @return The return value of xQueueReceive.  This must be checked before
+ * the LoggerMessage can be considered valid.
+ */
+char receive_logger_message(xQueueHandle queue, LoggerMessage *lm,
+                            portTickType timeout);
+
+/**
+ * Checks to ensure that the LoggerMessage object is pointing to a usable
+ * data_sample structure.  This is needed because while the LoggerMessages are
+ * deeply copied to their respective queues, the data_sample structures are not
+ * (they are a part of a ring buffer).  So we must validate that the timestamp
+ * on the LoggerMessage matches that of the data_sample object.
+ * @param lm The LoggerMessage object.
+ * @return True if the data_sample is usable, false otherwise.
+ */
+bool is_data_sample_valid(const LoggerMessage *lm);
 
 #endif /* SAMPLERECORD_H_ */

--- a/src/logger/connectivityTask.c
+++ b/src/logger/connectivityTask.c
@@ -279,17 +279,20 @@ void connectivityTask(void *params)
                     break;
                 }
                 case LoggerMessageType_Sample: {
-                    if (should_stream) {
-                        int sendMeta = (tick == 0 ||
-                                        (connParams->periodicMeta &&
-                                         (tick % METADATA_SAMPLE_INTERVAL == 0)));
-                        api_send_sample_record(serial, msg.sample, tick, sendMeta);
+                        if (!should_stream)
+                                break;
+
+                        const int send_meta = tick == 0 ||
+                                (connParams->periodicMeta &&
+                                 (tick % METADATA_SAMPLE_INTERVAL == 0));
+                        api_send_sample_record(serial, msg.sample, tick, send_meta);
+
                         if (connParams->isPrimary)
-                            toggle_connectivity_indicator();
+                                toggle_connectivity_indicator();
+
                         put_crlf(serial);
                         tick++;
-                    }
-                    break;
+                        break;
                 }
                 default:
                     break;

--- a/src/logger/connectivityTask.c
+++ b/src/logger/connectivityTask.c
@@ -209,7 +209,7 @@ void connectivityTask(void *params)
     size_t rxCount = 0;
 
     ConnParams *connParams = (ConnParams*)params;
-    LoggerMessage *msg = NULL;
+    LoggerMessage msg;
 
     Serial *serial = get_serial(connParams->serial);
 
@@ -246,38 +246,44 @@ void connectivityTask(void *params)
             if ( should_reconnect )
                 break; /*break out and trigger the re-connection if needed */
 
-            should_stream = logging_enabled ||
-                            logger_config->ConnectivityConfigs.telemetryConfig.backgroundStreaming ||
-                            connParams->always_streaming;
+            should_stream =
+                    logging_enabled ||
+                    connParams->always_streaming ||
+                    logger_config->ConnectivityConfigs.telemetryConfig.backgroundStreaming;
 
-            char res = xQueueReceive(sampleQueue, &(msg), IDLE_TIMEOUT);
+            const char res = receive_logger_message(sampleQueue, &msg,
+                                                    IDLE_TIMEOUT);
 
             /*///////////////////////////////////////////////////////////
             // Process a pending message from logger task, if exists
             ////////////////////////////////////////////////////////////*/
             if (pdFALSE != res) {
-                switch(msg->type) {
+                switch(msg.type) {
                 case LoggerMessageType_Start: {
                     api_sendLogStart(serial);
                     put_crlf(serial);
                     tick = 0;
                     logging_enabled = true;
-                    if (!should_stream) /*if we're not already streaming trigger a re-connect */
+                    /* If we're not already streaming trigger a re-connect */
+                    if (!should_stream)
                         should_reconnect = true;
                     break;
                 }
                 case LoggerMessageType_Stop: {
                     api_sendLogEnd(serial);
                     put_crlf(serial);
-                    if (! (logger_config->ConnectivityConfigs.telemetryConfig.backgroundStreaming || connParams->always_streaming))
+                    if (! (logger_config->ConnectivityConfigs.telemetryConfig.backgroundStreaming ||
+                           connParams->always_streaming))
                         should_reconnect = true;
                     logging_enabled = false;
                     break;
                 }
                 case LoggerMessageType_Sample: {
                     if (should_stream) {
-                        int sendMeta = (tick == 0 || (connParams->periodicMeta && (tick % METADATA_SAMPLE_INTERVAL == 0)));
-                        api_sendSampleRecord(serial, msg->channelSamples, msg->sampleCount, tick, sendMeta);
+                        int sendMeta = (tick == 0 ||
+                                        (connParams->periodicMeta &&
+                                         (tick % METADATA_SAMPLE_INTERVAL == 0)));
+                        api_send_sample_record(serial, msg.sample, tick, sendMeta);
                         if (connParams->isPrimary)
                             toggle_connectivity_indicator();
                         put_crlf(serial);

--- a/src/logger/fileWriter.c
+++ b/src/logger/fileWriter.c
@@ -123,10 +123,10 @@ static void appendFloat(float num, int precision)
 static int write_samples_header(const LoggerMessage *msg)
 {
         int i;
-        ChannelSample *sample = msg->channelSamples;
-        size_t channelCount = msg->sampleCount;
+        const ChannelSample *sample = msg->sample->channel_samples;
+        size_t count = msg->sample->channel_count;
 
-        for (i = 0; 0 < channelCount; channelCount--, sample++, i++) {
+        for (i = 0; 0 < count; count--, sample++, i++) {
                 appendFileBuffer(0 == i ? "" : ",");
 
                 uint8_t precision = sample->cfg->precision;
@@ -148,8 +148,8 @@ static int write_samples_header(const LoggerMessage *msg)
 
 static int write_samples_data(const LoggerMessage *msg)
 {
-        ChannelSample *sample = msg->channelSamples;
-        size_t channelCount = msg->sampleCount;
+        const ChannelSample *sample = msg->sample->channel_samples;
+        size_t count = msg->sample->channel_count;
 
         if (NULL == sample) {
                 pr_warning("Logger: null sample record\r\n");
@@ -157,7 +157,7 @@ static int write_samples_data(const LoggerMessage *msg)
         }
 
         int i;
-        for (i = 0; 0 < channelCount; channelCount--, sample++, i++) {
+        for (i = 0; 0 < count; count--, sample++, i++) {
                 appendFileBuffer(0 == i ? "" : ",");
 
                 if (!sample->populated)
@@ -392,7 +392,7 @@ TESTABLE_STATIC int flush_logfile(struct logging_status *ls)
 
 static void fileWriterTask(void *params)
 {
-        LoggerMessage *msg = NULL;
+        LoggerMessage msg;
         struct logging_status ls;
         memset(&ls, 0, sizeof(struct logging_status));
 
@@ -400,11 +400,16 @@ static void fileWriterTask(void *params)
                 int rc = -1;
 
                 /* Get a sample. */
-                xQueueReceive(g_sampleRecordQueue, &(msg), portMAX_DELAY);
+                const char status = receive_logger_message(g_sampleRecordQueue,
+                                                           &msg, portMAX_DELAY);
 
-                switch (msg->type) {
+                /* If we fail to receive for any reason, keep trying */
+                if (pdPASS != status)
+                   continue;
+
+                switch (msg.type) {
                 case LoggerMessageType_Sample:
-                        rc = logging_sample(&ls, msg);
+                        rc = logging_sample(&ls, &msg);
                         break;
                 case LoggerMessageType_Start:
                         rc = logging_start(&ls);
@@ -420,7 +425,7 @@ static void fileWriterTask(void *params)
                 error_led(rc);
                 if (rc) {
                         pr_debug("Msg type ");
-                        pr_debug_int(msg->type);
+                        pr_debug_int(msg.type);
                         pr_debug_int_msg(" failed with code ", rc);
                 }
 

--- a/src/logger/logger.c
+++ b/src/logger/logger.c
@@ -50,4 +50,3 @@ bool logging_is_active()
 {
     return g_logging_since > 0;
 }
-

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -313,22 +313,21 @@ int api_sampleData(Serial *serial, const jsmntok_t *json)
             sendMeta = modp_atoi(value->data);
         }
     }
-    LoggerConfig * config = getWorkingLoggerConfig();
+
+    LoggerConfig *config = getWorkingLoggerConfig();
     size_t channelCount = get_enabled_channel_count(config);
-    ChannelSample *samples = create_channel_sample_buffer(config, channelCount);
 
-    if (samples == 0)
+    if (0 == channelCount)
         return API_ERROR_SEVERE;
-    LoggerMessage lm;
-    lm.channelSamples = samples;
-    lm.type = LoggerMessageType_Sample;
-    lm.ticks = getCurrentTicks();
-    lm.sampleCount = channelCount;
 
-    init_channel_sample_buffer(config, samples, channelCount);
-    populate_sample_buffer(&lm, channelCount, 0);
-    api_sendSampleRecord(serial, samples, channelCount, 0, sendMeta);
-    portFree(samples);
+    struct sample s;
+    memset(&s, 0, sizeof(struct sample));
+    init_sample_buffer(&s, channelCount);
+
+    populate_sample_buffer(&s, 0);
+    api_send_sample_record(serial, &s, 0, sendMeta);
+
+    free_sample_buffer(&s);
     return API_SUCCESS_NO_RETURN;
 }
 
@@ -384,38 +383,41 @@ static void json_channelConfig(Serial *serial, ChannelConfig *cfg, int more)
     json_int(serial, "sr", decodeSampleRate(cfg->sampleRate), more);
 }
 
-static void writeSampleMeta(Serial *serial, ChannelSample *sample,
-                            size_t channelCount, int sampleRateLimit, int more)
+static void write_sample_meta(Serial *serial, const struct sample *sample,
+                              int sampleRateLimit, int more)
 {
-    json_arrayStart(serial, "meta");
+        json_arrayStart(serial, "meta");
+        ChannelSample *channel_sample = sample->channel_samples;
 
-    for (size_t i = 0; i < channelCount; i++, sample++) {
+        for (size_t i = 0; i < sample->channel_count; ++i, ++channel_sample) {
+                if (0 < i)
+                        serial->put_c(',');
 
-        if (0 < i)
-            serial->put_c(',');
+                serial->put_c('{');
+                json_channelConfig(serial, channel_sample->cfg, 0);
+                serial->put_c('}');
+        }
 
-        serial->put_c('{');
-        json_channelConfig(serial, sample->cfg, 0);
-        serial->put_c('}');
-    }
-
-    json_arrayEnd(serial, more);
+        json_arrayEnd(serial, more);
 }
 
 int api_getMeta(Serial *serial, const jsmntok_t *json)
 {
     json_objStart(serial);
 
-    LoggerConfig *loggerConfig = getWorkingLoggerConfig();
-    size_t channelCount = get_enabled_channel_count(loggerConfig);
-    ChannelSample *channelSamples = create_channel_sample_buffer(loggerConfig, channelCount);
-    if (channelSamples == 0)
+    LoggerConfig * config = getWorkingLoggerConfig();
+    const size_t channelCount = get_enabled_channel_count(config);
+
+    if (0 == channelCount)
         return API_ERROR_SEVERE;
 
-    init_channel_sample_buffer(loggerConfig, channelSamples, channelCount);
-    writeSampleMeta(serial, channelSamples, channelCount, getConnectivitySampleRateLimit(), 0);
+    struct sample sample;
+    memset(&sample, 0, sizeof(struct sample));
+    init_sample_buffer(&sample, channelCount);
 
-    portFree(channelSamples);
+    write_sample_meta(serial, &sample, getConnectivitySampleRateLimit(), 0);
+
+    free_sample_buffer(&sample);
     json_objEnd(serial, 0);
     return API_SUCCESS_NO_RETURN;
 }
@@ -423,71 +425,77 @@ int api_getMeta(Serial *serial, const jsmntok_t *json)
 
 #define MAX_BITMAPS 10
 
-void api_sendSampleRecord(Serial *serial, ChannelSample *channelSamples,
-                          size_t channelCount, unsigned int tick, int sendMeta)
+void api_send_sample_record(Serial *serial, struct sample *sample,
+                            unsigned int tick, int sendMeta)
 {
-    json_objStart(serial);
-    json_objStartString(serial, "s");
-    json_uint(serial,"t", tick, 1);
+        json_objStart(serial);
+        json_objStartString(serial, "s");
+        json_uint(serial,"t", tick, 1);
 
-    if (sendMeta)
-        writeSampleMeta(serial, channelSamples, channelCount,
-                        getConnectivitySampleRateLimit(), 1);
+        if (sendMeta)
+                write_sample_meta(serial, sample,
+                                  getConnectivitySampleRateLimit(), 1);
 
-    size_t channelBitmaskIndex = 0;
-    unsigned int channelBitmask[MAX_BITMAPS];
-    memset(channelBitmask, 0, sizeof(channelBitmask));
+        size_t channelBitmaskIndex = 0;
+        unsigned int channelBitmask[MAX_BITMAPS];
+        memset(channelBitmask, 0, sizeof(channelBitmask));
 
-    json_arrayStart(serial, "d");
-    ChannelSample *sample = channelSamples;
+        json_arrayStart(serial, "d");
+        ChannelSample *cs = sample->channel_samples;
 
-    size_t channelBitPosition = 0;
-    for (size_t i = 0; i < channelCount; i++, channelBitPosition++, sample++) {
-        if (channelBitPosition > 31) {
-            channelBitmaskIndex++;
-            channelBitPosition=0;
-            if (channelBitmaskIndex > MAX_BITMAPS)
-                break;
+        size_t channelBitPosition = 0;
+        for (size_t i = 0; i < sample->channel_count;
+             i++, channelBitPosition++, cs++) {
+
+                if (channelBitPosition > 31) {
+                        channelBitmaskIndex++;
+                        channelBitPosition=0;
+                        if (channelBitmaskIndex > MAX_BITMAPS)
+                                break;
+                }
+
+                if (cs->populated) {
+                        channelBitmask[channelBitmaskIndex] =
+                                channelBitmask[channelBitmaskIndex] |
+                                (1 << channelBitPosition);
+
+                        const int precision = cs->cfg->precision;
+                        switch(cs->sampleData) {
+                        case SampleData_Float:
+                        case SampleData_Float_Noarg:
+                                put_float(serial, cs->valueFloat, precision);
+                                break;
+                        case SampleData_Int:
+                        case SampleData_Int_Noarg:
+                                put_int(serial, cs->valueInt);
+                                break;
+                        case SampleData_LongLong:
+                        case SampleData_LongLong_Noarg:
+                                put_ll(serial, cs->valueLongLong);
+                                break;
+                        case SampleData_Double:
+                        case SampleData_Double_Noarg:
+                                put_double(serial, cs->valueDouble, precision);
+                                break;
+                        default:
+                                pr_warning("sendSampleRec: unknown sample "
+                                           "data type\r\n");
+                                break;
+                        }
+                        serial->put_c(',');
+                }
         }
 
-        if (sample->populated) {
-            channelBitmask[channelBitmaskIndex] = channelBitmask[channelBitmaskIndex] | (1 << channelBitPosition);
-
-            const int precision = sample->cfg->precision;
-            switch(sample->sampleData) {
-            case SampleData_Float:
-            case SampleData_Float_Noarg:
-                put_float(serial, sample->valueFloat, precision);
-                break;
-            case SampleData_Int:
-            case SampleData_Int_Noarg:
-                put_int(serial, sample->valueInt);
-                break;
-            case SampleData_LongLong:
-            case SampleData_LongLong_Noarg:
-                put_ll(serial, sample->valueLongLong);
-                break;
-            case SampleData_Double:
-            case SampleData_Double_Noarg:
-                put_double(serial, sample->valueDouble, precision);
-                break;
-            default:
-                pr_warning("sendSampleRec: unknown sample data type\n");
-                break;
-            }
-            serial->put_c(',');
+        size_t channelBitmaskCount = channelBitmaskIndex + 1;
+        for (size_t i = 0; i < channelBitmaskCount; i++) {
+                put_uint(serial, channelBitmask[i]);
+                if (i < channelBitmaskCount - 1)
+                        serial->put_c(',');
         }
-    }
 
-    size_t channelBitmaskCount = channelBitmaskIndex + 1;
-    for (size_t i = 0; i < channelBitmaskCount; i++) {
-        put_uint(serial, channelBitmask[i]);
-        if (i < channelBitmaskCount - 1)
-            serial->put_c(',');
-    }
-    json_arrayEnd(serial, 0);
-    json_objEnd(serial, 0);
-    json_objEnd(serial, 0);
+        json_arrayEnd(serial, 0);
+        json_objEnd(serial, 0);
+        json_objEnd(serial, 0);
 }
 
 static const jsmntok_t * setChannelConfig(Serial *serial, const jsmntok_t *cfg,

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -300,7 +300,6 @@ int api_getStatus(Serial *serial, const jsmntok_t *json)
 
 int api_sampleData(Serial *serial, const jsmntok_t *json)
 {
-
     int sendMeta = 0;
     if (json->type == JSMN_OBJECT && json->size == 2) {
         const jsmntok_t * meta = json + 1;
@@ -322,7 +321,9 @@ int api_sampleData(Serial *serial, const jsmntok_t *json)
 
     struct sample s;
     memset(&s, 0, sizeof(struct sample));
-    init_sample_buffer(&s, channelCount);
+    const size_t size = init_sample_buffer(&s, channelCount);
+    if (!size)
+       return API_ERROR_SEVERE;
 
     populate_sample_buffer(&s, 0);
     api_send_sample_record(serial, &s, 0, sendMeta);
@@ -411,13 +412,15 @@ int api_getMeta(Serial *serial, const jsmntok_t *json)
     if (0 == channelCount)
         return API_ERROR_SEVERE;
 
-    struct sample sample;
-    memset(&sample, 0, sizeof(struct sample));
-    init_sample_buffer(&sample, channelCount);
+    struct sample s;
+    memset(&s, 0, sizeof(struct sample));
+    const size_t size = init_sample_buffer(&s, channelCount);
+    if (!size)
+       return API_ERROR_SEVERE;
 
-    write_sample_meta(serial, &sample, getConnectivitySampleRateLimit(), 0);
+    write_sample_meta(serial, &s, getConnectivitySampleRateLimit(), 0);
 
-    free_sample_buffer(&sample);
+    free_sample_buffer(&s);
     json_objEnd(serial, 0);
     return API_SUCCESS_NO_RETURN;
 }

--- a/src/logger/loggerSampleData.c
+++ b/src/logger/loggerSampleData.c
@@ -209,12 +209,11 @@ float get_imu_sample(int channelId)
     return value;
 }
 
-/* XXX Now we setup how we initialize the sample buffer XXX */
-
-void init_channel_sample_buffer(LoggerConfig *loggerConfig, ChannelSample * samples, size_t channelCount)
+void init_channel_sample_buffer(LoggerConfig *loggerConfig, struct sample *buff)
 {
-    ChannelSample *sample = samples;
-    ChannelConfig *chanCfg;
+        buff->ticks = 0;
+        ChannelSample *sample = buff->channel_samples;
+        ChannelConfig *chanCfg;
 
     /*
      * This sets up immutable channels.  These channels are channels that are always
@@ -295,7 +294,6 @@ void init_channel_sample_buffer(LoggerConfig *loggerConfig, ChannelSample * samp
     sample = processChannelSampleWithFloatGetterNoarg(sample, chanCfg, GPS_getDOP);
 
 
-
     LapConfig *trackConfig = &(loggerConfig->LapConfigs);
     chanCfg = &(trackConfig->lapCountCfg);
     sample = processChannelSampleWithIntGetterNoarg(sample, chanCfg, getLapCount);
@@ -352,10 +350,11 @@ static void populate_channel_sample(ChannelSample *sample)
     }
 }
 
-int populate_sample_buffer(LoggerMessage *lm,  size_t count, size_t logTick)
+int populate_sample_buffer(struct sample *s, size_t logTick)
 {
     unsigned short highestRate = SAMPLE_DISABLED;
-    ChannelSample *samples = lm->channelSamples;
+    ChannelSample *samples = s->channel_samples;
+    const size_t count = s->channel_count;
 
     for (size_t i = 0; i < count; i++, samples++) {
         const unsigned short sampleRate = samples->cfg->sampleRate;
@@ -375,7 +374,7 @@ int populate_sample_buffer(LoggerMessage *lm,  size_t count, size_t logTick)
         return SAMPLE_DISABLED;
 
     // If there was a sample taken, now we fill in the always sampled fields.
-    samples = lm->channelSamples;
+    samples = s->channel_samples;
     for (size_t i = 0; i < count; i++, samples++) {
         const int isAlwaysSampled = samples->cfg->flags & ALWAYS_SAMPLED;
         if (!isAlwaysSampled)
@@ -384,9 +383,6 @@ int populate_sample_buffer(LoggerMessage *lm,  size_t count, size_t logTick)
         samples->populated = true;
         populate_channel_sample(samples);
     }
-
-    lm->ticks = getCurrentTicks();
-    lm->sampleCount = count;
 
     return highestRate;
 }

--- a/src/logger/loggerTaskEx.c
+++ b/src/logger/loggerTaskEx.c
@@ -122,7 +122,7 @@ static int init_sample_ring_buffer(LoggerConfig *loggerConfig)
                 }
         }
 
-        pr_info_int_msg("Sample buffers allocated: ", i);
+        pr_debug_int_msg("Sample buffers allocated: ", i);
         return i;
 }
 

--- a/src/logger/loggerTaskEx.c
+++ b/src/logger/loggerTaskEx.c
@@ -115,7 +115,7 @@ static int init_sample_ring_buffer(LoggerConfig *loggerConfig)
 
         for (i = 0; s < end; ++s, ++i) {
                 const size_t bytes = init_sample_buffer(s, channel_count);
-                if (bytes) {
+                if (0 == bytes) {
                         /* If here, then can't alloc memory for buffers */
                         pr_error("Failed to allocate memory for sample buffers\r\n");
                         break;

--- a/src/logger/loggerTaskEx.c
+++ b/src/logger/loggerTaskEx.c
@@ -36,11 +36,11 @@
 #include "lap_stats.h"
 #include "printk.h"
 
-#define LOGGER_TASK_PRIORITY				( tskIDLE_PRIORITY + 4 )
-#define LOGGER_STACK_SIZE  					200
-#define IDLE_TIMEOUT						configTICK_RATE_HZ / 1
+#define LOGGER_TASK_PRIORITY	( tskIDLE_PRIORITY + 4 )
+#define LOGGER_STACK_SIZE	200
+#define IDLE_TIMEOUT	configTICK_RATE_HZ / 1
 
-#define BACKGROUND_SAMPLE_RATE				SAMPLE_50Hz
+#define BACKGROUND_SAMPLE_RATE	SAMPLE_50Hz
 
 int g_loggingShouldRun;
 int g_configChanged;
@@ -48,25 +48,18 @@ int g_telemetryBackgroundStreaming;
 
 xSemaphoreHandle onTick;
 
-#define LOGGER_MESSAGE_BUFFER_SIZE 10
-static LoggerMessage g_sampleRecordMsgBuffer[LOGGER_MESSAGE_BUFFER_SIZE];
-
-static LoggerMessage getTimeInsensativeLoggerMessage(const enum LoggerMessageType t)
-{
-    LoggerMessage msg;
-    msg.type = t;
-    msg.ticks = 0; // Time insensitive.
-    return msg;
-}
+#define LOGGER_MESSAGE_BUFFER_SIZE	10
+/* This should be 0'd out accroding to C standards */
+static struct sample g_sample_buffer[LOGGER_MESSAGE_BUFFER_SIZE];
 
 static LoggerMessage getLogStartMessage()
 {
-    return getTimeInsensativeLoggerMessage(LoggerMessageType_Start);
+        return create_logger_message(LoggerMessageType_Start, NULL);
 }
 
 static LoggerMessage getLogStopMessage()
 {
-    return getTimeInsensativeLoggerMessage(LoggerMessageType_Stop);
+        return create_logger_message(LoggerMessageType_Stop, NULL);
 }
 
 /**
@@ -108,24 +101,20 @@ static void logging_stopped()
 
 void startLoggerTaskEx(int priority)
 {
-    xTaskCreate( loggerTaskEx,( signed portCHAR * ) "logger",	LOGGER_STACK_SIZE, NULL, priority, NULL );
+    xTaskCreate(loggerTaskEx, ( signed portCHAR * ) "logger",
+                 LOGGER_STACK_SIZE, NULL, priority, NULL );
 }
 
-static size_t initSampleRecords(LoggerConfig *loggerConfig)
+static size_t init_samples(LoggerConfig *loggerConfig)
 {
-    size_t channelSampleCount = get_enabled_channel_count(loggerConfig);
+        const size_t channel_count = get_enabled_channel_count(loggerConfig);
+        struct sample *s = g_sample_buffer;
+        const struct sample * const end = s + LOGGER_MESSAGE_BUFFER_SIZE;
 
-    for (size_t i=0; i < LOGGER_MESSAGE_BUFFER_SIZE; i++) {
-        LoggerMessage *msg = (g_sampleRecordMsgBuffer + i);
-        msg->type = LoggerMessageType_Sample;
-        if (msg->channelSamples != NULL) {
-            vPortFree(msg->channelSamples);
-        }
-        ChannelSample *channelSamples = create_channel_sample_buffer(loggerConfig, channelSampleCount);
-        init_channel_sample_buffer(loggerConfig, channelSamples, channelSampleCount);
-        msg->channelSamples = channelSamples;
-    }
-    return channelSampleCount;
+        for (; s < end; ++s)
+                init_sample_buffer(s, channel_count);
+
+        return channel_count;
 }
 
 static int calcTelemetrySampleRate(LoggerConfig *config, int desiredSampleRate)
@@ -140,9 +129,8 @@ size_t updateSampleRates(LoggerConfig *loggerConfig, int *loggingSampleRate,
     *loggingSampleRate = getHighestSampleRate(loggerConfig);
     *timebaseSampleRate = *loggingSampleRate;
     *timebaseSampleRate = getHigherSampleRate(BACKGROUND_SAMPLE_RATE, *timebaseSampleRate);
-
     *telemetrySampleRate = calcTelemetrySampleRate(loggerConfig, *loggingSampleRate);
-    size_t channelCount = initSampleRecords(loggerConfig);
+
     pr_info("timebase/logging/telemetry sample rate: ");
     pr_info_int(decodeSampleRate(*timebaseSampleRate));
     pr_info("/");
@@ -150,89 +138,91 @@ size_t updateSampleRates(LoggerConfig *loggerConfig, int *loggingSampleRate,
     pr_info("/");
     pr_info_int(decodeSampleRate(*telemetrySampleRate));
     pr_info("\r\n");
-    return channelCount;
+
+    return init_samples(loggerConfig);
 }
 
 void loggerTaskEx(void *params)
 {
-    g_loggingShouldRun = 0;
-    memset(&g_sampleRecordMsgBuffer, 0, sizeof(g_sampleRecordMsgBuffer));
-    vSemaphoreCreateBinary(onTick);
+        LoggerConfig *loggerConfig = getWorkingLoggerConfig();
+        size_t bufferIndex = 0;
+        size_t currentTicks = 0;
+        size_t channelCount = 0;
+        int loggingSampleRate = SAMPLE_DISABLED;
+        int sampleRateTimebase = SAMPLE_DISABLED;
+        int telemetrySampleRate = SAMPLE_DISABLED;
 
-    LoggerConfig *loggerConfig = getWorkingLoggerConfig();
+        g_loggingShouldRun = 0;
+        vSemaphoreCreateBinary(onTick);
+        logging_set_status(LOGGING_STATUS_IDLE);
+        logging_set_logging_start(0);
+        g_configChanged = 1;
 
-    logging_set_status(LOGGING_STATUS_IDLE);
-    logging_set_logging_start(0);
-    size_t bufferIndex = 0;
-    size_t currentTicks = 0;
-    g_configChanged = 1;
-    size_t channelCount = 0;
+        while (1) {
+                xSemaphoreTake(onTick, portMAX_DELAY);
+                watchdog_reset();
+                ++currentTicks;
 
-    int loggingSampleRate = SAMPLE_DISABLED;
-    int sampleRateTimebase = SAMPLE_DISABLED;
-    int telemetrySampleRate = SAMPLE_DISABLED;
+                if (currentTicks % BACKGROUND_SAMPLE_RATE == 0)
+                        doBackgroundSampling();
 
-    while (1) {
-        xSemaphoreTake(onTick, portMAX_DELAY);
-        watchdog_reset();
-        ++currentTicks;
+                if (g_configChanged) {
+                        g_configChanged = 0;
+                        currentTicks = 0;
+                        channelCount = updateSampleRates(
+                                loggerConfig, &loggingSampleRate,
+                                &telemetrySampleRate, &sampleRateTimebase);
+                        resetLapCount();
+                        lapstats_reset_distance();
+                }
 
-        if (currentTicks % BACKGROUND_SAMPLE_RATE == 0)
-            doBackgroundSampling();
+                const bool is_logging = logging_is_active();
+                if (g_loggingShouldRun && !is_logging) {
+                        logging_started();
+                        LoggerMessage logStartMsg = getLogStartMessage();
+                        queue_logfile_record(&logStartMsg);
+                        queueTelemetryRecord(&logStartMsg);
+                }
 
-        if (g_configChanged) {
-            currentTicks = 0;
-            channelCount = updateSampleRates(loggerConfig, &loggingSampleRate, &telemetrySampleRate,
-                                             &sampleRateTimebase);
-            resetLapCount();
-            lapstats_reset_distance();
-            g_configChanged = 0;
+                if (!g_loggingShouldRun && is_logging) {
+                        logging_stopped();
+                        LoggerMessage logStopMsg = getLogStopMessage();
+                        queue_logfile_record(&logStopMsg);
+                        queueTelemetryRecord(&logStopMsg);
+                        logging_set_status(LOGGING_STATUS_IDLE);
+                }
+
+                /* Prepare a LoggerMessage */
+                struct sample *sample = &g_sample_buffer[bufferIndex];
+                sample->channel_count = channelCount;
+                LoggerMessage msg = create_logger_message(
+                        LoggerMessageType_Sample, sample);
+
+                /* Check if we need to actually populate the buffer. */
+                const int sampledRate = populate_sample_buffer(sample,
+                                                               currentTicks);
+                if (sampledRate == SAMPLE_DISABLED)
+                        continue;
+
+                /*
+                 * We only log to file if the user has manually pushed the
+                 * logging button.
+                 */
+                if (is_logging && sampledRate >= loggingSampleRate) {
+                        /* XXX Move this to file writer? */
+                        const portBASE_TYPE res = queue_logfile_record(&msg);
+                        const logging_status_t ls = pdTRUE == res ?
+                                LOGGING_STATUS_WRITING :
+                                LOGGING_STATUS_ERROR_WRITING;
+                        logging_set_status(ls);
+                }
+
+                /* send the sample on to the telemetry task(s) */
+                if (sampledRate >= telemetrySampleRate ||
+                    currentTicks % telemetrySampleRate == 0)
+                        queueTelemetryRecord(&msg);
+
+                ++bufferIndex;
+                bufferIndex %= LOGGER_MESSAGE_BUFFER_SIZE;
         }
-
-        {
-            bool is_logging = logging_is_active();
-            if (g_loggingShouldRun && !is_logging) {
-                logging_started();
-                LoggerMessage logStartMsg = getLogStartMessage();
-                queue_logfile_record(&logStartMsg);
-                queueTelemetryRecord(&logStartMsg);
-            }
-
-            if (!g_loggingShouldRun && is_logging) {
-                logging_stopped();
-                LoggerMessage logStopMsg = getLogStopMessage();
-                queue_logfile_record(&logStopMsg);
-                queueTelemetryRecord(&logStopMsg);
-                logging_set_status(LOGGING_STATUS_IDLE);
-            }
-        }
-
-        /* Check if we need to actually populate the buffer. */
-        LoggerMessage *msg = &g_sampleRecordMsgBuffer[bufferIndex];
-        int sampledRate = populate_sample_buffer(msg, channelCount, currentTicks);
-        msg->sampleCount = channelCount;
-
-        if (sampledRate == SAMPLE_DISABLED) {
-            continue; /* If here, no sample to give. */
-        }
-
-        bool is_logging = logging_is_active();
-        /* We only log to file if the user has manually pushed the logging button. */
-        if (is_logging && sampledRate >= loggingSampleRate) {
-            const portBASE_TYPE res = queue_logfile_record(msg);
-            if (res == pdTRUE) {
-                logging_set_status(LOGGING_STATUS_WRITING);
-            } else {
-                logging_set_status(LOGGING_STATUS_ERROR_WRITING);
-                LED_enable(3); //error LED
-            }
-        }
-
-        /* send the sample on to the telemetry task(s) */
-        if (sampledRate >= telemetrySampleRate || currentTicks % telemetrySampleRate == 0) {
-            queueTelemetryRecord(msg);
-        }
-        ++bufferIndex;
-        bufferIndex %= LOGGER_MESSAGE_BUFFER_SIZE;
-    }
 }

--- a/src/logger/sampleRecord.c
+++ b/src/logger/sampleRecord.c
@@ -9,15 +9,65 @@
 #include "mem_mang.h"
 #include "FreeRTOS.h"
 #include "taskUtil.h"
+#include "loggerSampleData.h"
 
-ChannelSample * create_channel_sample_buffer(LoggerConfig *loggerConfig, size_t channelCount)
+#include <stdbool.h>
+
+size_t init_sample_buffer(struct sample *s, const size_t count)
 {
-    size_t size = sizeof(ChannelSample[channelCount]);
-    ChannelSample * samples = (ChannelSample *)portMalloc(size);
-    return samples;
+        if (s->channel_samples)
+                free_sample_buffer(s);
+
+        const size_t size = sizeof(ChannelSample[count]);
+        s->ticks = 0;
+        s->channel_count = count;
+        s->channel_samples = (ChannelSample *) portMalloc(size);
+
+        init_channel_sample_buffer(getWorkingLoggerConfig(), s);
+
+        return size;
 }
 
-int isValidLoggerMessageAge(LoggerMessage *lm)
+void free_sample_buffer(struct sample *s)
 {
-    return (getCurrentTicks() - lm->ticks) < 10;
+        portFree(s->channel_samples);
+        s->channel_samples = NULL;
+}
+
+bool is_sample_data_valid(const LoggerMessage *lm)
+{
+        /* Only LoggerMessageType_Sample will have sample data to validate */
+        if (lm->type != LoggerMessageType_Sample)
+                return true;
+
+        return lm->ticks == lm->sample->ticks;
+}
+
+char receive_logger_message(xQueueHandle queue, LoggerMessage *lm,
+                            portTickType timeout)
+{
+        char res;
+
+        do {
+                res = xQueueReceive(queue, lm, timeout);
+        } while (pdPASS == res && !is_sample_data_valid(lm));
+
+        return res;
+}
+
+LoggerMessage create_logger_message(const enum LoggerMessageType t,
+                                    struct sample *s)
+{
+        const size_t ticks = getCurrentTicks();
+        LoggerMessage msg;
+
+        msg.type = t;
+        msg.ticks = ticks;
+        msg.sample = s;
+
+        /* Set matching timestamps.  Needed for validation */
+        if (s)
+                s->ticks = ticks;
+
+        return msg;
 }

--- a/src/logger/sampleRecord.c
+++ b/src/logger/sampleRecord.c
@@ -19,10 +19,13 @@ size_t init_sample_buffer(struct sample *s, const size_t count)
                 free_sample_buffer(s);
 
         const size_t size = sizeof(ChannelSample[count]);
-        s->ticks = 0;
-        s->channel_count = count;
         s->channel_samples = (ChannelSample *) portMalloc(size);
 
+        if (NULL == s->channel_samples)
+                return 0;
+
+        s->ticks = 0;
+        s->channel_count = count;
         init_channel_sample_buffer(getWorkingLoggerConfig(), s);
 
         return size;

--- a/test/sampleRecord_test.cpp
+++ b/test/sampleRecord_test.cpp
@@ -22,79 +22,81 @@ using std::string;
 // Registers the fixture into the 'registry'
 CPPUNIT_TEST_SUITE_REGISTRATION( SampleRecordTest );
 
+LoggerConfig *lc;
+struct sample s;
+
 void SampleRecordTest::setUp()
 {
 	InitLoggerHardware();
 	GPS_init(10, get_serial(SERIAL_GPS));
 	initialize_logger_config();
 	reset_ticks();
+
+        lc = getWorkingLoggerConfig();
+        lapStats_init();
+        size_t channelCount = get_enabled_channel_count(lc);
+        init_sample_buffer(&s, channelCount);
+
 }
 
 
 void SampleRecordTest::tearDown()
 {
+        free_sample_buffer(&s);
 }
 
 
 void SampleRecordTest::testPopulateSampleRecord(){
-	LoggerConfig *lc = getWorkingLoggerConfig();
-   GPS_init(10, get_serial(SERIAL_GPS));
-   lapStats_init();
-
 	//mock up some values to test later
 	lc->ADCConfigs[7].scalingMode = SCALING_MODE_RAW;
 	ADC_mock_set_value(7, 123);
 	ADC_sample_all();
 
-	size_t channelCount = get_enabled_channel_count(lc);
-	ChannelSample * samples = create_channel_sample_buffer(lc, channelCount);
-	init_channel_sample_buffer(lc, samples, channelCount);
-
-	LoggerMessage lm;
-	lm.channelSamples = samples;
-	lm.sampleCount = channelCount;
-	lm.type = LoggerMessageType_Sample;
-
-   // Set it so we have 1 tick.
-   reset_ticks();
-   increment_tick();
-   CPPUNIT_ASSERT_EQUAL(1, (int) (xTaskGetTickCount()));
+        // Set it so we have 1 tick.
+        increment_tick();
+        CPPUNIT_ASSERT_EQUAL(1, (int) (xTaskGetTickCount()));
 
 	const unsigned short highSampleRate =
-    (unsigned short) populate_sample_buffer(&lm, channelCount, 0);
+                (unsigned short) populate_sample_buffer(&s, 0);
+        const ChannelSample *samples = s.channel_samples;
 
-   // Interval Channel
-   CPPUNIT_ASSERT_EQUAL((int) (xTaskGetTickCount() * MS_PER_TICK), samples->valueInt);
+        // Interval Channel
+        CPPUNIT_ASSERT_EQUAL((int) (xTaskGetTickCount() * MS_PER_TICK),
+                             samples->valueInt);
 
-
-   // UtC Channel.  Just test that its 0 for now
-   samples++;
-   CPPUNIT_ASSERT_EQUAL(0ll, (long long) getMillisSinceEpoch());
-   CPPUNIT_ASSERT_EQUAL(0ll, samples->valueLongLong);
-
+        // UtC Channel.  Just test that its 0 for now
+        samples++;
+        CPPUNIT_ASSERT_EQUAL(0ll, (long long) getMillisSinceEpoch());
+        CPPUNIT_ASSERT_EQUAL(0ll, samples->valueLongLong);
 
 	//analog channel
-   samples++;
+        samples++;
 	CPPUNIT_ASSERT_EQUAL(123 * 0.0048828125f, samples->valueFloat);
 
 	//accelerometer channels
 	samples++;
-	CPPUNIT_ASSERT_EQUAL(imu_read_value(0, &lc->ImuConfigs[0]), samples->valueFloat);
+	CPPUNIT_ASSERT_EQUAL(imu_read_value(0, &lc->ImuConfigs[0]),
+                             samples->valueFloat);
 
 	samples++;
-	CPPUNIT_ASSERT_EQUAL(imu_read_value(1, &lc->ImuConfigs[1]), samples->valueFloat);
+	CPPUNIT_ASSERT_EQUAL(imu_read_value(1, &lc->ImuConfigs[1]),
+                             samples->valueFloat);
 
 	samples++;
-	CPPUNIT_ASSERT_EQUAL(imu_read_value(2, &lc->ImuConfigs[2]), samples->valueFloat);
+	CPPUNIT_ASSERT_EQUAL(imu_read_value(2, &lc->ImuConfigs[2]),
+                             samples->valueFloat);
 
 	samples++;
-	CPPUNIT_ASSERT_EQUAL(imu_read_value(3, &lc->ImuConfigs[3]), samples->valueFloat);
+	CPPUNIT_ASSERT_EQUAL(imu_read_value(3, &lc->ImuConfigs[3]),
+                             samples->valueFloat);
 
 	samples++;
-	CPPUNIT_ASSERT_EQUAL(imu_read_value(4, &lc->ImuConfigs[4]), samples->valueFloat);
+	CPPUNIT_ASSERT_EQUAL(imu_read_value(4, &lc->ImuConfigs[4]),
+                             samples->valueFloat);
 
 	samples++;
-	CPPUNIT_ASSERT_EQUAL(imu_read_value(5, &lc->ImuConfigs[4]), samples->valueFloat);
+	CPPUNIT_ASSERT_EQUAL(imu_read_value(5, &lc->ImuConfigs[4]),
+                             samples->valueFloat);
 
 	//GPS / Track channels
         /*
@@ -105,34 +107,34 @@ void SampleRecordTest::testPopulateSampleRecord(){
          * get NaN or something else weird that you didn't expect.
          */
 	samples++;
-	CPPUNIT_ASSERT_EQUAL((float)0, samples->valueFloat);
+	CPPUNIT_ASSERT_EQUAL((float) 0, samples->valueFloat);
 
 	samples++;
-	CPPUNIT_ASSERT_EQUAL((float)0, samples->valueFloat);
+	CPPUNIT_ASSERT_EQUAL((float) 0, samples->valueFloat);
 
 	samples++;
-	CPPUNIT_ASSERT_EQUAL((float)0, samples->valueFloat);
+	CPPUNIT_ASSERT_EQUAL((float) 0, samples->valueFloat);
 
 	samples++;
-	CPPUNIT_ASSERT_EQUAL((float)0, samples->valueFloat);
+	CPPUNIT_ASSERT_EQUAL((float) 0, samples->valueFloat);
 
 	samples++;
-	CPPUNIT_ASSERT_EQUAL((float)0, samples->valueFloat);
+	CPPUNIT_ASSERT_EQUAL((float) 0, samples->valueFloat);
 
 	samples++;
-	CPPUNIT_ASSERT_EQUAL((float)0, samples->valueFloat);
+	CPPUNIT_ASSERT_EQUAL((float) 0, samples->valueFloat);
 
-    samples++;
-    CPPUNIT_ASSERT_EQUAL((float)0, samples->valueFloat);
+        samples++;
+        CPPUNIT_ASSERT_EQUAL((float) 0, samples->valueFloat);
 
-    samples++;
-    CPPUNIT_ASSERT_EQUAL((float)0, samples->valueFloat);
+        samples++;
+        CPPUNIT_ASSERT_EQUAL((float) 0, samples->valueFloat);
 
-    samples++;
-    CPPUNIT_ASSERT_EQUAL((float)0, samples->valueFloat);
+        samples++;
+        CPPUNIT_ASSERT_EQUAL((float) 0, samples->valueFloat);
 
-    samples++;
-	CPPUNIT_ASSERT_EQUAL((float)0, samples->valueFloat);
+        samples++;
+	CPPUNIT_ASSERT_EQUAL((float) 0, samples->valueFloat);
 
         samples++;
         CPPUNIT_ASSERT_EQUAL(-1, samples->valueInt);
@@ -140,251 +142,280 @@ void SampleRecordTest::testPopulateSampleRecord(){
 
 void SampleRecordTest::testInitSampleRecord()
 {
-   LoggerConfig *lc = getWorkingLoggerConfig();
+        LoggerConfig *lc = getWorkingLoggerConfig();
 
-   size_t expectedEnabledChannels = 24;
+        const size_t expectedEnabledChannels = 24;
+        size_t channelCount = get_enabled_channel_count(lc);
+        CPPUNIT_ASSERT_EQUAL(expectedEnabledChannels, channelCount);
 
-   size_t channelCount = get_enabled_channel_count(lc);
-   CPPUNIT_ASSERT_EQUAL(expectedEnabledChannels, channelCount);
+        ChannelSample *ts = s.channel_samples;
+        const struct TimeConfig *tc = lc->TimeConfigs;
 
-   ChannelSample * samples = create_channel_sample_buffer(lc, channelCount);
-   init_channel_sample_buffer(lc, samples, channelCount);
+        // Check what should be Uptime (Interval)
+        CPPUNIT_ASSERT_EQUAL(string("Interval"), string(tc->cfg.label));
+        CPPUNIT_ASSERT_EQUAL(string("ms"), string(tc->cfg.units));
+        CPPUNIT_ASSERT_EQUAL(TimeType_Uptime, tc->tt);
+        CPPUNIT_ASSERT_EQUAL(SampleData_Int_Noarg, ts->sampleData);
+        ++ts;
+        ++tc;
 
-   ChannelSample * ts = samples;
+        // Check what should be the Utc
+        CPPUNIT_ASSERT_EQUAL(string("Utc"), string(tc->cfg.label));
+        CPPUNIT_ASSERT_EQUAL(string("ms"), string(tc->cfg.units));
+        CPPUNIT_ASSERT_EQUAL(TimeType_UtcMillis, tc->tt);
+        CPPUNIT_ASSERT_EQUAL(SampleData_LongLong_Noarg, ts->sampleData);
+        ++ts;
 
-   const struct TimeConfig *tc = lc->TimeConfigs;
+        for (int i = 0; i < CONFIG_ADC_CHANNELS; i++){
+                ADCConfig *ac = &lc->ADCConfigs[i];
+                if (ac->cfg.sampleRate == SAMPLE_DISABLED)
+                        continue;
 
-   // Check what should be Uptime (Interval)
-   CPPUNIT_ASSERT_EQUAL(string("Interval"), string(tc->cfg.label));
-   CPPUNIT_ASSERT_EQUAL(string("ms"), string(tc->cfg.units));
-   CPPUNIT_ASSERT_EQUAL(TimeType_Uptime, tc->tt);
-   CPPUNIT_ASSERT_EQUAL(SampleData_Int_Noarg, ts->sampleData);
-   ++ts;
-   ++tc;
+                CPPUNIT_ASSERT_EQUAL((size_t) i, ts->channelIndex);
+                CPPUNIT_ASSERT_EQUAL((void *) &ac->cfg, (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL((void *) get_analog_sample,
+                                     (void *) ts->get_float_sample);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Float, ts->sampleData);
+                ts++;
+        }
 
-   // Check what should be the Utc
-   CPPUNIT_ASSERT_EQUAL(string("Utc"), string(tc->cfg.label));
-   CPPUNIT_ASSERT_EQUAL(string("ms"), string(tc->cfg.units));
-   CPPUNIT_ASSERT_EQUAL(TimeType_UtcMillis, tc->tt);
-   CPPUNIT_ASSERT_EQUAL(SampleData_LongLong_Noarg, ts->sampleData);
-   ++ts;
+        for (int i = 0; i < CONFIG_IMU_CHANNELS; i++){
+                ImuConfig *ac = &lc->ImuConfigs[i];
+                if (ac->cfg.sampleRate == SAMPLE_DISABLED)
+                        continue;
 
-   for (int i = 0; i < CONFIG_ADC_CHANNELS; i++){
-      ADCConfig *ac = &lc->ADCConfigs[i];
-      if (ac->cfg.sampleRate != SAMPLE_DISABLED){
-         CPPUNIT_ASSERT_EQUAL((size_t) i, ts->channelIndex);
-         CPPUNIT_ASSERT_EQUAL((void *) &ac->cfg, (void *) ts->cfg);
-         CPPUNIT_ASSERT_EQUAL((void *) get_analog_sample, (void *)ts->get_float_sample);
-         CPPUNIT_ASSERT_EQUAL(SampleData_Float, ts->sampleData);
-         ts++;
-      }
-   }
+                CPPUNIT_ASSERT_EQUAL((size_t)i,ts->channelIndex);
+                CPPUNIT_ASSERT_EQUAL((void *) &ac->cfg, (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL((void *) get_imu_sample,
+                                     (void *) ts->get_float_sample);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Float, ts->sampleData);
+                ts++;
+        }
 
-   for (int i = 0; i < CONFIG_IMU_CHANNELS; i++){
-      ImuConfig *ac = &lc->ImuConfigs[i];
-      if (ac->cfg.sampleRate != SAMPLE_DISABLED){
-         CPPUNIT_ASSERT_EQUAL((size_t)i,ts->channelIndex);
-         CPPUNIT_ASSERT_EQUAL((void *) &ac->cfg, (void *) ts->cfg);
-         CPPUNIT_ASSERT_EQUAL((void *)get_imu_sample, (void *)ts->get_float_sample);
-         CPPUNIT_ASSERT_EQUAL(SampleData_Float, ts->sampleData);
-         ts++;
-      }
-   }
+        for (int i = 0; i < CONFIG_TIMER_CHANNELS; i++){
+                TimerConfig *tc = &lc->TimerConfigs[i];
+                if (tc->cfg.sampleRate == SAMPLE_DISABLED)
+                        continue;
 
-   for (int i = 0; i < CONFIG_TIMER_CHANNELS; i++){
-      TimerConfig *tc = &lc->TimerConfigs[i];
-      if (tc->cfg.sampleRate != SAMPLE_DISABLED){
-         CPPUNIT_ASSERT_EQUAL((size_t)i, ts->channelIndex);
-         CPPUNIT_ASSERT_EQUAL((void *) &tc->cfg, (void *) ts->cfg);
-         CPPUNIT_ASSERT_EQUAL((void *)get_timer_sample, (void *)ts->get_float_sample);
-         CPPUNIT_ASSERT_EQUAL(SampleData_Float, ts->sampleData);
-         ts++;
-      }
-   }
+                CPPUNIT_ASSERT_EQUAL((size_t)i, ts->channelIndex);
+                CPPUNIT_ASSERT_EQUAL((void *) &tc->cfg, (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL((void *) get_timer_sample,
+                                     (void *) ts->get_float_sample);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Float, ts->sampleData);
+                ts++;
+        }
 
-   for (int i = 0; i < CONFIG_GPIO_CHANNELS; i++){
-      GPIOConfig *gc = &lc->GPIOConfigs[i];
-      if (gc->cfg.sampleRate != SAMPLE_DISABLED){
-         CPPUNIT_ASSERT_EQUAL((size_t)i, ts->channelIndex);
-         CPPUNIT_ASSERT_EQUAL((void *) &gc->cfg, (void *) ts->cfg);
-         CPPUNIT_ASSERT_EQUAL((void *) GPIO_get, (void *) ts->get_int_sample);
-         CPPUNIT_ASSERT_EQUAL(SampleData_Int, ts->sampleData);
-         ts++;
-      }
-   }
+        for (int i = 0; i < CONFIG_GPIO_CHANNELS; i++){
+                GPIOConfig *gc = &lc->GPIOConfigs[i];
+                if (gc->cfg.sampleRate == SAMPLE_DISABLED)
+                        continue;
 
-   for (int i = 0; i < CONFIG_PWM_CHANNELS; i++){
-      PWMConfig *pc = &lc->PWMConfigs[i];
-      if (pc->cfg.sampleRate != SAMPLE_DISABLED){
-         CPPUNIT_ASSERT_EQUAL((size_t)i, ts->channelIndex);
-         CPPUNIT_ASSERT_EQUAL((void *) &pc->cfg, (void *) ts->cfg);
-         CPPUNIT_ASSERT_EQUAL((void *)get_pwm_sample, (void *)ts->get_int_sample);
-         CPPUNIT_ASSERT_EQUAL(SampleData_Int, ts->sampleData);
-         ts++;
-      }
-   }
+                CPPUNIT_ASSERT_EQUAL((size_t)i, ts->channelIndex);
+                CPPUNIT_ASSERT_EQUAL((void *) &gc->cfg, (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL((void *) GPIO_get,
+                                     (void *) ts->get_int_sample);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Int, ts->sampleData);
+                ts++;
+        }
+
+        for (int i = 0; i < CONFIG_PWM_CHANNELS; i++){
+                PWMConfig *pc = &lc->PWMConfigs[i];
+                if (pc->cfg.sampleRate == SAMPLE_DISABLED)
+                        continue;
+
+                CPPUNIT_ASSERT_EQUAL((size_t)i, ts->channelIndex);
+                CPPUNIT_ASSERT_EQUAL((void *) &pc->cfg, (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL((void *) get_pwm_sample,
+                                     (void *) ts->get_int_sample);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Int, ts->sampleData);
+                ts++;
+        }
 
 
-   GPSConfig *gpsConfig = &(lc->GPSConfigs);
+        GPSConfig *gpsConfig = &(lc->GPSConfigs);
+        if (gpsConfig->latitude.sampleRate != SAMPLE_DISABLED){
+                CPPUNIT_ASSERT_EQUAL((void *) &gpsConfig->latitude,
+                                     (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL((void *) GPS_getLatitude,
+                                     (void *) ts->get_float_sample);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
+                ts++;
+        }
 
-   if (gpsConfig->latitude.sampleRate != SAMPLE_DISABLED){
-      CPPUNIT_ASSERT_EQUAL((void *) &gpsConfig->latitude, (void *) ts->cfg);
-      CPPUNIT_ASSERT_EQUAL((void *) GPS_getLatitude, (void *) ts->get_float_sample);
-      CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
-      ts++;
-   }
+        if (gpsConfig->longitude.sampleRate != SAMPLE_DISABLED){
+                CPPUNIT_ASSERT_EQUAL((void *) &gpsConfig->longitude,
+                                     (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL((void *) GPS_getLongitude,
+                                     (void *) ts->get_float_sample);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
+                ts++;
+        }
 
-   if (gpsConfig->longitude.sampleRate != SAMPLE_DISABLED){
-      CPPUNIT_ASSERT_EQUAL((void *) &gpsConfig->longitude, (void *) ts->cfg);
-      CPPUNIT_ASSERT_EQUAL((void *) GPS_getLongitude, (void *) ts->get_float_sample);
-      CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
-      ts++;
-   }
+        if (gpsConfig->speed.sampleRate != SAMPLE_DISABLED){
+                CPPUNIT_ASSERT_EQUAL((void *) &gpsConfig->speed,
+                                     (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL((void *) getGpsSpeedInMph,
+                                     (void *) ts->get_float_sample);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
+                ts++;
+        }
 
-   if (gpsConfig->speed.sampleRate != SAMPLE_DISABLED){
-      CPPUNIT_ASSERT_EQUAL((void *) &gpsConfig->speed, (void *) ts->cfg);
-      CPPUNIT_ASSERT_EQUAL((void *) getGpsSpeedInMph, (void *) ts->get_float_sample);
-      CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
-      ts++;
-   }
+        if (gpsConfig->distance.sampleRate != SAMPLE_DISABLED){
+                CPPUNIT_ASSERT_EQUAL((void *) &gpsConfig->distance,
+                                     (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL((void *) getLapDistanceInMiles,
+                                     (void *) ts->get_float_sample);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
+                ts++;
+        }
 
-   if (gpsConfig->distance.sampleRate != SAMPLE_DISABLED){
-      CPPUNIT_ASSERT_EQUAL((void *) &gpsConfig->distance, (void *) ts->cfg);
-      CPPUNIT_ASSERT_EQUAL((void *) getLapDistanceInMiles, (void *) ts->get_float_sample);
-      CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
-      ts++;
-   }
+        if (gpsConfig->altitude.sampleRate != SAMPLE_DISABLED){
+                CPPUNIT_ASSERT_EQUAL((void *) &gpsConfig->altitude,
+                                     (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL((void *) getAltitude,
+                                     (void *) ts->get_float_sample);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
+                ts++;
+        }
 
-   if (gpsConfig->altitude.sampleRate != SAMPLE_DISABLED){
-      CPPUNIT_ASSERT_EQUAL((void *) &gpsConfig->altitude, (void *) ts->cfg);
-      CPPUNIT_ASSERT_EQUAL((void *) getAltitude, (void *) ts->get_float_sample);
-      CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
-      ts++;
-   }
+        if (gpsConfig->satellites.sampleRate != SAMPLE_DISABLED){
+                CPPUNIT_ASSERT_EQUAL((void *) &gpsConfig->satellites,
+                                     (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL((void *) GPS_getSatellitesUsedForPosition,
+                                     (void *) ts->get_int_sample);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Int_Noarg, ts->sampleData);
+                ts++;
+        }
 
-   if (gpsConfig->satellites.sampleRate != SAMPLE_DISABLED){
-      CPPUNIT_ASSERT_EQUAL((void *) &gpsConfig->satellites, (void *) ts->cfg);
-      CPPUNIT_ASSERT_EQUAL((void *) GPS_getSatellitesUsedForPosition, (void *) ts->get_int_sample);
-      CPPUNIT_ASSERT_EQUAL(SampleData_Int_Noarg, ts->sampleData);
-      ts++;
-   }
+        if (gpsConfig->quality.sampleRate != SAMPLE_DISABLED){
+                CPPUNIT_ASSERT_EQUAL((void *) &gpsConfig->quality,
+                                     (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL((void *) GPS_getQuality,
+                                     (void *) ts->get_int_sample);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Int_Noarg, ts->sampleData);
+                ts++;
+        }
 
-   if (gpsConfig->quality.sampleRate != SAMPLE_DISABLED){
-      CPPUNIT_ASSERT_EQUAL((void *) &gpsConfig->quality, (void *) ts->cfg);
-      CPPUNIT_ASSERT_EQUAL((void *) GPS_getQuality, (void *) ts->get_int_sample);
-      CPPUNIT_ASSERT_EQUAL(SampleData_Int_Noarg, ts->sampleData);
-      ts++;
-   }
+        if (gpsConfig->DOP.sampleRate != SAMPLE_DISABLED){
+                CPPUNIT_ASSERT_EQUAL((void *) &gpsConfig->DOP,
+                                     (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL((void *) GPS_getDOP,
+                                     (void *) ts->get_float_sample);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
+                ts++;
+        }
 
-   if (gpsConfig->DOP.sampleRate != SAMPLE_DISABLED){
-      CPPUNIT_ASSERT_EQUAL((void *) &gpsConfig->DOP, (void *) ts->cfg);
-      CPPUNIT_ASSERT_EQUAL((void *) GPS_getDOP, (void *) ts->get_float_sample);
-      CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
-      ts++;
-   }
+        LapConfig *lapConfig = &(lc->LapConfigs);
+        if (lapConfig->lapCountCfg.sampleRate != SAMPLE_DISABLED){
+                CPPUNIT_ASSERT_EQUAL((void *) &lapConfig->lapCountCfg,
+                                     (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Int_Noarg, ts->sampleData);
+                CPPUNIT_ASSERT_EQUAL((void *) getLapCount,
+                                     (void *) ts->get_int_sample);
+                ts++;
+        }
 
-   LapConfig *lapConfig = &(lc->LapConfigs);
-   if (lapConfig->lapCountCfg.sampleRate != SAMPLE_DISABLED){
-      CPPUNIT_ASSERT_EQUAL((void *) &lapConfig->lapCountCfg, (void *) ts->cfg);
-      CPPUNIT_ASSERT_EQUAL(SampleData_Int_Noarg, ts->sampleData);
-      CPPUNIT_ASSERT_EQUAL((void *) getLapCount, (void *) ts->get_int_sample);
-      ts++;
-   }
+        if (lapConfig->lapTimeCfg.sampleRate != SAMPLE_DISABLED){
+                CPPUNIT_ASSERT_EQUAL((void *) &lapConfig->lapTimeCfg,
+                                     (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
+                CPPUNIT_ASSERT_EQUAL((void *) getLastLapTimeInMinutes,
+                                     (void *) ts->get_float_sample);
+                ts++;
+        }
 
-   if (lapConfig->lapTimeCfg.sampleRate != SAMPLE_DISABLED){
-      CPPUNIT_ASSERT_EQUAL((void *) &lapConfig->lapTimeCfg, (void *) ts->cfg);
-      CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
-      CPPUNIT_ASSERT_EQUAL((void *) getLastLapTimeInMinutes, (void *) ts->get_float_sample);
-      ts++;
-   }
+        if (lapConfig->sectorCfg.sampleRate != SAMPLE_DISABLED){
+                CPPUNIT_ASSERT_EQUAL((void *) &lapConfig->sectorCfg,
+                                     (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Int_Noarg, ts->sampleData);
+                CPPUNIT_ASSERT_EQUAL((void *) getSector,
+                                     (void *) ts->get_int_sample);
+                ts++;
+        }
 
-   if (lapConfig->sectorCfg.sampleRate != SAMPLE_DISABLED){
-      CPPUNIT_ASSERT_EQUAL((void *) &lapConfig->sectorCfg, (void *) ts->cfg);
-      CPPUNIT_ASSERT_EQUAL(SampleData_Int_Noarg, ts->sampleData);
-      CPPUNIT_ASSERT_EQUAL((void *) getSector, (void *) ts->get_int_sample);
-      ts++;
-   }
+        if (lapConfig->sectorTimeCfg.sampleRate != SAMPLE_DISABLED){
+                CPPUNIT_ASSERT_EQUAL((void *) &lapConfig->sectorTimeCfg,
+                                     (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
+                CPPUNIT_ASSERT_EQUAL((void *) getLastSectorTimeInMinutes,
+                                     (void *) ts->get_float_sample);
+                ts++;
+        }
 
-   if (lapConfig->sectorTimeCfg.sampleRate != SAMPLE_DISABLED){
-      CPPUNIT_ASSERT_EQUAL((void *) &lapConfig->sectorTimeCfg, (void *) ts->cfg);
-      CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
-      CPPUNIT_ASSERT_EQUAL((void *) getLastSectorTimeInMinutes, (void *) ts->get_float_sample);
-      ts++;
-   }
+        if (lapConfig->predTimeCfg.sampleRate != SAMPLE_DISABLED){
+                CPPUNIT_ASSERT_EQUAL((void *) &lapConfig->predTimeCfg,
+                                     (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
+                CPPUNIT_ASSERT_EQUAL((void *) getPredictedTimeInMinutes,
+                                     (void *) ts->get_float_sample);
+                ts++;
+        }
 
-   if (lapConfig->predTimeCfg.sampleRate != SAMPLE_DISABLED){
-      CPPUNIT_ASSERT_EQUAL((void *) &lapConfig->predTimeCfg, (void *) ts->cfg);
-      CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
-      CPPUNIT_ASSERT_EQUAL((void *) getPredictedTimeInMinutes, (void *) ts->get_float_sample);
-      ts++;
-   }
+        if (lapConfig->elapsed_time_cfg.sampleRate != SAMPLE_DISABLED){
+                CPPUNIT_ASSERT_EQUAL((void *) &lapConfig->elapsed_time_cfg,
+                                     (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
+                CPPUNIT_ASSERT_EQUAL((void *) lapstats_elapsed_time_minutes,
+                                     (void *) ts->get_float_sample);
+                ts++;
+        }
 
-   if (lapConfig->elapsed_time_cfg.sampleRate != SAMPLE_DISABLED){
-           CPPUNIT_ASSERT_EQUAL((void *) &lapConfig->elapsed_time_cfg,
-                                (void *) ts->cfg);
-           CPPUNIT_ASSERT_EQUAL(SampleData_Float_Noarg, ts->sampleData);
-           CPPUNIT_ASSERT_EQUAL((void *) lapstats_elapsed_time_minutes,
-                                (void *) ts->get_float_sample);
-           ts++;
-   }
+        if (lapConfig->current_lap_cfg.sampleRate != SAMPLE_DISABLED){
+                CPPUNIT_ASSERT_EQUAL((void *) &lapConfig->current_lap_cfg,
+                                     (void *) ts->cfg);
+                CPPUNIT_ASSERT_EQUAL(SampleData_Int_Noarg, ts->sampleData);
+                CPPUNIT_ASSERT_EQUAL((void *) lapstats_current_lap,
+                                     (void *) ts->get_int_sample);
+                ts++;
+        }
 
-   if (lapConfig->current_lap_cfg.sampleRate != SAMPLE_DISABLED){
-           CPPUNIT_ASSERT_EQUAL((void *) &lapConfig->current_lap_cfg,
-                                (void *) ts->cfg);
-           CPPUNIT_ASSERT_EQUAL(SampleData_Int_Noarg, ts->sampleData);
-           CPPUNIT_ASSERT_EQUAL((void *) lapstats_current_lap,
-                                (void *) ts->get_int_sample);
-           ts++;
-   }
-
-   //amount shoud match
-   const size_t size = ts - samples;
-   CPPUNIT_ASSERT_EQUAL(expectedEnabledChannels, size);
+        //amount shoud match
+        const size_t size = ts - s.channel_samples;
+        CPPUNIT_ASSERT_EQUAL(expectedEnabledChannels, size);
 }
 
 
-void SampleRecordTest::testIsValidLoggerMessageAge() {
-    LoggerMessage lm;
-    lm.ticks = 0;
+void SampleRecordTest::testIsValidLoggerMessage() {
+        LoggerMessage lm;
+        struct sample s;
 
-    set_ticks(0);
-    CPPUNIT_ASSERT_EQUAL(1, isValidLoggerMessageAge(&lm));
+        /* Test the non sample case.  This always passes */
+        lm = create_logger_message(LoggerMessageType_Start, &s);
+        lm.ticks = 42;
+        s.ticks = 42;
+        CPPUNIT_ASSERT_EQUAL(true, is_sample_data_valid(&lm));
+        lm.ticks = 41;
+        CPPUNIT_ASSERT_EQUAL(true,  is_sample_data_valid(&lm));
 
-    set_ticks(9);
-    CPPUNIT_ASSERT_EQUAL(1, isValidLoggerMessageAge(&lm));
+        /* Test the sample case.  This always passes */
+        lm = create_logger_message(LoggerMessageType_Sample, &s);
+        lm.ticks = 42;
+        s.ticks = 42;
+        CPPUNIT_ASSERT_EQUAL(true, is_sample_data_valid(&lm));
+        lm.ticks = 41;
+        CPPUNIT_ASSERT_EQUAL(false,  is_sample_data_valid(&lm));
 
-    set_ticks(10);
-    CPPUNIT_ASSERT_EQUAL(0, isValidLoggerMessageAge(&lm));
 }
 
 void SampleRecordTest::testLoggerMessageAlwaysHasTime() {
-    LoggerConfig *lc = getWorkingLoggerConfig();
+        size_t channelCount = get_enabled_channel_count(lc);
 
-    size_t channelCount = get_enabled_channel_count(lc);
-    ChannelSample * samples = create_channel_sample_buffer(lc, channelCount);
-    init_channel_sample_buffer(lc, samples, channelCount);
+        /*
+         * Check that we always populate the Interval time, regardless of
+         * what the sample rate is that is set for that channel.
+         */
+        int var = 0;
+        int tick = 0;
+        while (var < 5 && tick <= 1000) {
+                int sr = populate_sample_buffer(&s, tick++);
 
-    LoggerMessage lm;
-    lm.channelSamples = samples;
-    lm.sampleCount = channelCount;
-    lm.type = LoggerMessageType_Sample;
+                // No sample, no check.
+                if (SAMPLE_DISABLED == sr)
+                        continue;
 
-    /**
-     * Check that we always populate the Interval time, regardless of what the sample rate is that
-     * is set for that channel.
-     */
-    int var = 0;
-    int tick = 0;
-    while (var < 5 && tick <= 1000) {
-        int sr = populate_sample_buffer(&lm, channelCount, tick++);
+                ++var;
+                CPPUNIT_ASSERT_EQUAL(true, s.channel_samples->populated);
+        }
 
-        // No sample, no check.
-        if (sr == 0)
-            continue;
-
-        ++var;
-        CPPUNIT_ASSERT_EQUAL(true, lm.channelSamples->populated);
-    }
-
-    CPPUNIT_ASSERT_EQUAL(true, tick < 1000);
+        CPPUNIT_ASSERT_EQUAL(true, tick < 1000);
 }

--- a/test/sampleRecord_test.h
+++ b/test/sampleRecord_test.h
@@ -9,7 +9,7 @@ class SampleRecordTest : public CppUnit::TestFixture
     CPPUNIT_TEST_SUITE( SampleRecordTest );
     CPPUNIT_TEST( testInitSampleRecord );
     CPPUNIT_TEST( testPopulateSampleRecord );
-    CPPUNIT_TEST( testIsValidLoggerMessageAge );
+    CPPUNIT_TEST( testIsValidLoggerMessage );
     CPPUNIT_TEST( testLoggerMessageAlwaysHasTime );
     CPPUNIT_TEST_SUITE_END();
 
@@ -19,7 +19,7 @@ public:
     void tearDown();
     void testInitSampleRecord();
     void testPopulateSampleRecord();
-    void testIsValidLoggerMessageAge();
+    void testIsValidLoggerMessage();
     void testLoggerMessageAlwaysHasTime();
 
 private:


### PR DESCRIPTION
The main intent of this fix is to validate LogMessages.  Specifically
this means that we validate that the sample buffer that a LogMessage
points to has not been over-written/re-used since the LogMessage was
queued.  To achieve this we timestamp both the LogMessage and the
sample buffer.  The LogMessage is deeply copied on the queue while the
sample buffer isn't.  If when the LogMessage is read we find that the
times are different, then we know the LogMessage is pointing to a
buffer that has been overwritten since the LogMessage was queued and
thus we skip it as it is invalid.  This will in turn prevent us from
recording empty log lines as we are (mostly) ensured that the sample
buffer will not change out from underneath us when reading it.  If
that does begin to happen (as is possible since this is a pre-emptive
system) then we must add a lock to these sample structures to prevent
the behavior.

This change also fixes some very bad behavior where we were popping
LogMessages off of the queue into an undefined space.  This was
occuring because we were allocating pointers to point to areas where
the xQueueReceive should copy its contents to instead of physically
allocating the space.  I'm honestly not quite sure how this never
caused any major issues, but somehow we seemed to have gotten away
with it.  Now the space is clearly defined on the stack.