### PR TITLE
Fix sector enabled logic

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,8 @@
 * Reduce max LUA script size on MK1 to 4K for stability reasons and increased
   max script size on MK2 to 16K.  This will result in the LUA script being
   restored to the default.  Please back up your scripts prior to upgrading.
+* Fix sector bug with no sector definitions.  Now sectors will not arbitrarily
+  count up.
 
 === 2.8.4 ===
 * Background streaming switch only affects telemetry link; Wireless (Bluetooth) link always streams

--- a/include/gps/geopoint.h
+++ b/include/gps/geopoint.h
@@ -48,4 +48,10 @@ float distPythag(const GeoPoint *a, const GeoPoint *b);
  */
 int isValidPoint(const GeoPoint *p);
 
+/**
+ * Tests if both GeoPoint values are the same.
+ * @return True if they are, false otherwise.
+ */
+bool are_geo_points_equal(const GeoPoint *p1, const GeoPoint *p2);
+
 #endif /* GEOPOINT_H_ */

--- a/src/gps/geopoint.c
+++ b/src/gps/geopoint.c
@@ -1,13 +1,29 @@
 /*
- * geopoint.c
+ * Race Capture Pro Firmware
  *
- *  Created on: Jan 20, 2014
- *      Author: stieg
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "geopoint.h"
 #include "gps.h"
+
 #include <math.h>
+#include <stdbool.h>
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -38,4 +54,13 @@ float distPythag(const GeoPoint *a, const GeoPoint *b)
 int isValidPoint(const GeoPoint *p)
 {
     return p->latitude != 0.0 || p->longitude != 0.0;
+}
+
+bool are_geo_points_equal(const GeoPoint *p1, const GeoPoint *p2)
+{
+        if (NULL == p1 || NULL == p2)
+                return p1 == p2;
+
+        return p1->latitude == p2->latitude &&
+                p1->longitude == p2->longitude;
 }

--- a/src/lap_stats/lap_stats.c
+++ b/src/lap_stats/lap_stats.c
@@ -412,14 +412,24 @@ static int isStartFinishEnabled(const Track *track)
 
 static int isSectorTrackingEnabled(const Track *track)
 {
-    if (!isStartFinishEnabled(track))
-        return 0;
+        if (!isStartFinishEnabled(track))
+                return 0;
 
-    // Must have >=  one valid sector; must start at position 0.
-    const LoggerConfig *config = getWorkingLoggerConfig();
-    const GeoPoint p0 = getSectorGeoPointAtIndex(track, 0);
-    return config->LapConfigs.sectorTimeCfg.sampleRate != SAMPLE_DISABLED
-           && isValidPoint(&p0);
+        const LoggerConfig *config = getWorkingLoggerConfig();
+        if (SAMPLE_DISABLED != config->LapConfigs.sectorTimeCfg.sampleRate)
+                return 0;
+
+        /*
+         * Must have >= one valid sector; must start at position 0.  Be careful
+         * when using getSectorGeoPointAtIndex because if a point is in within
+         * a valid range but is an invalid GPS value, it will return the finish
+         * line (logical because the last sector boundary is always the finish
+         * line).  So we must compare sector 0 against the finish line and if
+         * they are the same, then we do not have sector values defined.
+         */
+        const GeoPoint sp0 = getSectorGeoPointAtIndex(track, 0);
+        const GeoPoint fin = getFinishPoint(track);
+        return !are_geo_points_equal(fin, sp0);
 }
 
 static void setupGeoTriggers(const TrackConfig *tc, const Track *track)

--- a/src/lap_stats/lap_stats.c
+++ b/src/lap_stats/lap_stats.c
@@ -429,7 +429,7 @@ static int isSectorTrackingEnabled(const Track *track)
          */
         const GeoPoint sp0 = getSectorGeoPointAtIndex(track, 0);
         const GeoPoint fin = getFinishPoint(track);
-        return !are_geo_points_equal(fin, sp0);
+        return !are_geo_points_equal(&fin, &sp0);
 }
 
 static void setupGeoTriggers(const TrackConfig *tc, const Track *track)


### PR DESCRIPTION
There was a hilarious bug in the firmware where we were thinking
sectors were enabled when in fact they were not.  This was because
the method that gets a sector at an index returns the finish line
if it has no more sectors (because that is the next logical sector
boundary).  However if no sectors are defined, then sector 0 will
return the finish line, and in our logic we were not taking that
behavior into account.  This fixes that issue.