### PR TITLE
Improve mk1 usart

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
   restored to the default.  Please back up your scripts prior to upgrading.
 * Fix sector bug with no sector definitions.  Now sectors will not arbitrarily
   count up.
+* Fix MK1 BT buffer overflow when CPU under heavy load.
 
 === 2.8.4 ===
 * Background streaming switch only affects telemetry link; Wireless (Bluetooth) link always streams

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+=== 2.8.6 ===
+* Improve the USART code for MK1 by removing duplicated code, eliminating
+  externs, and cleaning up the handling of character queues.
+
 === 2.8.5 ===
 * Increased GPS task stack size from 200 to 256 to prevent HULK smash.
 * Increased printing precision in LUA from 3 to 6 decimal places (as needed).
@@ -16,7 +20,6 @@
   restored to the default.  Please back up your scripts prior to upgrading.
 * Fix sector bug with no sector definitions.  Now sectors will not arbitrarily
   count up.
-* Fix MK1 BT buffer overflow when CPU under heavy load.
 
 === 2.8.4 ===
 * Background streaming switch only affects telemetry link; Wireless (Bluetooth) link always streams

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,3 +79,23 @@ if (foo) {
 	bar();
 }
 ```
+
+## No Magic Numbers in Code
+If a method has a parameter whose purpose is non-trivial in the configuration
+of a device, then this number shall be defined in a `#define` declaration at
+the top of the file.
+
+So in example
+
+```
+init_txrx_queue(0, 512, 512)
+```
+
+should look like this:
+
+```
+#define TELEM_RX_QUEUE_LEN	512
+#define TELEM_TX_QUEUE_LEN	512
+...
+init_txrx_queue(0, TELEM_TX_QUEUE_LEN, TELEM_RX_QUEUE_LEN)
+```

--- a/SAM7s_base/usart_at91/serialIsr.c
+++ b/SAM7s_base/usart_at91/serialIsr.c
@@ -1,14 +1,30 @@
+/*
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "FreeRTOS.h"
+#include "board.h"
 #include "queue.h"
 #include "semphr.h"
-#include "board.h"
 #include "task.h"
-
-extern xQueueHandle xUsart0Tx;
-extern xQueueHandle xUsart0Rx;
-extern xQueueHandle xUsart1Tx;
-extern xQueueHandle xUsart1Rx;
-
+#include "usart_device_at91.h"
 
 /* The ISR can cause a context switch so is declared naked. */
 void usart0_irq_handler( void ) __attribute__ ((naked));
