### PR TITLE
Fix MK1 Crash Bug, Cleanup Large Flashing Routines

### DIFF
--- a/SAM7s_base/capabilities.h
+++ b/SAM7s_base/capabilities.h
@@ -14,8 +14,17 @@
 #define MAX_VIRTUAL_CHANNELS	10
 #define LOGGER_MESSAGE_BUFFER_SIZE	5
 
+/*
+ * Adds additional memory saving behavior for low memory systems.
+ * These come at a cost of interruption of other services as needed
+ * to save RAM.  Usually quick interruptions, but interruptions
+ * none the less.
+ */
+#define RCP_LOW_MEM	1
+
 
 /* LUA Configuration */
+
 /*
  * What is the maximum length of the script that can be provided?
  * Must be divisible by 256.

--- a/include/lua/luaScript.h
+++ b/include/lua/luaScript.h
@@ -1,24 +1,49 @@
+/*
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef LUASCRIPT_H_
 #define LUASCRIPT_H_
 
-#include <stdint.h>
-#include "memory.h"
 #include "capabilities.h"
+#include "memory.h"
 
-#define SCRIPT_ADD_RESULT_OK  		1
-#define SCRIPT_ADD_RESULT_FAIL  	0
+#include <stdint.h>
 
-#define SCRIPT_ADD_MODE_IN_PROGRESS	1
-#define SCRIPT_ADD_MODE_COMPLETE 	2
+enum script_add_result {
+        SCRIPT_ADD_RESULT_FAIL = 0,
+        SCRIPT_ADD_RESULT_OK = 1,
+};
 
-#define MAGIC_NUMBER_SCRIPT_INIT 0xBADDECAF
+enum script_add_mode {
+        SCRIPT_ADD_MODE_IN_PROGRESS = 1,
+        SCRIPT_ADD_MODE_COMPLETE = 2,
+};
 
-#define SCRIPT_PAGE_SIZE 256
-#define MAX_SCRIPT_PAGES SCRIPT_MEMORY_LENGTH / SCRIPT_PAGE_SIZE
+#define MAGIC_NUMBER_SCRIPT_INIT	0xBADDECAF
+#define SCRIPT_PAGE_SIZE	256
+#define MAX_SCRIPT_PAGES	(SCRIPT_MEMORY_LENGTH / SCRIPT_PAGE_SIZE)
 
 typedef struct _ScriptConfig {
-    char script[SCRIPT_MEMORY_LENGTH - 4];
-    uint32_t magicInit;
+        char script[SCRIPT_MEMORY_LENGTH - 4];
+        uint32_t magicInit;
 } ScriptConfig;
 
 void initialize_script();
@@ -27,7 +52,8 @@ int flash_default_script();
 
 const char * getScript();
 
-int flashScriptPage(unsigned int page, const char *data, int mode);
+enum script_add_result flashScriptPage(unsigned int page, const char *data,
+                                       enum script_add_mode mode);
 
 void unescapeScript(char *data);
 

--- a/include/tracks/tracks.h
+++ b/include/tracks/tracks.h
@@ -34,7 +34,6 @@ enum track_add_result {
 };
 
 enum track_add_mode {
-        TRACK_ADD_MODE_UNKNOWN = 0,
         TRACK_ADD_MODE_IN_PROGRESS = 1,
         TRACK_ADD_MODE_COMPLETE = 2,
 };

--- a/include/tracks/tracks.h
+++ b/include/tracks/tracks.h
@@ -1,17 +1,43 @@
+/*
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef TRACKS_H_
 #define TRACKS_H_
 
-#include <stdint.h>
-#include "stddef.h"
-#include "geopoint.h"
 #include "capabilities.h"
+#include "geopoint.h"
+#include "stddef.h"
 #include "versionInfo.h"
+#include <stdint.h>
 
-#define TRACK_ADD_RESULT_OK  		1
-#define TRACK_ADD_RESULT_FAIL  		0
+enum track_add_result {
+        TRACK_ADD_RESULT_FAIL = 0,
+        TRACK_ADD_RESULT_OK = 1,
+};
 
-#define TRACK_ADD_MODE_IN_PROGRESS	1
-#define TRACK_ADD_MODE_COMPLETE 	2
+enum track_add_mode {
+        TRACK_ADD_MODE_UNKNOWN = 0,
+        TRACK_ADD_MODE_IN_PROGRESS = 1,
+        TRACK_ADD_MODE_COMPLETE = 2,
+};
 
 #define MAX_TRACK_COUNT				40
 #define SECTOR_COUNT				MAX_SECTORS
@@ -61,7 +87,8 @@ typedef struct _Tracks {
 
 void initialize_tracks();
 int flash_tracks(const Tracks *source, size_t rawSize);
-int add_track(const Track *track, size_t index, int mode);
+enum track_add_result add_track(const Track *track, const size_t index,
+                                enum track_add_mode mode);
 int flash_default_tracks(void);
 const Tracks * get_tracks();
 

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -1565,7 +1565,8 @@ int api_addTrackDb(Serial *serial, const jsmntok_t *json)
         const jsmntok_t *trackNode = findNode(json, "track");
         if (trackNode != NULL)
             setTrack(trackNode + 1, &track);
-        int result = add_track(&track, index, mode);
+        const int result = (int) add_track(&track, index,
+                                     (enum track_add_mode) mode);
         if (result == TRACK_ADD_RESULT_OK) {
             if (mode == TRACK_ADD_MODE_COMPLETE) {
                 lapstats_config_changed();
@@ -1636,7 +1637,9 @@ int api_setScript(Serial *serial, const jsmntok_t *json)
         if (page < MAX_SCRIPT_PAGES) {
             char *script = dataTok->data;
             unescapeScript(script);
-            int flashResult = flashScriptPage(page, script, mode);
+            const int flashResult =
+               flashScriptPage(page, script, (enum script_add_mode) mode);
+
             rc = flashResult == 1 ? API_SUCCESS : API_ERROR_SEVERE;
             reload_script = rc == API_SUCCESS && mode == SCRIPT_ADD_MODE_COMPLETE;
         } else {
@@ -1645,10 +1648,6 @@ int api_setScript(Serial *serial, const jsmntok_t *json)
     } else {
         rc = API_ERROR_PARAMETER;
     }
-
-    /* If we are done loading in the script, then we can start LUA again */
-    if (reload_script)
-            initialize_lua();
 
     return rc;
 }

