### PR TITLE
P/stieg/fix lua printing precision

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,54 @@ following:
 Coding Standard
 ===============
 
+# Standard
+
 We use the Linux Kernel coding standard, which can be found here:
 https://www.kernel.org/doc/Documentation/CodingStyle
 
-We do however ask for the following modification to be made to your
-source contributions:  Single line if/for/while statements should
+# Modifications
+
+While we think the Linux standard is great, we have our own tweaks
+that we have made.  They are as follows...
+
+## File Headers
+
+Always ensure that the file header at the top of the file matches the
+following:
+
+```C
+/*
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+```
+
+If it doesn't, please fix it as part of your patch.
+
+## Includes
+
+Please sort all include alphabetically.  Not only does this make things
+easier to find, it also eliminates duplicates.
+
+## Control Statements Always Have Brackets
+
+Single line if/for/while statements should
 always include braces.
 
 So:

--- a/SAM7s_base/capabilities.h
+++ b/SAM7s_base/capabilities.h
@@ -11,7 +11,7 @@
 //configuration
 #define MAX_TRACKS				40
 #define MAX_SECTORS				20
-#define SCRIPT_MEMORY_LENGTH	10240
+#define SCRIPT_MEMORY_LENGTH	8192
 #define MAX_VIRTUAL_CHANNELS	10
 
 //Input / output Channels

--- a/include/auto_config/auto_track.h
+++ b/include/auto_config/auto_track.h
@@ -1,19 +1,22 @@
-/**
- * AutoSport Labs - Race Capture Pro Firmware
+/*
+ * Race Capture Pro Firmware
  *
- * Copyright (C) 2014 AutoSport Labs
+ * Copyright (C) 2015 Autosport Labs
  *
- * This file is part of the Race Capture Pro firmware suite
+ * This file is part of the Race Capture Pro fimrware suite
  *
- * This is free software: you can redistribute it and/or modify it under the terms of the
- * GNU General Public License as published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
- * See the GNU General Public License for more details. You should have received a copy of the GNU
- * General Public License along with this code. If not, see <http://www.gnu.org/licenses/>.
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef __AUTO_TRACK_H__
@@ -24,10 +27,10 @@
 #include "tracks.h"
 
 /**
- * Using 1K Meters as max distance from start finish as if you are farther than
+ * Using 5KM as max distance from start finish as if you are farther than
  * that from start/finish then just wow.
  */
-#define MAX_DIST_FROM_SF 1000
+#define MAX_DIST_FROM_SF 5000
 
 /**
  * Automatically picks the best track (if available) and updates the config to use this

--- a/lib_lua/src/luaconf.h
+++ b/lib_lua/src/luaconf.h
@@ -515,7 +515,7 @@
 */
 #define LUAI_UACNUMBER	double
 
