### PR TITLE
Cleanup the sample rate check in loggerTaskEx.c, fix headers and incudes

### DIFF
--- a/src/logger/connectivityTask.c
+++ b/src/logger/connectivityTask.c
@@ -1,26 +1,47 @@
-#include "connectivityTask.h"
+/*
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "FreeRTOS.h"
-#include "task.h"
-#include "queue.h"
-#include "loggerConfig.h"
-#include "sampleRecord.h"
-#include "modp_numtoa.h"
-#include "stdint.h"
-#include "mod_string.h"
-#include "loggerHardware.h"
-#include "loggerApi.h"
-#include "serial.h"
-#include "usart.h"
-#include "printk.h"
-#include "api.h"
-#include "devices_common.h"
-#include "capabilities.h"
-#include "mem_mang.h"
-#include "taskUtil.h"
 #include "LED.h"
-#include "null_device.h"
+#include "api.h"
 #include "bluetooth.h"
+#include "capabilities.h"
+#include "connectivityTask.h"
+#include "devices_common.h"
+#include "loggerApi.h"
+#include "loggerConfig.h"
+#include "loggerHardware.h"
+#include "mem_mang.h"
+#include "mod_string.h"
+#include "modp_numtoa.h"
+#include "null_device.h"
+#include "printk.h"
+#include "queue.h"
+#include "sampleRecord.h"
+#include "serial.h"
 #include "sim900.h"
+#include "stdint.h"
+#include "task.h"
+#include "taskUtil.h"
+#include "usart.h"
 
 
 #if (CONNECTIVITY_CHANNELS == 1)

--- a/stm32_base/hal/usart_stm32/usart_device_stm32.c
+++ b/stm32_base/hal/usart_stm32/usart_device_stm32.c
@@ -650,18 +650,21 @@ int usart3_readLine(char *s, int len)
 
 static void handle_usart_overrun(USART_TypeDef* USARTx)
 {
-    uint32_t cChar;
-    if (USART_GetITStatus(USARTx, USART_IT_ORE_RX) != SET)
-    	return;
-	/*
+        if (USART_GetITStatus(USARTx, USART_IT_ORE_RX) != SET)
+                return;
+
+        /*
 	 * Handle Overrun error
-	 * This bit is set by hardware when the word currently being received in the shift register is
-	 * ready to be transferred into the RDR register while RXNE=1. An interrupt is generated if
-	 * RXNEIE=1 in the USART_CR1 register. It is cleared by a software sequence (an read to the
-	 * USART_SR register followed by a read to the USART_DR register)
+         *
+	 * This bit is set by hardware when the word currently being received in
+         * the shift register is ready to be transferred into the RDR register
+         * while RXNE=1. An interrupt is generated if RXNEIE=1 in the USART_CR1
+         * register. It is cleared by a software sequence (an read to the
+         * USART_SR register followed by a read to the USART_DR register)
 	 */
-	cChar = USART1->SR;
-	cChar = USART1->DR;
+        uint32_t cChar = USART1->SR;
+        cChar = USART1->DR;
+        cChar = cChar; /* Silence set but not used warning */
 }
 
 void DMA1_Stream5_IRQHandler(void)


### PR DESCRIPTION
Does some minor cleanup of the logic that chooses when to send
a logging message by replacing an opaque check with a function
whose purpose is more clear.

Also fixes the header and includes per the CONTRIBUTING file
of our repo.