### PR TITLE
allow user to request a lua runtime bypass in extreme cases 

### DIFF
--- a/include/LED/LED.h
+++ b/include/LED/LED.h
@@ -1,6 +1,7 @@
 #ifndef LED_H_
 #define LED_H_
 
+#define LED_ERROR 3
 int LED_init(void);
 void LED_enable(unsigned int Led);
 void LED_disable(unsigned int Led);

--- a/include/watchdog/watchdog.h
+++ b/include/watchdog/watchdog.h
@@ -7,10 +7,11 @@
 
 #ifndef WATCHDOG_H_
 #define WATCHDOG_H_
+#include <stdbool.h>
 
-void watchdog_reset();
+void watchdog_reset(void);
 void watchdog_init(int timeoutMs);
-int watchdog_is_watchdog_reset();
-int watchdog_is_poweron_reset();
+bool watchdog_is_watchdog_reset(void);
+bool watchdog_is_poweron_reset(void);
 
 #endif /* WATCHDOG_H_ */

--- a/src/lua/luaTask.c
+++ b/src/lua/luaTask.c
@@ -41,7 +41,6 @@
 
 #include <stdbool.h>
 
-#define ERROR_LED 3
 #define DEFAULT_ONTICK_HZ 1
 #define MAX_ONTICK_HZ 30
 #define LUA_STACK_SIZE 1000
@@ -217,16 +216,16 @@ static bool user_bypass_requested(void)
 {
         pr_info("lua: Checking for Lua runtime bypass request\r\n");
         bool bypass = false;
-        LED_disable(ERROR_LED);
+        LED_disable(LED_ERROR);
         for (size_t i = 0; i < LUA_BYPASS_FLASH_COUNT; i++) {
-            LED_toggle(ERROR_LED);
+            LED_toggle(LED_ERROR);
             if (GPIO_is_button_pressed()) {
                 bypass = true;
                 break;
             }
             delayMs(LUA_BYPASS_FLASH_DELAY);
         }
-        LED_disable(ERROR_LED);
+        LED_disable(LED_ERROR);
         return bypass;
 }
 
@@ -328,10 +327,10 @@ static void luaTask(void *params)
         set_ontick_freq(DEFAULT_ONTICK_HZ);
         initialize_script();
 
-        bool should_bypass_lua = (watchdog_is_watchdog_reset() && user_bypass_requested());
+        const bool should_bypass_lua = (watchdog_is_watchdog_reset() && user_bypass_requested());
         if (should_bypass_lua) {
                 pr_error("lua: Bypassing Lua Runtime\r\n");
-                LED_enable(ERROR_LED);
+                LED_enable(LED_ERROR);
         } else {
                 initialize_lua();
         }

--- a/src/watchdog/watchdog.c
+++ b/src/watchdog/watchdog.c
@@ -1,7 +1,8 @@
 #include "watchdog.h"
 #include "watchdog_device.h"
+#include "printk.h"
 
-void watchdog_reset()
+void watchdog_reset(void)
 {
     watchdog_device_reset();
 }
@@ -9,14 +10,17 @@ void watchdog_reset()
 void watchdog_init(int timeoutMs)
 {
     watchdog_device_init(timeoutMs);
+    if (watchdog_is_watchdog_reset()) {
+        pr_warning("watchdog: detected watchdog reset!\r\n");
+    }
 }
 
-int watchdog_is_watchdog_reset()
+bool watchdog_is_watchdog_reset(void)
 {
     return watchdog_device_is_watchdog_reset();
 }
 
-int watchdog_is_poweron_reset()
+bool watchdog_is_poweron_reset(void)
 {
     return watchdog_device_is_poweron_reset();
 }


### PR DESCRIPTION
...(if lua script or runtime is causing a repeated watchdog, effectively soft-bricking unit)

* added ability for user to signal a bypass of lua runtime if unit powers up under watchdog reset
User signals lua runtime to be bypassed within 5 seconds of watchdog reset by pressing the front-panel button after power up. if user does not press the front-panel button, Lua runtime will be loaded normally. During this phase the red led will toggle at 250ms intervals.

One usage problem is that pressing the button during this phase will also trigger logging. I think this is an acceptable issue due to the extreme nature of the recovery process, and the limited use it should experience.

Also various clean up of logger messages and function calls.
