### PR TITLE
Send telemetry to telemetry.podium.live

### DIFF
--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -448,7 +448,7 @@ typedef struct _CellularConfig {
 #define TELEMETRY_SERVER_HOST_LENGTH 100
 
 #define DEFAULT_DEVICE_ID ""
-#define DEFAULT_TELEMETRY_SERVER_HOST "telemetry.race-capture.com"
+#define DEFAULT_TELEMETRY_SERVER_HOST "telemetry.podium.live"
 
 #define BACKGROUND_STREAMING_ENABLED				1
 #define BACKGROUND_STREAMING_DISABLED				0

--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -448,7 +448,7 @@ typedef struct _CellularConfig {
 #define TELEMETRY_SERVER_HOST_LENGTH 100
 
 #define DEFAULT_DEVICE_ID ""
-#define DEFAULT_TELEMETRY_SERVER_HOST "race-capture.com"
+#define DEFAULT_TELEMETRY_SERVER_HOST "telemetry.race-capture.com"
 
 #define BACKGROUND_STREAMING_ENABLED				1
 #define BACKGROUND_STREAMING_DISABLED				0


### PR DESCRIPTION
Updates the default destination to telemetry.podium.live.  Will apply after users do a configReset.  Its safe to do this now as it will not corrupt or change the config layout.