### PR TITLE
LUA Math Fix and Memory Games

### DIFF
--- a/include/lua/luaTask.h
+++ b/include/lua/luaTask.h
@@ -1,26 +1,43 @@
+/*
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef LUATASK_H_
 #define LUATASK_H_
+
+#include "serial.h"
+
 #include <stddef.h>
 
-void lockLua(void);
-void unlockLua(void);
-
 void startLuaTask(int priority);
-void luaTask(void *params);
 
-void *myAlloc (void *ud, void *ptr, size_t osize,size_t nsize);
-
-void * getLua(void);
-
-unsigned int getLastPointer();
+void* getLua(void);
 
 void setAllocDebug(int enableDebug);
 int getAllocDebug();
 
-int getShouldReloadScript(void);
-void setShouldReloadScript(int reload);
-
 void set_ontick_freq(size_t freq);
 size_t get_ontick_freq();
+
+void initialize_lua();
+void terminate_lua();
+void run_lua_interactive_cmd(Serial *serial, const char* cmd);
 
 #endif /*LUATASK_H_*/

--- a/lib_lua/src/Makefile
+++ b/lib_lua/src/Makefile
@@ -7,12 +7,18 @@
 # Your platform. See PLATS for possible values.
 PLAT= none
 
+#
+# Disable Memory Opts.
+#
+# Disable the Memory optimizations as they are causing various system
+# libraries not to get registered.  The extra memory seems to be about
+# 1K.
 
 ifeq ($(PLAT), sam7s)
 	MCU   = arm7tdmi
 	THUMB = -mthumb -mthumb-interwork
 	CC = arm-elf-gcc
-	CFLAGS= -mcpu=$(MCU) $(THUMB) -ggdb -Os -Wall $(MYCFLAGS) -DLUA_OPTIMIZE_MEMORY=2 -DLUA_USE_MKSTEMP=1
+	CFLAGS= -mcpu=$(MCU) $(THUMB) -ggdb -Os -Wall $(MYCFLAGS) -DLUA_OPTIMIZE_MEMORY=0 -DLUA_USE_MKSTEMP=1
 	AR = arm-elf-ar rcu
 	RANLIB= arm-elf-ranlib
 else
@@ -20,7 +26,7 @@ ifeq ($(PLAT), stm32)
 	MCU   = cortex-m4
 	THUMB = -mthumb
 	CC = arm-none-eabi-gcc
-	CFLAGS= -mcpu=$(MCU) $(THUMB) -ggdb -Os -Wall $(MYCFLAGS) -DLUA_OPTIMIZE_MEMORY=2 -DLUA_USE_MKSTEMP=1
+	CFLAGS= -mcpu=$(MCU) $(THUMB) -ggdb -Os -Wall $(MYCFLAGS) -DLUA_OPTIMIZE_MEMORY=0 -DLUA_USE_MKSTEMP=1
 	AR = arm-none-eabi-ar rcu
 	RANLIB= arm-none-eabi-ranlib
 else

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -1,58 +1,61 @@
-/**
- * AutoSport Labs - Race Capture Pro Firmware
+/*
+ * Race Capture Pro Firmware
  *
- * Copyright (C) 2014 AutoSport Labs
+ * Copyright (C) 2015 Autosport Labs
  *
- * This file is part of the Race Capture Pro firmware suite
+ * This file is part of the Race Capture Pro fimrware suite
  *
- * This is free software: you can redistribute it and/or modify it under the terms of the
- * GNU General Public License as published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
- * See the GNU General Public License for more details. You should have received a copy of the GNU
- * General Public License along with this code. If not, see <http://www.gnu.org/licenses/>.
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
  */
+
+#include "ADC.h"
 #include "FreeRTOS.h"
-#include "task.h"
-#include "constants.h"
+#include "GPIO.h"
+#include "PWM.h"
+#include "bluetooth.h"
 #include "capabilities.h"
+#include "cellModem.h"
+#include "constants.h"
+#include "cpu.h"
+#include "dateTime.h"
+#include "geopoint.h"
+#include "gps.h"
+#include "imu.h"
+#include "lap_stats.h"
+#include "launch_control.h"
+#include "logger.h"
 #include "loggerApi.h"
 #include "loggerConfig.h"
