### PR TITLE
Cleanup logging of cell data

### DIFF
--- a/src/devices/cellModem.c
+++ b/src/devices/cellModem.c
@@ -60,8 +60,13 @@ void setCellBuffer(char *buffer, size_t len)
 static int readModemWait(Serial *serial, size_t delay)
 {
     int c = serial->get_line_wait(g_cellBuffer, g_bufferLen, msToTicks(delay));
-    if (c > 0) {
-        pr_debug_str_msg("Cell: read ", g_cellBuffer);
+    if (c > 2) {
+            /*
+             * Cell messages always end with a newline.  This also ignores
+             * the messages that are simply stupid short.
+             */
+            pr_debug("Cell: read ");
+            pr_debug(g_cellBuffer);
     }
     return c;
 }


### PR DESCRIPTION
Cleans up how cell data shows up in our logs.  Eliminates the
empty lines and useless lines where the modem starts a message
with /r/n.

=== Before ===
Cell: signal strength: 25
cellWrite: AT+CNUM
Cell: read

Cell: read +CNUM: "","16087700623",129

Cell: phone number: 16087700623
cellWrite: AT+CREG?
Cell: read

Cell: read +CREG: 0,1

cellWrite: AT+CGATT?
Cell: read

Cell: read +CGATT: 1

=== After ===
Cell: signal strength: 27
cellWrite: AT+CNUM
Cell: read +CNUM: "","16087700623",129
Cell: phone number: 16087700623
cellWrite: AT+CREG?
Cell: read +CREG: 0,1
cellWrite: AT+CGATT?
Cell: read +CGATT: 1
cellWrite: AT+CIPMUX=0