### PR TITLE
added Lua serial initialization and character read / write APIs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Improved tolerance and recovery to SD card write/eject/reinsertion
 * Reset CPU after we load factory defaults
 * Fixed handling of extended CAN IDs
+* Added Lua serial api for initializing port and character based reading / writing 
 
 === 2.8.3 ===
 * Read cell module stats before checking if on network

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@
 * Reset CPU after we load factory defaults
 * Reduce MK1 firmware size by over 15K by removing unneeded symbols in LUA lib.
 * Fixed handling of extended CAN IDs
-* Added Lua serial api for initializing port and character based reading / writing 
+* Added Lua serial api for initializing serial port and character based reading / writing 
 
 === 2.8.3 ===
 * Read cell module stats before checking if on network

--- a/include/logger/luaLoggerBinding.h
+++ b/include/logger/luaLoggerBinding.h
@@ -24,7 +24,10 @@ int Lua_GetButton(lua_State *L);
 int Lua_GetGPIO(lua_State *L);
 int Lua_SetGPIO(lua_State *L);
 
+int Lua_InitSerial(lua_State *L);
+int Lua_ReadSerialChar(lua_State *L);
 int Lua_ReadSerialLine(lua_State *L);
+int Lua_WriteSerialChar(lua_State *L);
 int Lua_WriteSerialLine(lua_State *L);
 
 int Lua_GetGPSSatellites(lua_State *L);

--- a/src/logger/luaLoggerBinding.c
+++ b/src/logger/luaLoggerBinding.c
@@ -296,7 +296,7 @@ int Lua_GetButton(lua_State *L)
  */
 int Lua_InitSerial(lua_State *L)
 {
-    int lua_top =lua_gettop(L);
+    int lua_top = lua_gettop(L);
     serial_id_t port = lua_top >= 1 ? lua_tointeger(L,1) : LUA_DEFAULT_SERIAL_PORT;
     uint32_t baud = lua_top >= 2 ? lua_tointeger(L, 2) : LUA_DEFAULT_SERIAL_BAUD;
     uint8_t bits = lua_top >= 3 ? lua_tointeger(L, 3) : LUA_DEFAULT_SERIAL_BITS;


### PR DESCRIPTION
added additional serial port management functions for Lua

initSerial() -- initializes the serial port with the specified settings
writeCSer() - write a character to the specified serial port
readCSer() - read a character from the specified serial port

example usage from the serial console, looping data from Aux serial (4) to wireless port (3).  Note, Bluetooth was disabled for this test

 RaceCapture/Pro MK2 > lua
 Entering Lua Interpreter. enter 'exit' to leave
 > initSer(3, 9600)
 > initSer(4, 9600)
 > writeCSer(3, 11)
 > println(readCSer(4))
 11.0
 > initSer(4, 115200)
 > initSer(3, 115200)
 > writeCSer(3, 22)
 > println(readCSer(4))
 22.0
 > println(readCSer(4))
 > 