-#include "modp_atonum.h"
-#include "mod_string.h"
-#include "sampleRecord.h"
-#include "loggerSampleData.h"
 #include "loggerData.h"
-#include "loggerNotifications.h"
-#include "imu.h"
-#include "tracks.h"
 #include "loggerHardware.h"
-#include "serial.h"
-#include "mem_mang.h"
-#include "printk.h"
-#include "geopoint.h"
-#include "timer.h"
-#include "ADC.h"
-#include "imu.h"
-#include "PWM.h"
-#include "cpu.h"
+#include "loggerNotifications.h"
+#include "loggerSampleData.h"
+#include "loggerTaskEx.h"
 #include "luaScript.h"
 #include "luaTask.h"
-#include "logger.h"
-#include "loggerTaskEx.h"
-#include "FreeRTOS.h"
-#include "taskUtil.h"
-#include "GPIO.h"
-#include "gps.h"
-#include "dateTime.h"
-#include "cellModem.h"
-#include "bluetooth.h"
+#include "mem_mang.h"
+#include "mod_string.h"
+#include "modp_atonum.h"
+#include "printk.h"
+#include "sampleRecord.h"
+#include "serial.h"
 #include "sim900.h"
-#include "launch_control.h"
-#include "lap_stats.h"
+#include "task.h"
+#include "taskUtil.h"
+#include "timer.h"
+#include "tracks.h"
+
 #include <stdbool.h>
 
 /* Max number of PIDs that can be specified in the setOBD2Cfg message */
@@ -86,7 +89,6 @@ void unescapeTextField(char *data)
             case '\0': //this should *NOT* happen
                 *result = '\0';
                 return;
-                break;
             default: // unknown escape char?
                 *result = ' ';
                 break;
@@ -1614,7 +1616,6 @@ int api_getScript(Serial *serial, const jsmntok_t *json)
 
 int api_setScript(Serial *serial, const jsmntok_t *json)
 {
-
     int rc = API_ERROR_UNSPECIFIED;
     bool reload_script = false;
     const jsmntok_t *dataTok = findNode(json, "data");
@@ -1644,12 +1645,17 @@ int api_setScript(Serial *serial, const jsmntok_t *json)
     } else {
         rc = API_ERROR_PARAMETER;
     }
-    setShouldReloadScript(reload_script);
+
+    /* If we are done loading in the script, then we can start LUA again */
+    if (reload_script)
+            initialize_lua();
+
     return rc;
 }
 
 int api_runScript(Serial *serial, const jsmntok_t *json)
 {
-    setShouldReloadScript(1);
-    return API_SUCCESS;
+        terminate_lua();
+        initialize_lua();
+        return API_SUCCESS;
 }

--- a/src/lua/luaBaseBinding.c
+++ b/src/lua/luaBaseBinding.c
@@ -1,22 +1,36 @@
 /*
- * luaBaseBinding.c
+ * Race Capture Pro Firmware
  *
- *  Created on: May 10, 2011
- *      Author: brent
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
  */
-#include "mod_string.h"
-#include "luaBaseBinding.h"
-#include "memory.h"
-#include "FreeRTOS.h"
-#include "lauxlib.h"
-#include "lualib.h"
-#include "luaScript.h"
-#include "luaCommands.h"
-#include "command.h"
-#include "taskUtil.h"
-#include "luaTask.h"
-#include "printk.h"
 