--- a/src/lua/luaScript.c
+++ b/src/lua/luaScript.c
@@ -120,33 +120,34 @@ enum script_add_result flashScriptPage(const unsigned int page,
                 /* Valid cases.  Carry on */
                 break;
         default:
-                pr_error_int_msg("Unknown script_add_mode: ", mode);
+                pr_error_int_msg("lua: Unknown script_add_mode: ", mode);
                 return SCRIPT_ADD_RESULT_FAIL;
         }
 
         static ScriptConfig *g_scriptBuffer;
-        if (g_scriptBuffer == NULL) {
+        if (NULL == g_scriptBuffer) {
                 terminate_lua();
 
-                pr_info("Allocating new script buffer\r\n");
+                pr_debug("lua: Allocating new script buffer\r\n");
                 g_scriptBuffer =
                         (ScriptConfig *) portMalloc(sizeof(ScriptConfig));
                 memcpy((void *)g_scriptBuffer, (void *)&g_scriptConfig,
                        sizeof(ScriptConfig));
         }
 
-        if (g_scriptBuffer == NULL) {
-                pr_error("Failed to allocate memory for script buffer.\r\n");
+        if (NULL == g_scriptBuffer) {
+                pr_error("lua: Failed to allocate memory for script "
+                         "buffer.\r\n");
                 return SCRIPT_ADD_RESULT_FAIL;
         }
 
         char *pageToAdd = g_scriptBuffer->script + page * SCRIPT_PAGE_SIZE;
         strncpy(pageToAdd, data, SCRIPT_PAGE_SIZE);
 
-        if (mode == SCRIPT_ADD_MODE_IN_PROGRESS)
+        if (SCRIPT_ADD_MODE_IN_PROGRESS == mode)
                 return SCRIPT_ADD_RESULT_OK;
 
-        pr_info("Completed updating LUA. Flashing... ");
+        pr_info("lua: Completed updating LUA. Flashing... ");
         const int rc = memory_flash_region((void*) &g_scriptConfig,
                                            (void*) g_scriptBuffer,
                                            sizeof(ScriptConfig));

--- a/src/lua/luaScript.c
+++ b/src/lua/luaScript.c
@@ -25,14 +25,11 @@
 #include "mod_string.h"
 #include "printk.h"
 
-
 #ifndef RCP_TESTING
 static const volatile ScriptConfig g_scriptConfig  __attribute__((section(".script\n\t#")));
 #else
 static ScriptConfig g_scriptConfig = {DEFAULT_SCRIPT, MAGIC_NUMBER_SCRIPT_INIT};
 #endif
-
-static ScriptConfig * g_scriptBuffer = NULL;
 
 void initialize_script()
 {
@@ -108,47 +105,60 @@ void unescapeScript(char *data)
     *result='\0';
 }
 
-int flashScriptPage(unsigned int page, const char *data, int mode)
+enum script_add_result flashScriptPage(const unsigned int page,
+                                       const char *data,
+                                       const enum script_add_mode mode)
 {
-    int result = SCRIPT_ADD_RESULT_OK;
-
-    /*
-     * Stop LUA if we are flashing its data.  This is mainly done to recover
-     * RAM since our flashing operation is a heavy bugger
-     */
-    terminate_lua();
-
-    if (page < MAX_SCRIPT_PAGES) {
-        if (mode == SCRIPT_ADD_MODE_IN_PROGRESS || mode == SCRIPT_ADD_MODE_COMPLETE) {
-            if (g_scriptBuffer == NULL) {
-                g_scriptBuffer = (ScriptConfig *)portMalloc(sizeof(ScriptConfig));
-                memcpy((void *)g_scriptBuffer, (void *)&g_scriptConfig, sizeof(ScriptConfig));
-            }
-
-            if (g_scriptBuffer != NULL) {
-                page = page * SCRIPT_PAGE_SIZE;
-                char *pageToAdd = g_scriptBuffer->script + page;
-                strncpy(pageToAdd, data, SCRIPT_PAGE_SIZE);
-
-                if (mode == SCRIPT_ADD_MODE_COMPLETE) {
-                    pr_info("lua: update complete, flashing: ");
-                    if (memory_flash_region((void *)&g_scriptConfig, (void *)g_scriptBuffer, sizeof(ScriptConfig)) == 0) {
-                        pr_info("win\r\n");
-                    } else {
-                        pr_error("fail\r\n");
-                        result = SCRIPT_ADD_RESULT_FAIL;
-                    }
-                    portFree(g_scriptBuffer);
-                    g_scriptBuffer = NULL;
-                }
-            } else {
-                pr_error("lua: script buffer alloc fail\r\n");
-                result = SCRIPT_ADD_RESULT_FAIL;
-            }
+        if (page >= MAX_SCRIPT_PAGES) {
+                pr_error("lua: invalid script index\r\n");
+                return SCRIPT_ADD_RESULT_FAIL;
         }
-    } else {
-        pr_error("lua: invalid script index\r\n");
-        result = SCRIPT_ADD_RESULT_FAIL;
-    }
-    return result;
+
+        switch (mode) {
+        case SCRIPT_ADD_MODE_IN_PROGRESS:
+        case SCRIPT_ADD_MODE_COMPLETE:
+                /* Valid cases.  Carry on */
+                break;
+        default:
+                pr_error_int_msg("Unknown script_add_mode: ", mode);
+                return SCRIPT_ADD_RESULT_FAIL;
+        }
+
+        static ScriptConfig *g_scriptBuffer;
+        if (g_scriptBuffer == NULL) {
+                terminate_lua();
+
+                pr_info("Allocating new script buffer\r\n");
+                g_scriptBuffer =
+                        (ScriptConfig *) portMalloc(sizeof(ScriptConfig));
+                memcpy((void *)g_scriptBuffer, (void *)&g_scriptConfig,
+                       sizeof(ScriptConfig));
+        }
+
+        if (g_scriptBuffer == NULL) {
+                pr_error("Failed to allocate memory for script buffer.\r\n");
+                return SCRIPT_ADD_RESULT_FAIL;
+        }
+
+        char *pageToAdd = g_scriptBuffer->script + page * SCRIPT_PAGE_SIZE;
+        strncpy(pageToAdd, data, SCRIPT_PAGE_SIZE);
+
+        if (mode == SCRIPT_ADD_MODE_IN_PROGRESS)
+                return SCRIPT_ADD_RESULT_OK;
+
+        pr_info("Completed updating LUA. Flashing... ");
+        const int rc = memory_flash_region((void*) &g_scriptConfig,
+                                           (void*) g_scriptBuffer,
+                                           sizeof(ScriptConfig));
+        portFree(g_scriptBuffer);
+        g_scriptBuffer = NULL;
+
+        if (0 != rc) {
+                pr_info_int_msg("failed with code ", rc);
+                return SCRIPT_ADD_RESULT_FAIL;
+        }
+
+        pr_info("win!\r\n");
+        initialize_lua();
+        return SCRIPT_ADD_RESULT_FAIL;
 }

--- a/src/tracks/tracks.c
+++ b/src/tracks/tracks.c
@@ -1,8 +1,30 @@
-#include "tracks.h"
+/*
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "luaTask.h"
+#include "mem_mang.h"
+#include "memory.h"
 #include "mod_string.h"
 #include "printk.h"
-#include "memory.h"
-#include "mem_mang.h"
+#include "tracks.h"
 
 #ifndef RCP_TESTING
 #include "memory.h"
@@ -12,8 +34,6 @@ static Tracks g_tracks = DEFAULT_TRACKS;
 #endif
 
 static const Tracks g_defaultTracks = DEFAULT_TRACKS;
-
-static Tracks *g_tracksBuffer = NULL;
 
 void initialize_tracks()
 {
@@ -42,44 +62,60 @@ const Tracks * get_tracks()
 }
 
 
-int add_track(const Track *track, size_t index, int mode)
+enum track_add_result add_track(const Track *track, const size_t index,
+                                const enum track_add_mode mode)
 {
-    int result = TRACK_ADD_RESULT_OK;
-
-    if (index < MAX_TRACK_COUNT) {
-        if (mode == TRACK_ADD_MODE_IN_PROGRESS || mode == TRACK_ADD_MODE_COMPLETE) {
-            if (g_tracksBuffer == NULL) {
-                pr_info("allocating new tracks buffer\r\n");
-                g_tracksBuffer = (Tracks *)portMalloc(sizeof(Tracks));
-                memcpy((void *)g_tracksBuffer, (void *)&g_tracks, sizeof(Tracks));
-            }
-
-            if (g_tracksBuffer != NULL) {
-                Track *trackToAdd = g_tracksBuffer->tracks + index;
-                memcpy(trackToAdd, track, sizeof(Track));
-                g_tracksBuffer->count = index + 1;
-
-                if (mode == TRACK_ADD_MODE_COMPLETE) {
-                    pr_info("completed updating tracks, flashing: ");
-                    if (flash_tracks(g_tracksBuffer, sizeof(Tracks)) == 0) {
-                        pr_info("win\r\n");
-                    } else {
-                        pr_error("fail\r\n");
-                        result = TRACK_ADD_RESULT_FAIL;
-                    }
-                    portFree(g_tracksBuffer);
-                    g_tracksBuffer = NULL;
-                }
-            } else {
-                pr_error("could not allocate buffer for tracks\r\n");
-                result = TRACK_ADD_RESULT_FAIL;
-            }
+        if (index >= MAX_TRACK_COUNT) {
+                pr_error("Invalid track index\r\n");
+                return TRACK_ADD_RESULT_FAIL;
         }
-    } else {
-        pr_error("invalid track index\r\n");
-        result = TRACK_ADD_RESULT_FAIL;
-    }
-    return result;
+
+        switch (mode) {
+        case TRACK_ADD_MODE_IN_PROGRESS:
+        case TRACK_ADD_MODE_COMPLETE:
+                /* Valid cases.  Carry on */
+                break;
+        default:
+                pr_error_int_msg("Unknown track_add_mode: ", mode);
+                return TRACK_ADD_RESULT_FAIL;
+        }
+
+        static Tracks *g_tracksBuffer;
+        if (g_tracksBuffer == NULL) {
+                terminate_lua();
+
+                pr_info("allocating new tracks buffer\r\n");
+                g_tracksBuffer = (Tracks *) portMalloc(sizeof(Tracks));
+                memcpy(g_tracksBuffer, (void*) &g_tracks, sizeof(Tracks));
+        }
+
+        if (g_tracksBuffer == NULL) {
+                pr_error("Failed to allocate memory for track buffer.\r\n");
+                return TRACK_ADD_RESULT_FAIL;
+        }
+
+        Track *trackToAdd = g_tracksBuffer->tracks + index;
+        memcpy(trackToAdd, track, sizeof(Track));
+        g_tracksBuffer->count = index + 1;
+
+        /* If we made it here and are still in progress, then we are done */
+        if (mode == TRACK_ADD_MODE_IN_PROGRESS)
+                return TRACK_ADD_RESULT_OK;
+
+        /* If here, time to flash and tidy up */
+        pr_info("Completed updating tracks, flashing... ");
+        const int rc = flash_tracks(g_tracksBuffer, sizeof(Tracks));
+        portFree(g_tracksBuffer);
+        g_tracksBuffer = NULL;
+
+        if (0 != rc) {
+                pr_info_int_msg("failed with code ", rc);
+                return TRACK_ADD_RESULT_FAIL;
+        }
+
+        pr_info("win!\r\n");
+        initialize_lua();
+        return TRACK_ADD_RESULT_OK;
 }
 
 static int isStage(const Track *t)

--- a/src/tracks/tracks.c
+++ b/src/tracks/tracks.c
@@ -66,7 +66,7 @@ enum track_add_result add_track(const Track *track, const size_t index,
                                 const enum track_add_mode mode)
 {
         if (index >= MAX_TRACK_COUNT) {
-                pr_error("Invalid track index\r\n");
+                pr_error("tracks: Invalid track index\r\n");
                 return TRACK_ADD_RESULT_FAIL;
         }
 
@@ -76,21 +76,21 @@ enum track_add_result add_track(const Track *track, const size_t index,
                 /* Valid cases.  Carry on */
                 break;
         default:
-                pr_error_int_msg("Unknown track_add_mode: ", mode);
+                pr_error_int_msg("tracks: Unknown track_add_mode: ", mode);
                 return TRACK_ADD_RESULT_FAIL;
         }
 
         static Tracks *g_tracksBuffer;
-        if (g_tracksBuffer == NULL) {
+        if (NULL == g_tracksBuffer) {
                 terminate_lua();
 
-                pr_info("allocating new tracks buffer\r\n");
+                pr_debug("tracks: Allocating new tracks buffer\r\n");
                 g_tracksBuffer = (Tracks *) portMalloc(sizeof(Tracks));
                 memcpy(g_tracksBuffer, (void*) &g_tracks, sizeof(Tracks));
         }
 
-        if (g_tracksBuffer == NULL) {
-                pr_error("Failed to allocate memory for track buffer.\r\n");
+        if (NULL == g_tracksBuffer) {
+                pr_error("tracks: Failed to allocate memory for track buffer.\r\n");
                 return TRACK_ADD_RESULT_FAIL;
         }
 
@@ -99,11 +99,11 @@ enum track_add_result add_track(const Track *track, const size_t index,
         g_tracksBuffer->count = index + 1;
 
         /* If we made it here and are still in progress, then we are done */
-        if (mode == TRACK_ADD_MODE_IN_PROGRESS)
+        if (TRACK_ADD_MODE_IN_PROGRESS == mode)
                 return TRACK_ADD_RESULT_OK;
 
         /* If here, time to flash and tidy up */
-        pr_info("Completed updating tracks, flashing... ");
+        pr_info("tracks: Completed updating tracks. Flashing... ");
         const int rc = flash_tracks(g_tracksBuffer, sizeof(Tracks));
         portFree(g_tracksBuffer);
         g_tracksBuffer = NULL;

--- a/src/tracks/tracks.c
+++ b/src/tracks/tracks.c
@@ -82,7 +82,8 @@ enum track_add_result add_track(const Track *track, const size_t index,
 
         static Tracks *g_tracksBuffer;
         if (NULL == g_tracksBuffer) {
-                terminate_lua();
+                if (RCP_LOW_MEM)
+                        terminate_lua();
 
                 pr_debug("tracks: Allocating new tracks buffer\r\n");
                 g_tracksBuffer = (Tracks *) portMalloc(sizeof(Tracks));
@@ -114,7 +115,10 @@ enum track_add_result add_track(const Track *track, const size_t index,
         }
 
         pr_info("win!\r\n");
-        initialize_lua();
+
+        if (RCP_LOW_MEM)
+                initialize_lua();
+
         return TRACK_ADD_RESULT_OK;
 }
 

--- a/stm32_base/capabilities.h
+++ b/stm32_base/capabilities.h
@@ -12,10 +12,19 @@
 #define MAX_TRACKS				240
 #define MAX_SECTORS				20
 #define MAX_VIRTUAL_CHANNELS	30
-
 #define LOGGER_MESSAGE_BUFFER_SIZE	10
 
+/*
+ * Adds additional memory saving behavior for low memory systems.
+ * These come at a cost of interruption of other services as needed
+ * to save RAM.  Usually quick interruptions, but interruptions
+ * none the less.
+ */
+#define RCP_LOW_MEM	0
+
+
 /* LUA Configuration */
+
 /*
  * What is the maximum length of the script that can be provided?
  * Must be divisible by 256.

--- a/test/capabilities.h
+++ b/test/capabilities.h
@@ -14,8 +14,17 @@
 
 #define LOGGER_MESSAGE_BUFFER_SIZE	5
 
+/*
+ * Adds additional memory saving behavior for low memory systems.
+ * These come at a cost of interruption of other services as needed
+ * to save RAM.  Usually quick interruptions, but interruptions
+ * none the less.
+ */
+#define RCP_LOW_MEM	0
+
 
 /* LUA Configuration */
+
 /*
  * What is the maximum length of the script that can be provided?
  *


### PR DESCRIPTION
Flashing the tracks DB was causing MK1 to crash because it
was allocating a large chunk of RAM to do it.  We need to
disable LUA before we do this, else we will die due to RAM
starvation.  This fix does that and cleans up both of the
large flashing methods because they really could use it.  Now
both methods are much cleaner, up to CONTRIBUTING spec, and
generally make me happy.