### PR TITLE
Code cleanup on the API methods for loggin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 === 2.8.6 ===
+* Code cleanup around the some API methods.  Also eliminates unused variable
+  errors and removes some unneeded variables.
 * Improve the USART code for MK1 by removing duplicated code, eliminating
   externs, and cleaning up the handling of character queues.
 

--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -92,7 +92,11 @@ struct TimeConfig {
 
 #define EMPTY_CHANNEL_CONFIG {"","", 0.0f, 0.0f, SAMPLE_DISABLED, 0}
 
-// Default to lowest active sample rate.  This will change in code later.
+/*
+ * Default to lowest active sample rate.  This will change in code later.
+ * NOTE: This should never be below SAMPLE_1Hz, else you could potentially
+ *       starve the telemtry task if a user somehow disables all channels.
+ */
 #define DEFAULT_UPTIME_CONFIG {"Interval", "ms", 0, 0, SAMPLE_1Hz, 0, ALWAYS_SAMPLED}
 #define DEFAULT_UTC_MILLIS_CONFIG {"Utc", "ms", 0, 0, SAMPLE_1Hz, 0, ALWAYS_SAMPLED}
 

--- a/src/logger/connectivityTask.c
+++ b/src/logger/connectivityTask.c
@@ -43,6 +43,7 @@
 #include "taskUtil.h"
 #include "usart.h"
 
+
 #if (CONNECTIVITY_CHANNELS == 1)
 #define CONNECTIVITY_TASK_INIT {NULL}
 #elif (CONNECTIVITY_CHANNELS == 2)

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -1618,39 +1618,27 @@ int api_getScript(Serial *serial, const jsmntok_t *json)
 
 int api_setScript(Serial *serial, const jsmntok_t *json)
 {
-    int rc = API_ERROR_UNSPECIFIED;
-    bool reload_script = false;
-    const jsmntok_t *dataTok = findNode(json, "data");
-    const jsmntok_t *pageTok = findNode(json, "page");
-    const jsmntok_t *modeTok = findNode(json, "mode");
+        const jsmntok_t *dataTok = findNode(json, "data");
+        const jsmntok_t *pageTok = findNode(json, "page");
+        const jsmntok_t *modeTok = findNode(json, "mode");
 
-    if (dataTok != NULL && pageTok != NULL && modeTok !=NULL) {
-        dataTok++;
-        pageTok++;
-        modeTok++;
+        if (dataTok == NULL || pageTok == NULL || modeTok == NULL)
+                return API_ERROR_PARAMETER;
 
-        jsmn_trimData(dataTok);
-        jsmn_trimData(pageTok);
-        jsmn_trimData(modeTok);
+        jsmn_trimData(++dataTok);
+        jsmn_trimData(++pageTok);
+        jsmn_trimData(++modeTok);
 
-        size_t page = modp_atoi(pageTok->data);
-        size_t mode = modp_atoi(modeTok->data);
-        if (page < MAX_SCRIPT_PAGES) {
-            char *script = dataTok->data;
-            unescapeScript(script);
-            const int flashResult =
-               flashScriptPage(page, script, (enum script_add_mode) mode);
+        const size_t page = modp_atoi(pageTok->data);
+        if (page >= MAX_SCRIPT_PAGES)
+                return API_ERROR_PARAMETER;
 
-            rc = flashResult == 1 ? API_SUCCESS : API_ERROR_SEVERE;
-            reload_script = rc == API_SUCCESS && mode == SCRIPT_ADD_MODE_COMPLETE;
-        } else {
-            rc = API_ERROR_PARAMETER;
-        }
-    } else {
-        rc = API_ERROR_PARAMETER;
-    }
-
-    return rc;
+        const enum script_add_mode mode =
+                (enum script_add_mode) modp_atoi(modeTok->data);
+        char *script = dataTok->data;
+        unescapeScript(script);
+        return flashScriptPage(page, script, mode) ?
+                API_SUCCESS : API_ERROR_SEVERE;
 }
 
 int api_runScript(Serial *serial, const jsmntok_t *json)

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -531,10 +531,10 @@ unsigned int getHighestSampleRate(LoggerConfig *config)
     int s = SAMPLE_DISABLED;
     int sr;
 
-    /*
-     * Bypass Interval and Utc here since they will always be logging
-     * at the highest rate based on the results of this very method
-     */
+    for (int i = 0; i < CONFIG_TIME_CHANNELS; i++) {
+            sr = config->TimeConfigs[i].cfg.sampleRate;
+            s = getHigherSampleRate(sr, s);
+    }
 
     for (int i = 0; i < CONFIG_ADC_CHANNELS; i++) {
         sr = config->ADCConfigs[i].cfg.sampleRate;

--- a/src/logger/loggerTaskEx.c
+++ b/src/logger/loggerTaskEx.c
@@ -1,9 +1,9 @@
 /*
- * Race Capture Pro Firmware
+ * Race Capture Firmware
  *
  * Copyright (C) 2015 Autosport Labs
  *
- * This file is part of the Race Capture Pro fimrware suite
+ * This file is part of the Race Capture fimrware suite
  *
  * This is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -236,7 +236,8 @@ void loggerTaskEx(void *params)
                  * We only log to file if the user has manually pushed the
                  * logging button.
                  */
-                if (is_logging && sampledRate >= loggingSampleRate) {
+                if (!isHigherSampleRate(sampledRate, loggingSampleRate)
+                    && is_logging) {
                         /* XXX Move this to file writer? */
                         const portBASE_TYPE res = queue_logfile_record(&msg);
                         const logging_status_t ls = pdTRUE == res ?
@@ -246,8 +247,7 @@ void loggerTaskEx(void *params)
                 }
 
                 /* send the sample on to the telemetry task(s) */
-                if (sampledRate >= telemetrySampleRate ||
-                    currentTicks % telemetrySampleRate == 0)
+                if (!isHigherSampleRate(sampledRate, telemetrySampleRate))
                         queueTelemetryRecord(&msg);
 
                 ++bufferIndex;

--- a/stm32_base/hal/usart_stm32/usart_device_stm32.c
+++ b/stm32_base/hal/usart_stm32/usart_device_stm32.c
@@ -650,20 +650,24 @@ int usart3_readLine(char *s, int len)
 
 static void handle_usart_overrun(USART_TypeDef* USARTx)
 {
-    uint32_t cChar;
-    if (USART_GetITStatus(USARTx, USART_IT_ORE_RX) != SET)
-    	return;
-	/*
+        if (USART_GetITStatus(USARTx, USART_IT_ORE_RX) != SET)
+                return;
+
+        /*
 	 * Handle Overrun error
-	 * This bit is set by hardware when the word currently being received in the shift register is
-	 * ready to be transferred into the RDR register while RXNE=1. An interrupt is generated if
-	 * RXNEIE=1 in the USART_CR1 register. It is cleared by a software sequence (an read to the
-	 * USART_SR register followed by a read to the USART_DR register)
+         *
+	 * This bit is set by hardware when the word currently being received in
+         * the shift register is ready to be transferred into the RDR register
+         * while RXNE=1. An interrupt is generated if RXNEIE=1 in the USART_CR1
+         * register. It is cleared by a software sequence (an read to the
+         * USART_SR register followed by a read to the USART_DR register)
 	 */
+        uint32_t cChar;
 	cChar = USART1->SR;
 	cChar = USART1->DR;
+
 	/* Suppress compiler warning */
-	cChar = cChar;
+	(void) cChar;
 }
 
 void DMA1_Stream5_IRQHandler(void)


### PR DESCRIPTION
Cleans up the API methods for logging and makes it so that users can never fully disable telemetry.  This in turn allows us to eliminate some hacks.