### PR TITLE
Update telemetry address

### DIFF
--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -448,7 +448,7 @@ typedef struct _CellularConfig {
 #define TELEMETRY_SERVER_HOST_LENGTH 100
 
 #define DEFAULT_DEVICE_ID ""
-#define DEFAULT_TELEMETRY_SERVER_HOST "race-capture.com"
+#define DEFAULT_TELEMETRY_SERVER_HOST "telemetry.race-capture.com"
 
 #define BACKGROUND_STREAMING_ENABLED				1
 #define BACKGROUND_STREAMING_DISABLED				0


### PR DESCRIPTION
The addition of cloud front means we need to use a better qualifier of a
host name as the telemetry destination so as not to interfere with the
CF operations.

telemetry.race-capture.com will always bypass CF and go straight to the
recording backend.