### PR TITLE
Add unit tests for ring_buffer.h

### DIFF
--- a/include/ring_buffer.h
+++ b/include/ring_buffer.h
@@ -1,5 +1,22 @@
-/*
- * Race Capture
+/**
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef __RING_BUFFER_H__
@@ -35,6 +52,17 @@ size_t dump_data(struct ring_buff *rb, size_t size);
 size_t clear_data(struct ring_buff *rb);
 
 bool has_data(struct ring_buff *rb);
+
+/**
+ * Initializes a ring_buff structure with the data given.  Sets all
+ * other appropriate variables as needed.
+ * @param rb The ring_buff structure to setup.
+ * @param buff Pointer to the buffer to use.
+ * @param size Size of the buffer
+ * @return The size of the buffer.
+ */
+size_t init_ring_buffer(struct ring_buff *rb, char *buff,
+                        const size_t size);
 
 /**
  * Allocates a Ring Buffer and assigns relevant data to the ring_buff

--- a/src/ring_buffer.c
+++ b/src/ring_buffer.c
@@ -122,7 +122,8 @@ size_t init_ring_buffer(struct ring_buff *rb, char *buff,
                         const size_t size)
 {
         rb->head = rb->tail = rb->buf = buff;
-        return rb->size = size;
+        rb->size = size;
+        return size - 1;
 }
 
 size_t create_ring_buffer(struct ring_buff *rb, size_t size)

--- a/test/Makefile
+++ b/test/Makefile
@@ -111,6 +111,7 @@ T_SRC = loggerApi_test.cpp \
 		$(LAP_STATS_DIR)/current_lap_test.cpp \
 		$(UTIL_DIR)/numtoa_test.cpp \
 		$(UTIL_DIR)/atonum_test.cpp \
+		ring_buffer_test.cpp \
 
 SRC =		mock_uart.c \
 		mock_gps_device.c \

--- a/test/ring_buffer_test.cpp
+++ b/test/ring_buffer_test.cpp
@@ -1,0 +1,144 @@
+/**
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ring_buffer.h"
+#include "ring_buffer_test.hh"
+
+#include <string.h>
+
+CPPUNIT_TEST_SUITE_REGISTRATION( RingBufferTest );
+
+static const size_t buff_size = 8;
+static char buff[buff_size];
+static struct ring_buff rb;
+
+void RingBufferTest::setUp()
+{
+        init_ring_buffer(&rb, buff, buff_size);
+}
+
+void RingBufferTest::tearDown() {}
+
+void RingBufferTest::putGetTest()
+{
+        char data_in[] = "FOO";
+        const size_t size = sizeof(data_in);
+        char data_out[size];
+
+        /* Check initial sizes */
+        CPPUNIT_ASSERT_EQUAL(buff_size - 1, get_space(&rb));
+        CPPUNIT_ASSERT_EQUAL((size_t) 0, get_used(&rb));
+
+        /* Put in the data */
+        CPPUNIT_ASSERT_EQUAL(size, put_data(&rb, data_in, size));
+
+        /* Check the sizes now */
+        CPPUNIT_ASSERT_EQUAL(buff_size - 1 - size, get_space(&rb));
+        CPPUNIT_ASSERT_EQUAL(size, get_used(&rb));
+
+        /* Get the data */
+        CPPUNIT_ASSERT_EQUAL(size, get_data(&rb, data_out, size));
+
+        /* Check final sizes */
+        CPPUNIT_ASSERT_EQUAL(buff_size - 1, get_space(&rb));
+        CPPUNIT_ASSERT_EQUAL((size_t) 0, get_used(&rb));
+
+        /* Check data in == data out */
+        CPPUNIT_ASSERT(0 == strcmp(data_in, data_out));
+}
+
+void RingBufferTest::putFailTest()
+{
+        /* Fill up the buffer */
+        for(size_t i = 0; i < buff_size - 1; ++i)
+                CPPUNIT_ASSERT_EQUAL((size_t) 1, put_data(&rb, "F", 1));
+
+        /* Check that we have no space */
+        CPPUNIT_ASSERT_EQUAL(false, have_space(&rb, 1));
+
+        /* Now it should fail to put */
+        CPPUNIT_ASSERT_EQUAL((size_t) 0, put_data(&rb, "F", 1));
+}
+
+void RingBufferTest::getFailTest()
+{
+        char buff[1];
+
+        /* Clear our ring bufer (should be already) */
+        CPPUNIT_ASSERT_EQUAL((size_t) 0, clear_data(&rb));
+
+        /* Check that we don't get anything */
+        CPPUNIT_ASSERT_EQUAL((size_t) 0, get_data(&rb, buff, 1));
+}
+
+void RingBufferTest::dumpTest()
+{
+        const size_t toDump = 3;
+
+        /* Sanity Check */
+        CPPUNIT_ASSERT(toDump < buff_size - 1);
+
+        /* Fill up the buffer */
+        for(size_t i = 0; i < buff_size - 1; ++i)
+                CPPUNIT_ASSERT_EQUAL((size_t) 1, put_data(&rb, "F", 1));
+
+        /* Check that we have no space */
+        CPPUNIT_ASSERT_EQUAL((size_t) 0, get_space(&rb));
+
+        /* Dump toDump bytes */
+        CPPUNIT_ASSERT_EQUAL(toDump, dump_data(&rb, toDump));
+
+        /* Check that we have toDump space now */
+        CPPUNIT_ASSERT_EQUAL(toDump, get_space(&rb));
+}
+
+void RingBufferTest::clearTest()
+{
+        /* Fill up the buffer */
+        for(size_t i = 0; i < buff_size - 1; ++i)
+                CPPUNIT_ASSERT_EQUAL((size_t) 1, put_data(&rb, "F", 1));
+
+        /* Check that we have no space */
+        CPPUNIT_ASSERT_EQUAL((size_t) 0, get_space(&rb));
+
+        /* Clear out all the data.  Ensure we clear buff_size -1 bytes */
+        CPPUNIT_ASSERT_EQUAL(buff_size - 1, clear_data(&rb));
+
+        /* Check that we have no space */
+        CPPUNIT_ASSERT_EQUAL(buff_size - 1, get_space(&rb));
+}
+
+void RingBufferTest::createDestroyTest()
+{
+        const size_t size = 11;
+
+        /* Check that creation works as expected */
+        CPPUNIT_ASSERT_EQUAL(size - 1, create_ring_buffer(&rb, size));
+
+        /* Check that we have expected space */
+        CPPUNIT_ASSERT_EQUAL(size - 1, get_space(&rb));
+
+        /* Now destroy it */
+        free_ring_buffer(&rb);
+
+        /* Assert that we have no space internally */
+        CPPUNIT_ASSERT_EQUAL((size_t) 0, rb.size);
+}

--- a/test/ring_buffer_test.hh
+++ b/test/ring_buffer_test.hh
@@ -1,0 +1,49 @@
+/**
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _RING_BUFFER_TEST_H_
+#define _RING_BUFFER_TEST_H_
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class RingBufferTest : public CppUnit::TestFixture
+{
+        CPPUNIT_TEST_SUITE( RingBufferTest );
+        CPPUNIT_TEST( putGetTest );
+        CPPUNIT_TEST( putFailTest );
+        CPPUNIT_TEST( getFailTest );
+        CPPUNIT_TEST( dumpTest );
+        CPPUNIT_TEST( clearTest );
+        CPPUNIT_TEST( createDestroyTest );
+        CPPUNIT_TEST_SUITE_END();
+
+public:
+        void setUp();
+        void tearDown();
+        void putGetTest();
+        void putFailTest();
+        void getFailTest();
+        void dumpTest();
+        void clearTest();
+        void createDestroyTest();
+};
+
+#endif /* _RING_BUFFER_TEST_H_ */


### PR DESCRIPTION
Adds unit tests for our ring_buffer struct because its value is
very high in our code and we must be confident that it is working
correctly.