+#include "FreeRTOS.h"
+#include "command.h"
+#include "lauxlib.h"
+#include "luaBaseBinding.h"
+#include "luaCommands.h"
+#include "luaScript.h"
+#include "luaTask.h"
+#include "lualib.h"
+#include "memory.h"
+#include "mod_string.h"
+#include "printk.h"
+#include "taskUtil.h"
 
 void registerBaseLuaFunctions(lua_State *L)
 {

--- a/src/lua/luaCommands.c
+++ b/src/lua/luaCommands.c
@@ -1,79 +1,71 @@
 /*
- * luaCommands.c
+ * Race Capture Pro Firmware
  *
- *  Created on: Jul 24, 2011
- *      Author: brent
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
  */
-#include "mod_string.h"
-#include "luaCommands.h"
-#include "modp_numtoa.h"
-#include "modp_atonum.h"
-#include "luaScript.h"
-#include "lua.h"
-#include "luaTask.h"
-#include "memory.h"
-#include "FreeRTOS.h"
-#include "printk.h"
-#include "lua.h"
-#include "lauxlib.h"
-#include "lualib.h"
 
-#define LINE_BUFFER_SIZE  256
+#include "FreeRTOS.h"
+#include "lauxlib.h"
+#include "lua.h"
+#include "luaCommands.h"
+#include "luaScript.h"
+#include "luaTask.h"
+#include "lualib.h"
+#include "memory.h"
+#include "mod_string.h"
+#include "modp_atonum.h"
+#include "modp_numtoa.h"
+#include "printk.h"
 
 static int g_interactive_mode = 0;
 
 void ExecLuaInterpreter(Serial *serial, unsigned int argc, char **argv)
 {
+        serial->put_s("Entering Lua Interpreter. enter 'exit' to leave");
+        put_crlf(serial);
 
-    g_interactive_mode = 1;
-    serial->put_s("Entering Lua Interpreter. enter 'exit' to leave");
-    put_crlf(serial);
+        cmd_context *cmdContext = get_command_context();
+        char *luaLine = cmdContext->lineBuffer;
 
-    lua_State *L = getLua();
+        g_interactive_mode = 1;
 
-    cmd_context *cmdContext = get_command_context();
-    char * luaLine = cmdContext->lineBuffer;
+        for(;;) {
+                serial->put_s("> ");
+                interactive_read_line(serial, luaLine, cmdContext->lineBufferSize);
 
-    int result;
-    while(1) {
-        serial->put_s("> ");
-        interactive_read_line(serial, luaLine, cmdContext->lineBufferSize);
-        if (strcmp(luaLine,"exit") == 0) break;
-        lockLua();
-        lua_gc(L,LUA_GCCOLLECT,0);
-        result = luaL_loadbuffer(L, luaLine, strlen(luaLine), "");
-        if (0 != result) {
-            serial->put_s("error: (");
-            serial->put_s(lua_tostring(L,-1));
-            serial->put_s(")");
-            put_crlf(serial);
-            lua_pop(L,1);
-        } else {
-            lua_pushvalue(L,-1);
-            result = lua_pcall(L,0,0,0);
-            if (0 != result) {
-                serial->put_s("error: (");
-                serial->put_s(lua_tostring(L,-1));
-                serial->put_s(")");
-                put_crlf(serial);
-                lua_pop(L,1);
-            }
-            lua_pop(L,1);
+                if (0 == strcmp(luaLine, "exit"))
+                        break;
+
+                run_lua_interactive_cmd(serial, luaLine);
         }
-        unlockLua();
-    }
-    g_interactive_mode = 0;
+
+        g_interactive_mode = 0;
 }
 
 
 void ReloadScript(Serial *serial, unsigned int argc, char **argv)
 {
-    setShouldReloadScript(1);
-    put_commandOK(serial);
+        terminate_lua();
+        initialize_lua();
+        put_commandOK(serial);
 }
 
 int in_interactive_mode()
 {
-    return g_interactive_mode;
+        return g_interactive_mode;
 }
-

--- a/src/lua/luaScript.c
+++ b/src/lua/luaScript.c
@@ -1,7 +1,29 @@
+/*
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "luaScript.h"
+#include "luaTask.h"
 #include "mem_mang.h"
-#include "printk.h"
 #include "mod_string.h"
+#include "printk.h"
 
 
 #ifndef RCP_TESTING
@@ -23,6 +45,13 @@ int flash_default_script()
 {
     int result = -1;
     pr_info("flashing default script...");
+
+    /*
+     * Stop LUA if we are flashing its data.  This is mainly done to recover
+     * RAM since our flashing operation is a heavy bugger
+     */
+    terminate_lua();
+
     ScriptConfig *defaultScriptConfig = (ScriptConfig *)portMalloc(sizeof(ScriptConfig));
     if (defaultScriptConfig != NULL) {
         defaultScriptConfig->magicInit = MAGIC_NUMBER_SCRIPT_INIT;
@@ -81,8 +110,13 @@ void unescapeScript(char *data)
 
 int flashScriptPage(unsigned int page, const char *data, int mode)
 {
-
     int result = SCRIPT_ADD_RESULT_OK;
+
+    /*
+     * Stop LUA if we are flashing its data.  This is mainly done to recover
+     * RAM since our flashing operation is a heavy bugger
+     */
+    terminate_lua();
 
     if (page < MAX_SCRIPT_PAGES) {
         if (mode == SCRIPT_ADD_MODE_IN_PROGRESS || mode == SCRIPT_ADD_MODE_COMPLETE) {
@@ -118,9 +152,3 @@ int flashScriptPage(unsigned int page, const char *data, int mode)
     }
     return result;
 }
-
-
-
-
-
-

--- a/src/lua/luaTask.c
+++ b/src/lua/luaTask.c
@@ -1,3 +1,24 @@
+/*
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "luaTask.h"
 #include "FreeRTOS.h"
 #include "task.h"
@@ -17,21 +38,22 @@
 #include "lauxlib.h"
 #include "lualib.h"
 
+#include <stdbool.h>
 
 #define DEFAULT_ONTICK_HZ 1
 #define MAX_ONTICK_HZ 30
 #define LUA_STACK_SIZE 1000
-
 #define LUA_PERIODIC_FUNCTION "onTick"
 
+static enum {
+        LUA_DISABLED = 0,
+        LUA_ENABLED,
+} lua_run_state;
 
 static lua_State *g_lua;
 static xSemaphoreHandle xLuaLock;
 static unsigned int lastPointer;
-static int g_shouldReloadScript;
 static size_t onTickSleepInterval;
-
-//#define ALLOC_DEBUG
 
 #ifdef ALLOC_DEBUG
 static int g_allocDebug = 0;
@@ -104,12 +126,12 @@ int getAllocDebug()
 #endif
 }
 
-void lockLua(void)
+static void lockLua(void)
 {
     xSemaphoreTake(xLuaLock, portMAX_DELAY);
 }
 
-void unlockLua(void)
+static void unlockLua(void)
 {
     xSemaphoreGive(xLuaLock);
 }
@@ -124,117 +146,206 @@ size_t get_ontick_freq()
     return 1000 / ticksToMs(onTickSleepInterval);
 }
 
-int getShouldReloadScript(void)
+void* getLua()
 {
-    return g_shouldReloadScript;
+    return g_lua;
 }
 
-void setShouldReloadScript(int reload)
+static void _terminate_lua()
 {
-    g_shouldReloadScript = reload;
+        lua_close(g_lua);
+        g_lua = NULL;
+
+        lua_run_state = LUA_DISABLED;
 }
 
-static void initLuaState()
+void terminate_lua()
 {
-    lockLua();
-    if (g_lua != NULL) lua_close(g_lua);
-    g_lua=lua_newstate( myAlloc, NULL);
-    //open optional libraries
-    luaopen_base(g_lua);
-    luaopen_table(g_lua);
-    luaopen_string(g_lua);
-    luaopen_math(g_lua);
-    registerBaseLuaFunctions(g_lua);
-    registerLuaLoggerBindings(g_lua);
-    unlockLua();
+        lockLua();
+
+        pr_info("lua: Stopping...\r\n");
+
+        if (LUA_DISABLED == lua_run_state)
+                goto out;
+
+        _terminate_lua();
+
+out:
+        unlockLua();
+}
+
+static bool _load_script(void)
+{
+        const char *script = getScript();
+        const size_t len = strlen(script);
+
+        pr_info("Loading lua script (len = ");
+        pr_info_int(len);
+        pr_info("): ");
+
+        lua_gc(g_lua, LUA_GCCOLLECT,0);
+
+        if (0 != luaL_dostring(g_lua, script)) {
+                pr_info("ERROR!\r\n");
+
+                pr_error("lua: startup script error: (");
+                pr_error(lua_tostring(g_lua,-1));
+                pr_error(")\r\n");
+
+                lua_pop(g_lua,1);
+                return false;
+        }
+
+        pr_info("SUCCESS!\r\n");
+        /* Empty the stack? --> lua_settop (g_lua, 0); */
+
+        lua_gc(g_lua, LUA_GCCOLLECT,0);
+        pr_info("lua: memory usage: ");
+        pr_info_int(lua_gc(g_lua, LUA_GCCOUNT,0));
+        pr_info("Kb\r\n");
+
+        return true;
+}
+
+void initialize_lua()
+{
+        lockLua();
+
+        pr_info("lua: Starting...\r\n");
+
+        if (LUA_ENABLED == lua_run_state)
+                goto out;
+
+        g_lua = lua_newstate(myAlloc, NULL);
+        if (!g_lua) {
+                pr_error("LUA: Can't allocate memory for LUA state.\r\n");
+                goto out;
+        }
+
+        //open optional libraries
+        luaopen_base(g_lua);
+        luaopen_table(g_lua);
+        luaopen_string(g_lua);
+        luaopen_math(g_lua);
+        registerBaseLuaFunctions(g_lua);
+        registerLuaLoggerBindings(g_lua);
+
+        if (!_load_script()) {
+                _terminate_lua();
+                goto out;
+        }
+
+        /* If here, then init was successful.  Enable runtime */
+        lua_run_state = LUA_ENABLED;
+
+out:
+        unlockLua();
+}
+
+static void run_lua_method(const char *method)
+{
+        lockLua();
+
+        lua_getglobal(g_lua, method);
+        if (lua_isnil(g_lua, -1)) {
+                pr_error("Can't find \"");
+                pr_error(method);
+                pr_error("\"\r\n");
+
+                lua_pop(g_lua, 1);
+                _terminate_lua();
+                goto out;
+        }
+
+        if (0 != lua_pcall(g_lua, 0, 0, 0)) {
+                pr_error("lua method error: ");
+                pr_error(lua_tostring(g_lua, -1));
+                pr_error("\r\n");
+
+                lua_pop(g_lua, 1);
+                _terminate_lua();
+                goto out;
+        }
+
+out:
+        unlockLua();
+}
+
+void run_lua_interactive_cmd(Serial *serial, const char* cmd)
+{
+        lockLua();
+
+        lua_gc(g_lua, LUA_GCCOLLECT, 0);
+
+        /*
+         * We use a combination of loadstring + pcall instead of using
+         * dostring because we want to ensure that, after the call has
+         * completed, there is nothing left on the stack.  Since these
+         * commands come from the interactive console, we must take care
+         * to ensure that we don't leave anything on the stack at the end.
+         * dostring calls pcall with MULTRET, which could leave items on
+         * the stack.
+         */
+
+        int result = luaL_loadstring(g_lua, cmd);
+        if (0 != result) {
+            serial->put_s("error: (");
+            serial->put_s(lua_tostring(g_lua, -1));
+            serial->put_s(")");
+            put_crlf(serial);
+            lua_pop(g_lua, 1);
+            goto out;
+        }
+
+        result = lua_pcall(g_lua, 0, 0, 0);
+        if (0 != result) {
+                serial->put_s("error: (");
+                serial->put_s(lua_tostring(g_lua, -1));
+                serial->put_s(")");
+                put_crlf(serial);
+                lua_pop(g_lua, 1);
+                goto out;
+        }
+
+out:
+        unlockLua();
+}
+
+static bool is_watchdog_reset(void)
+{
+        if (!watchdog_is_watchdog_reset())
+                return false;
+
+        pr_error("lua: Crash detected! Bypassing Lua script as a "
+                 "recovery mode\r\n");
+        LED_enable(3);
+
+        return true;
+}
+
+static void luaTask(void *params)
+{
+        set_ontick_freq(DEFAULT_ONTICK_HZ);
+        initialize_script();
+
+        /* If we are starting up after watchdog, don't init LUA */
+        if (!is_watchdog_reset())
+                initialize_lua();
+
+        for(;;) {
+                portTickType xLastWakeTime = xTaskGetTickCount();
+                vTaskDelayUntil(&xLastWakeTime, onTickSleepInterval);
+
+                if (LUA_ENABLED != lua_run_state)
+                        continue;
+
+                run_lua_method(LUA_PERIODIC_FUNCTION);
+        }
 }
 
 void startLuaTask(int priority)
 {
-    g_lua = NULL;
-    setShouldReloadScript(0);
-    set_ontick_freq(DEFAULT_ONTICK_HZ);
-
-    vSemaphoreCreateBinary(xLuaLock);
-
-    xTaskCreate( luaTask,
-                 ( signed portCHAR * ) "luaTask",
-                 LUA_STACK_SIZE,
-                 NULL,
-                 priority,
-                 NULL);
-}
-
-static void doScript(void)
-{
-    lockLua();
-    const char *script = getScript();
-    size_t len = strlen(script);
-    pr_info("running lua script len(");
-    pr_info_int(len);
-    pr_info(")...");
-
-    lua_gc(g_lua, LUA_GCCOLLECT,0);
-
-    int result = (luaL_loadbuffer(g_lua, script, len, "startup") || lua_pcall(g_lua, 0, LUA_MULTRET, 0));
-    if (0 != result) {
-        pr_error("lua: startup script error: (");
-        pr_error(lua_tostring(g_lua,-1));
-        pr_error(")\r\n");
-        lua_pop(g_lua,1);
-    }
-    pr_info("done\r\n");
-    lua_gc(g_lua, LUA_GCCOLLECT,0);
-    pr_info("lua: memory usage: ");
-    pr_info_int(lua_gc(g_lua, LUA_GCCOUNT,0));
-    pr_info("Kb\r\n");
-    unlockLua();
-}
-
-static void guardedDoScript(void)
-{
-    if (!watchdog_is_watchdog_reset()) {
-        doScript();
-    } else {
-        pr_error("lua: Crash detected- bypassing Lua script for recovery mode\r\n");
-        LED_enable(3);
-    }
-}
-
-void luaTask(void *params)
-{
-    initLuaState();
-    guardedDoScript();
-    while(1) {
-        portTickType xLastWakeTime;
-        xLastWakeTime = xTaskGetTickCount();
-        if (getShouldReloadScript()) {
-            initLuaState();
-            doScript();
-            setShouldReloadScript(0);
-        }
-        lockLua();
-        lua_getglobal(g_lua, LUA_PERIODIC_FUNCTION);
-        if (! lua_isnil(g_lua,-1)) {
-            if (lua_pcall(g_lua, 0, 0, 0) != 0) {
-// TODO log or indicate error. store this in a "Last Error"
-//        		SendString("Error calling ");
-//        		SendString(LUA_PERIODIC_FUNCTION);
-//        		SendString("(): ");
-//        		SendString( lua_tostring(g_lua,-1));
-//        		SendCrlf();
-                lua_pop(g_lua,1);
-            }
-        } else {
-            // //handle missing function error
-            lua_pop(g_lua,1);
-        }
-        unlockLua();
-        vTaskDelayUntil( &xLastWakeTime, onTickSleepInterval );
-    }
-}
-
-void * getLua()
-{
-    return g_lua;
+        vSemaphoreCreateBinary(xLuaLock);
+        xTaskCreate(luaTask, (signed portCHAR *) "luaTask",
+                    LUA_STACK_SIZE, NULL, priority, NULL);
 }

--- a/test/logger_mock/luaTask_mock.c
+++ b/test/logger_mock/luaTask_mock.c
@@ -63,3 +63,7 @@ size_t get_ontick_freq()
 {
     return 1;
 }
+
+void terminate_lua() {}
+void initialize_lua() {}
+void run_lua_interactive_cmd(Serial *serial, const char* cmd) {}


### PR DESCRIPTION
So some of the LUA math methods were broken.  This fixes that.

This also addresses the MK1 and LUA issues that have been plaguing us since 2.8.0 release of firmware.  This works around the issue by releasing LUA resources before we program the LUA script (which is a memory hungry operation because we have done it sub optimally).  By doing this we free up enough of the heap to get things working again.