-#define LUA_NUMBER_PRECISION 3
+#define LUA_NUMBER_PRECISION 6
 
 
 /*
@@ -790,4 +790,3 @@ union luai_Cast {
 #endif
 
 #endif
-

--- a/src/auto_config/auto_track.c
+++ b/src/auto_config/auto_track.c
@@ -1,19 +1,22 @@
-/**
- * AutoSport Labs - Race Capture Pro Firmware
+/*
+ * Race Capture Pro Firmware
  *
- * Copyright (C) 2014 AutoSport Labs
+ * Copyright (C) 2015 Autosport Labs
  *
- * This file is part of the Race Capture Pro firmware suite
+ * This file is part of the Race Capture Pro fimrware suite
  *
- * This is free software: you can redistribute it and/or modify it under the terms of the
- * GNU General Public License as published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
- * See the GNU General Public License for more details. You should have received a copy of the GNU
- * General Public License along with this code. If not, see <http://www.gnu.org/licenses/>.
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "auto_track.h"

--- a/src/gps/gpsTask.c
+++ b/src/gps/gpsTask.c
@@ -15,7 +15,7 @@
 #include "taskUtil.h"
 #include "loggerConfig.h"
 
-#define GPS_TASK_STACK_SIZE			200
+#define GPS_TASK_STACK_SIZE	256
 
 static bool g_enableGpsDataLogging = false;
 

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -188,13 +188,12 @@ int api_systemReset(Serial *serial, const jsmntok_t *json)
 
 int api_factoryReset(Serial *serial, const jsmntok_t *json)
 {
-    int rc = (flash_default_logger_config() == 0 && flash_default_script() == 0 && flash_default_tracks() == 0) ? API_SUCCESS : API_ERROR_SEVERE;
-    if (rc == API_SUCCESS) {
+        flash_default_logger_config();
+        flash_default_script();
+        flash_default_tracks();
+
         cpu_reset(0);
         return API_SUCCESS_NO_RETURN;
-    } else {
-        return API_ERROR_SEVERE;
-    }
 }
 
 int api_getVersion(Serial *serial, const jsmntok_t *json)

--- a/src/logger/loggerCommands.c
+++ b/src/logger/loggerCommands.c
@@ -39,15 +39,40 @@ void TestSD(Serial *serial, unsigned int argc, char **argv)
 }
 
 
+static void print_reset_status(Serial *s, const char *msg, const int status)
+{
+        char* status_word = status ? "FAILED" : "PASS";
+        s->put_s(msg);
+        s->put_s(": ");
+        s->put_s(status_word);
+        s->put_s("\r\n");
+}
+
 void ResetConfig(Serial *serial, unsigned int argc, char **argv)
 {
-    if (flash_default_logger_config() == 0 && flash_default_script() == 0 && flash_default_tracks() == 0) {
-        put_commandOK(serial);
+        int tmp;
+        int res = 0;
+
+        tmp = flash_default_logger_config();
+        res += tmp;
+        print_reset_status(serial, "Flashing Default Logger Config", tmp);
+
+        tmp = flash_default_script();
+        res += tmp;
+        print_reset_status(serial, "Flashing Default Script", tmp);
+
+        tmp = flash_default_tracks();
+        res += tmp;
+        print_reset_status(serial, "Flashing Default Tracks", tmp);
+
+        if (res) {
+                put_commandError(serial, ERROR_CODE_CRITICAL_ERROR);
+        } else {
+                put_commandOK(serial);
+        }
+
         delayMs(500);
         cpu_reset(0);
-    } else {
-        put_commandError(serial, ERROR_CODE_CRITICAL_ERROR);
-    }
 }
 
 static void StartTerminalSession(Serial *fromSerial, Serial *toSerial, uint8_t localEcho)

--- a/src/lua/luaBaseBinding.c
+++ b/src/lua/luaBaseBinding.c
@@ -1,21 +1,36 @@
 /*
- * luaBaseBinding.c
+ * Race Capture Pro Firmware
  *
- *  Created on: May 10, 2011
- *      Author: brent
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
  */
-#include "mod_string.h"
-#include "luaBaseBinding.h"
-#include "memory.h"
+
 #include "FreeRTOS.h"
-#include "lauxlib.h"
-#include "lualib.h"
-#include "luaScript.h"
-#include "luaCommands.h"
 #include "command.h"
-#include "taskUtil.h"
+#include "lauxlib.h"
+#include "luaBaseBinding.h"
+#include "luaCommands.h"
+#include "luaScript.h"
 #include "luaTask.h"
+#include "lualib.h"
+#include "memory.h"
+#include "mod_string.h"
 #include "printk.h"
+#include "taskUtil.h"
 
 
 void registerBaseLuaFunctions(lua_State *L)
@@ -52,21 +67,29 @@ int Lua_GetTickRate(lua_State *L)
 
 static int printLog(lua_State *L, int addNewline)
 {
-    if (lua_gettop(L) >= 1) {
+        if (0 == lua_gettop(L))
+                return 0;
+
         const char *msg = lua_tostring(L, 1);
-        int level = lua_gettop(L) >= 2 ? lua_tointeger(L, 2) : INFO;
+        const int level = lua_gettop(L) >= 2 ? lua_tointeger(L, 2) : INFO;
+
         if (in_interactive_mode()) {
-            Serial *serial = get_command_context()->serial;
-            if (lua_gettop(L) >= 1 && serial) {
-                serial->put_s(lua_tostring(L,1));
-                if (addNewline) put_crlf(serial);
-            }
-        } else {
-            printk(level, msg);
-            if (addNewline) printk(level, "\r\n");
+                Serial *serial = get_command_context()->serial;
+                if (serial) {
+                        serial->put_s(lua_tostring(L,1));
+                        if (addNewline) {
+                                put_crlf(serial);
+                        }
+                }
         }
-    }
-    return 0;
+
+        printk(level, msg);
+
+        if (addNewline) {
+                printk(level, "\r\n");
+        }
+
+        return 0;
 }
 
 int Lua_PrintLogLn(lua_State *L)


### PR DESCRIPTION
Fixes the printing precision and cleans up some code.

```
lua: memory usage: 7Kb
Lat: 43.085308, Lon: -89.376518
Lat: 43.085342, Lon: -89.376495
Lat: 43.085342, Lon: -89.376495
Lat: 43.085342, Lon: -89.376495
Lat: 43.085342, Lon: -89.376495
Lat: 43.085342, Lon: -89.376495
Lat: 43.085342, Lon: -89.376495
```