### PR TITLE
Turn off the LUA memory optimizations

### DIFF
--- a/lib_lua/src/Makefile
+++ b/lib_lua/src/Makefile
@@ -7,12 +7,18 @@
 # Your platform. See PLATS for possible values.
 PLAT= none
 
+#
+# Disable Memory Opts.
+#
+# Disable the Memory optimizations as they are causing various system
+# libraries not to get registered.  The extra memory seems to be about
+# 1K.
 
 ifeq ($(PLAT), sam7s)
 	MCU   = arm7tdmi
 	THUMB = -mthumb -mthumb-interwork
 	CC = arm-elf-gcc
-	CFLAGS= -mcpu=$(MCU) $(THUMB) -ggdb -Os -Wall $(MYCFLAGS) -DLUA_OPTIMIZE_MEMORY=2 -DLUA_USE_MKSTEMP=1
+	CFLAGS= -mcpu=$(MCU) $(THUMB) -ggdb -Os -Wall $(MYCFLAGS) -DLUA_OPTIMIZE_MEMORY=0 -DLUA_USE_MKSTEMP=1
 	AR = arm-elf-ar rcu
 	RANLIB= arm-elf-ranlib
 else
@@ -20,7 +26,7 @@ ifeq ($(PLAT), stm32)
 	MCU   = cortex-m4
 	THUMB = -mthumb
 	CC = arm-none-eabi-gcc
-	CFLAGS= -mcpu=$(MCU) $(THUMB) -ggdb -Os -Wall $(MYCFLAGS) -DLUA_OPTIMIZE_MEMORY=2 -DLUA_USE_MKSTEMP=1
+	CFLAGS= -mcpu=$(MCU) $(THUMB) -ggdb -Os -Wall $(MYCFLAGS) -DLUA_OPTIMIZE_MEMORY=0 -DLUA_USE_MKSTEMP=1
 	AR = arm-none-eabi-ar rcu
 	RANLIB= arm-none-eabi-ranlib
 else


### PR DESCRIPTION
The memory opts are supposed to reduce memory usage while preseving
basic functionality of the various libraries that we implement.
However this was not the case as LUA was crashing whenever someone
would try to access these libraries.  Thus this change works around
the issue simply by disabling the memory optimizations.  The tradeoff
is ~1KB more usage of RAM compared to before.