### PR TITLE
Add time info support to LUA

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,10 @@
 * Reset CPU after we load factory defaults
 * Reduce MK1 firmware size by over 15K by removing unneeded symbols in LUA lib.
 * Fixed handling of extended CAN IDs
-* Added Lua serial api for initializing serial port and character based reading / writing 
+* Added Lua serial api for initializing serial port and character based reading / writing
+* Added getUptime LUA method to get system uptime
+* Added getDateTime LUA method to get date and time info.  Returns in format
+  year, month, day, hour, minute, second, millisecond.
 
 === 2.8.3 ===
 * Read cell module stats before checking if on network

--- a/src/logger/luaLoggerBinding.c
+++ b/src/logger/luaLoggerBinding.c
@@ -40,6 +40,36 @@
 
 char g_tempBuffer[TEMP_BUFFER_LEN];
 
+static int lua_get_uptime(lua_State *L)
+{
+        lua_pushinteger(L, (int) getUptime());
+        return 1;
+}
+
+static int lua_get_date_time(lua_State *L)
+{
+        const GpsSample sample = getGpsSample();
+
+        /*
+         * Have to use DateTime because LUA only uses floats and ints.
+         * Time is a uint64t value so can't just use it directly.  Hence
+         * this.  If folks want a monotonically increasing value, they
+         * need to use getUptime call.
+         */
+        DateTime dt;
+        getDateTimeFromEpochMillis(&dt, sample.time);
+
+        lua_pushinteger(L, (int) dt.year);
+        lua_pushinteger(L, (int) dt.month);
+        lua_pushinteger(L, (int) dt.day);
+        lua_pushinteger(L, (int) dt.hour);
+        lua_pushinteger(L, (int) dt.minute);
+        lua_pushinteger(L, (int) dt.second);
+        lua_pushinteger(L, (int) dt.millisecond);
+
+        return 7;
+}
+
 void registerLuaLoggerBindings(lua_State *L)
 {
 
@@ -109,6 +139,10 @@ void registerLuaLoggerBindings(lua_State *L)
 
     lua_registerlight(L, "addChannel", Lua_AddVirtualChannel);
     lua_registerlight(L, "setChannel", Lua_SetVirtualChannelValue);
+
+    /* Timing info */
+    lua_registerlight(L, "getUptime", lua_get_uptime);
+    lua_registerlight(L, "getDateTime", lua_get_date_time);
 }
 
 ////////////////////////////////////////////////////


### PR DESCRIPTION
Adds the ability to get both system uptime (measured in millis)
and full date time (based on gps data).  The date time had to
be broken into an array field that matches the DateTime struct
because our LUA library does not support a value large enough
to house the milliseconds since epoch value.

Note that this needs manual testing since we currently do not
have unit tests for LUA scripting.