### PR TITLE
Don't include OBDII channels in the stream when OBDII is disabled

### DIFF
--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -1,9 +1,31 @@
+/*
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "loggerConfig.h"
-#include "modp_numtoa.h"
-#include "mod_string.h"
 #include "memory.h"
+#include "mod_string.h"
+#include "modp_numtoa.h"
 #include "printk.h"
 #include "virtual_channel.h"
+
 #include <stdbool.h>
 
 #ifndef RCP_TESTING
@@ -618,8 +640,9 @@ size_t get_enabled_channel_count(LoggerConfig *loggerConfig)
         if (loggerConfig->PWMConfigs[i].cfg.sampleRate != SAMPLE_DISABLED)
             ++channels;
 
-    size_t enabled_obd2_pids = loggerConfig->OBD2Configs.enabledPids;
-    for (size_t i=0; i < enabled_obd2_pids; i++) {
+    const size_t enabled_obd2_pids = loggerConfig->OBD2Configs.enabledPids;
+    const unsigned char enabled = loggerConfig->OBD2Configs.enabled;
+    for (size_t i=0; i < enabled_obd2_pids && enabled; i++) {
         if (loggerConfig->OBD2Configs.pids[i].cfg.sampleRate != SAMPLE_DISABLED)
             ++channels;
     }

--- a/src/logger/loggerSampleData.c
+++ b/src/logger/loggerSampleData.c
@@ -1,26 +1,47 @@
-#include "dateTime.h"
-#include "GPIO.h"
-#include "lap_stats.h"
-#include "loggerSampleData.h"
-#include "loggerHardware.h"
-#include "loggerConfig.h"
-#include "loggerData.h"
-#include "virtual_channel.h"
-#include "imu.h"
+/*
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "ADC.h"
-#include "timer.h"
-#include "PWM.h"
+#include "FreeRTOS.h"
+#include "GPIO.h"
 #include "GPIO.h"
 #include "OBD2.h"
-#include "sampleRecord.h"
-#include "gps.h"
-#include "lap_stats.h"
+#include "PWM.h"
+#include "dateTime.h"
 #include "geopoint.h"
-#include "predictive_timer_2.h"
+#include "gps.h"
+#include "imu.h"
+#include "lap_stats.h"
+#include "lap_stats.h"
 #include "linear_interpolate.h"
+#include "loggerConfig.h"
+#include "loggerData.h"
+#include "loggerHardware.h"
+#include "loggerSampleData.h"
+#include "predictive_timer_2.h"
 #include "printk.h"
-#include "FreeRTOS.h"
+#include "sampleRecord.h"
 #include "taskUtil.h"
+#include "timer.h"
+#include "virtual_channel.h"
 
 #include <stdbool.h>
 
@@ -263,9 +284,11 @@ void init_channel_sample_buffer(LoggerConfig *loggerConfig, struct sample *buff)
     }
 
     OBD2Config *obd2Config = &(loggerConfig->OBD2Configs);
-    for (size_t i = 0; i < obd2Config->enabledPids; i++) {
+    const unsigned char enabled = loggerConfig->OBD2Configs.enabled;
+    for (size_t i = 0; i < obd2Config->enabledPids && enabled; i++) {
         chanCfg = &(obd2Config->pids[i].cfg);
-        sample = processChannelSampleWithIntGetter(sample, chanCfg, i, OBD2_get_current_PID_value);
+        sample = processChannelSampleWithIntGetter(sample, chanCfg, i,
+                                                   OBD2_get_current_PID_value);
     }
 
     const size_t virtualChannelCount = get_virtual_channel_count();


### PR DESCRIPTION
Fixes the issues where we were foolishly including OBDII data in
the stream when the OBDII system was disabled.  No longer shall
we do this.