@@ -27,7 +43,8 @@ void usart0_irq_handler( void )
     if( ulStatus & AT91C_US_TXRDY ) {
         /* The interrupt was caused by the THR becoming empty.  Are there any
         more characters to transmit? */
-        if( xQueueReceiveFromISR( xUsart0Tx, &cChar, &xTaskWokenByTx ) == pdTRUE ) {
+            if( xQueueReceiveFromISR(get_txrx_queue(0)->tx, &cChar,
+                                     &xTaskWokenByTx ) == pdTRUE ) {
             /* A character was retrieved from the queue so can be sent to the
             THR now. */
             AT91C_BASE_US0->US_THR = cChar;
@@ -42,7 +59,8 @@ void usart0_irq_handler( void )
         character from the RHR and place it in the queue or received
         characters. */
         cChar = AT91C_BASE_US0->US_RHR;
-        xTaskWokenByPost = xQueueSendFromISR( xUsart0Rx, &cChar, xTaskWokenByPost );
+        xTaskWokenByPost = xQueueSendFromISR(get_txrx_queue(0)->rx, &cChar,
+                                             xTaskWokenByPost );
     }
 
     /* If a task was woken by either a character being received or a character
@@ -73,7 +91,9 @@ void usart1_irq_handler( void )
     if( ulStatus & AT91C_US_TXRDY ) {
         /* The interrupt was caused by the THR becoming empty.  Are there any
         more characters to transmit? */
-        if( xQueueReceiveFromISR( xUsart1Tx, &cChar, &xTaskWokenByTx ) == pdTRUE ) {
+
+            if( xQueueReceiveFromISR(get_txrx_queue(1)->tx, &cChar,
+                                     &xTaskWokenByTx ) == pdTRUE ) {
             /* A character was retrieved from the queue so can be sent to the
             THR now. */
             AT91C_BASE_US1->US_THR = cChar;
@@ -88,7 +108,8 @@ void usart1_irq_handler( void )
         character from the RHR and place it in the queue or received
         characters. */
         cChar = AT91C_BASE_US1->US_RHR;
-        xTaskWokenByPost = xQueueSendFromISR( xUsart1Rx, &cChar, xTaskWokenByPost );
+        xTaskWokenByPost = xQueueSendFromISR(get_txrx_queue(1)->rx, &cChar,
+                                             xTaskWokenByPost );
     }
 
     /* If a task was woken by either a character being received or a character

--- a/SAM7s_base/usart_at91/usart_device_at91.c
+++ b/SAM7s_base/usart_at91/usart_device_at91.c
@@ -43,6 +43,11 @@
 #define TELEMETRY_BAUDRATE 115200
 #define USART_INTERRUPT_LEVEL 5
 
+#define GPS_RX_QUEUE_LEN	512
+#define GPS_TX_QUEUE_LEN	512
+#define TELEM_RX_QUEUE_LEN	512
+#define TELEM_TX_QUEUE_LEN	8
+
 void usart0_irq_handler (void);
 void usart1_irq_handler (void);
 
@@ -136,12 +141,12 @@ int usart_device_init()
     AT91F_PMC_EnablePeriphClock( AT91C_BASE_PMC,(1 << AT91C_ID_US0) | (1 << AT91C_ID_US1));
 
     /* Init device 0 (Telemetry) */
-    if (!init_txrx_queue(0, 512, 512))
+    if (!init_txrx_queue(0, TELEM_TX_QUEUE_LEN, TELEM_RX_QUEUE_LEN))
             return 0;
     usart_device_init_0(8, 0, 1, TELEMETRY_BAUDRATE);
 
     /* Init device 1 (GPS) */
-    if (!init_txrx_queue(1, 512, 128))
+    if (!init_txrx_queue(1, GPS_TX_QUEUE_LEN, GPS_RX_QUEUE_LEN))
             return 0;
     usart_device_init_1(8, 0, 1, GPS_BAUDRATE);
 

--- a/SAM7s_base/usart_at91/usart_device_at91.c
+++ b/SAM7s_base/usart_at91/usart_device_at91.c
@@ -44,9 +44,9 @@
 #define USART_INTERRUPT_LEVEL 5
 
 #define GPS_RX_QUEUE_LEN	512
-#define GPS_TX_QUEUE_LEN	512
+#define GPS_TX_QUEUE_LEN	8
 #define TELEM_RX_QUEUE_LEN	512
-#define TELEM_TX_QUEUE_LEN	8
+#define TELEM_TX_QUEUE_LEN	512
 
 void usart0_irq_handler (void);
 void usart1_irq_handler (void);

--- a/SAM7s_base/usart_at91/usart_device_at91.c
+++ b/SAM7s_base/usart_at91/usart_device_at91.c
@@ -31,12 +31,13 @@
 //         Headers
 //------------------------------------------------------------------------------
 
-#include "usart_device.h"
 #include "FreeRTOS.h"
-#include "task.h"
-#include "queue.h"
-#include "printk.h"
 #include "board.h"
+#include "printk.h"
+#include "queue.h"
+#include "task.h"
+#include "usart_device.h"
+#include "usart_device_at91.h"
 
 #define GPS_BAUDRATE 38400
 #define TELEMETRY_BAUDRATE 115200
@@ -45,10 +46,11 @@
 void usart0_irq_handler (void);
 void usart1_irq_handler (void);
 
-xQueueHandle xUsart0Tx;
-xQueueHandle xUsart0Rx;
-xQueueHandle xUsart1Tx;
-xQueueHandle xUsart1Rx;
+static struct txrx_queue usart_txrx_queues[2];
+
+struct txrx_queue* get_txrx_queue(const int idx) {
+        return &usart_txrx_queues[idx];
+}
 
 static void USART_Configure(AT91S_USART *usart,
                             unsigned int mode,
@@ -72,27 +74,17 @@ static void USART_Configure(AT91S_USART *usart,
     // TODO other modes
 }
 
-static int initQueues()
+static int init_txrx_queue(const int idx,
+                           const size_t tx_len,
+                           const size_t rx_len)
 {
+        const unsigned portBASE_TYPE char_size =
+                (unsigned portBASE_TYPE) sizeof(signed portCHAR);
 
-    int success = 1;
+        usart_txrx_queues[idx].tx = xQueueCreate(tx_len, char_size);
+        usart_txrx_queues[idx].rx = xQueueCreate(rx_len, char_size);
 
-    /* Create the queues used to hold Rx and Tx characters. */
-    /* Telemetry USART */
-    xUsart0Rx = xQueueCreate(512, ( unsigned portBASE_TYPE ) sizeof( signed portCHAR ) );
-    xUsart0Tx = xQueueCreate(512, ( unsigned portBASE_TYPE ) sizeof( signed portCHAR ) );
-
-    /* GPS USART */
-    xUsart1Rx = xQueueCreate(300, ( unsigned portBASE_TYPE ) sizeof( signed portCHAR ) );
-    xUsart1Tx = xQueueCreate(300, ( unsigned portBASE_TYPE ) sizeof( signed portCHAR ) );
-
-    if (xUsart0Rx == NULL ||
-        xUsart1Rx == NULL ||
-        xUsart0Rx == NULL ||
-        xUsart0Rx == NULL
-       ) success = 0;
-
-    return success;
+        return usart_txrx_queues[idx].tx && usart_txrx_queues[idx].rx;
 }
 
 static unsigned int createUartMode(unsigned int bits, unsigned int parity, unsigned int stopBits)
@@ -142,9 +134,17 @@ static unsigned int createUartMode(unsigned int bits, unsigned int parity, unsig
 int usart_device_init()
 {
     AT91F_PMC_EnablePeriphClock( AT91C_BASE_PMC,(1 << AT91C_ID_US0) | (1 << AT91C_ID_US1));
-    if (!initQueues()) return 0;
+
+    /* Init device 0 (Telemetry) */
+    if (!init_txrx_queue(0, 512, 512))
+            return 0;
     usart_device_init_0(8, 0, 1, TELEMETRY_BAUDRATE);
+
+    /* Init device 1 (GPS) */
+    if (!init_txrx_queue(1, 512, 128))
+            return 0;
     usart_device_init_1(8, 0, 1, GPS_BAUDRATE);
+
     return 1;
 }
 
@@ -254,113 +254,121 @@ void usart_device_init_1(unsigned int bits, unsigned int parity, unsigned int st
     AT91F_AIC_EnableIt( AT91C_BASE_AIC, AT91C_ID_US1 );
 }
 
+static void _usart_flush(const int idx)
+{
+        char rx;
+        while(xQueueReceive(usart_txrx_queues[idx].rx, &rx, 0));
+}
 
 void usart0_flush(void)
 {
-    char rx;
-    while(xQueueReceive( xUsart0Rx, &rx, 0 ));
+        _usart_flush(0);
 }
 
 void usart1_flush(void)
 {
-    char rx;
-    while(xQueueReceive( xUsart1Rx, &rx, 0 ));
+        _usart_flush(1);
+}
+
+static int _usart_get_char_wait(const int idx, char *c, size_t delay)
+{
+        return xQueueReceive(usart_txrx_queues[idx].rx, c, delay) == pdTRUE;
 }
 
 int usart0_getcharWait(char *c, size_t delay)
 {
-    return xQueueReceive( xUsart0Rx, c, delay ) == pdTRUE ? 1 : 0;
+        return _usart_get_char_wait(0, c, delay);
 }
 
 int usart1_getcharWait(char *c, size_t delay)
 {
-    return xQueueReceive( xUsart1Rx, c, delay ) == pdTRUE ? 1 : 0;
+        return _usart_get_char_wait(1, c, delay);
 }
 
 char usart0_getchar()
 {
-    char c;
-    usart0_getcharWait(&c, portMAX_DELAY);
-    return c;
+        char c;
+        _usart_get_char_wait(0, &c, portMAX_DELAY);
+        return c;
 }
 
 char usart1_getchar()
 {
-    char c;
-    return usart1_getcharWait(&c, portMAX_DELAY);
-    return c;
+        char c;
+        _usart_get_char_wait(1, &c, portMAX_DELAY);
+        return c;
 }
 
-void usart0_putchar(char c)
+static void _usart_putchar(const int idx, char c)
 {
-    if (TRACE_LEVEL) {
         char buf[2];
         buf[0] = c;
         buf[1] = '\0';
         pr_debug(buf);
-    }
-    xQueueSend( xUsart0Tx, &c, portMAX_DELAY );
-    //Enable transmitter interrupt
-    AT91F_US_EnableIt( AT91C_BASE_US0, AT91C_US_TXRDY | AT91C_US_RXRDY );
+
+        xQueueSend(usart_txrx_queues[idx].tx, &c, portMAX_DELAY);
+
+        //Enable transmitter interrupt
+        AT91F_US_EnableIt(AT91C_BASE_US0, AT91C_US_TXRDY | AT91C_US_RXRDY);
+}
+
+
+void usart0_putchar(char c)
+{
+        _usart_putchar(0, c);
 }
 
 void usart1_putchar(char c)
 {
-    if (TRACE_LEVEL) {
-        char buf[2];
-        buf[0] = c;
-        buf[1] = '\0';
-        pr_debug(buf);
-    }
-    xQueueSend( xUsart1Tx, &c, portMAX_DELAY );
-    //Enable transmitter interrupt
-    AT91F_US_EnableIt( AT91C_BASE_US1, AT91C_US_TXRDY | AT91C_US_RXRDY );
+        _usart_putchar(1, c);
 }
 
 void usart0_puts (const char* s )
 {
-    while ( *s ) usart0_putchar(*s++ );
+        while(*s)
+                _usart_putchar(0, *s++);
 }
 
 void usart1_puts (const char* s )
 {
-    while ( *s ) usart1_putchar(*s++ );
+        while(*s)
+                _usart_putchar(1, *s++);
+}
+
+static int _usart_read_line_wait(const int idx, char *s, int len, size_t delay)
+{
+        int count = 0;
+
+        while(count < len - 1) {
+                char c;
+                if (!_usart_get_char_wait(idx, &c, delay))
+                        break;
+                *s++ = c;
+                count++;
+                if ('\n' == c)
+                        break;
+        }
+
+        *s = '\0';
+        return count;
 }
 
 int usart0_readLineWait(char *s, int len, size_t delay)
 {
-    int count = 0;
-    while(count < len - 1) {
-        char c = 0;
-        if (!usart0_getcharWait(&c, delay)) break;
-        *s++ = c;
-        count++;
-        if (c == '\n') break;
-    }
-    *s = '\0';
-    return count;
+        return _usart_read_line_wait(0, s, len, delay);
 }
 
 int usart0_readLine(char *s, int len)
 {
-    return usart0_readLineWait(s,len,portMAX_DELAY);
+        return _usart_read_line_wait(0, s, len, portMAX_DELAY);
 }
 
 int usart1_readLineWait(char *s, int len, size_t delay)
 {
-    int count = 0;
-    while(count < len - 1) {
-        char c = 0;
-        if (!usart1_getcharWait(&c, delay)) break;
-        *s++ = c;
-        count++;
-        if (c == '\n') break;
-    }
-    *s = '\0';
-    return count;
+        return _usart_read_line_wait(1, s, len, delay);
 }
 
 int usart1_readLine(char *s, int len)
 {
-    return usart1_readLineWait(s,len,portMAX_DELAY);
+        return _usart_read_line_wait(1, s, len, portMAX_DELAY);
 }

--- a/SAM7s_base/usart_at91/usart_device_at91.h
+++ b/SAM7s_base/usart_at91/usart_device_at91.h
@@ -1,0 +1,32 @@
+/*
+ * Race Capture Pro Firmware
+ *
+ * Copyright (C) 2015 Autosport Labs
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _USART_DEVICE_AT91_H_
+#define _USART_DEVICE_AT91_H_
+
+struct txrx_queue {
+        xQueueHandle tx;
+        xQueueHandle rx;
+};
+
+struct txrx_queue* get_txrx_queue(const int idx);
+
+#endif /* _USART_DEVICE_AT91_H_ */

--- a/main.c
+++ b/main.c
@@ -114,11 +114,11 @@ void setupTask(void *delTask)
         initMessaging();
 
         startUSBCommTask(RCP_INPUT_PRIORITY);
+        startConnectivityTask(RCP_INPUT_PRIORITY);
         startGPIOTasks(RCP_INPUT_PRIORITY);
         startGPSTask(RCP_INPUT_PRIORITY);
         startOBD2Task(RCP_INPUT_PRIORITY);
         startFileWriterTask(RCP_OUTPUT_PRIORITY);
-        startConnectivityTask(RCP_OUTPUT_PRIORITY);
         startLoggerTaskEx(RCP_LOGGING_PRIORITY);
         startLuaTask(RCP_LUA_PRIORITY);
 

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -226,7 +226,9 @@ int process_api(Serial *serial, char *buffer, size_t bufferSize)
     if (r == JSMN_SUCCESS) {
         return execute_api(serial, g_json_tok);
     } else {
-        pr_warning_int_msg("API Error: ", r);
+        pr_warning("API Parsing Error: \"");
+        pr_warning(buffer);
+        pr_warning_int_msg("\"\r\n failed with code ", r);
         return API_ERROR_MALFORMED;
     }
 }


### PR DESCRIPTION
Improves the code used for the USART on MK1 by re factoring it and eliminating a bunch of the duplicated code and portions of code with externs and general bad practice coding in place.