### PR TITLE
Fix up BT on RCP

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,10 @@
 * Improve gyro sensitivity.  Cars don't rotate at a value of 2000 deg/sec.
   Changes maximum supported rotation rate to 250 deg/sec, but get much more
   sensitivity (8x more to be precise).
+* Add uniqueness to BT device name by appending last 4 digits of unit serial
+  to the BT device.  Applies after logger reset.
+* Fix up BT code so that we now properly set BT name and Pin.  Addresses race
+  issues observed in BT module during programming as well.
 
 === 2.8.5 ===
 * Increased GPS task stack size from 200 to 256 to prevent HULK smash.

--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -410,7 +410,7 @@ typedef struct _TrackConfig {
 #define BT_DEVICE_NAME_LENGTH 21
 #define BT_PASSCODE_LENGTH 5
 #define DEFAULT_BT_DEVICE_NAME "RaceCapturePro"
-#define DEFAULT_BT_PASSCODE "1010"
+#define DEFAULT_BT_PASSCODE "0000"
 #define DEFAULT_BT_BAUD 115200
 #define DEFAULT_BT_ENABLED 1
 

--- a/src/devices/bluetooth.c
+++ b/src/devices/bluetooth.c
@@ -24,8 +24,14 @@
 #include "task.h"
 #include "taskUtil.h"
 
+#include <stdbool.h>
+
 #define COMMAND_WAIT 	600
+#define BT_AT_CMD_BAUD	9600
 #define BT_INIT_DELAY   100
+#define BT_MAX_NAME_LEN	20
+#define BT_MAX_PIN_LEN	4
+#define BT_CMD_BACKOFF_MS	5
 
 static bluetooth_status_t g_bluetooth_status = BT_STATUS_NOT_INIT;
 
@@ -48,84 +54,127 @@ static void flushBt(DeviceConfig *config)
 
 void putsBt(DeviceConfig *config, const char *data)
 {
-    config->serial->put_s(data);
+        config->serial->put_s(data);
 }
 
-static int sendBtCommandWaitResponse(DeviceConfig *config, const char *cmd, const char *rsp,
-                                     size_t wait)
+static int sendBtCommandWaitResponse(DeviceConfig *config, const char *cmd,
+                                     const char *rsp, const size_t wait)
 {
-    flushBt(config);
-    vTaskDelay(COMMAND_WAIT);
-    putsBt(config, cmd);
-    readBtWait(config, wait);
-    pr_debug_str_msg("BT: cmd rsp: ", config->buffer);
-    int res = strncmp(config->buffer, rsp, strlen(rsp));
-    pr_debug_str_msg("BT: ", res == 0 ? "match" : "nomatch");
-    return res == 0;
-}
+        pr_debug_str_msg("BT: cmd: ", cmd);
 
-static int sendBtCommandWait(DeviceConfig *config, const char *cmd, size_t wait)
-{
-    return sendBtCommandWaitResponse(config, cmd, "OK", COMMAND_WAIT);
+        flushBt(config);
+        putsBt(config, cmd);
+        readBtWait(config, wait);
+
+        const bool res = 0 == strncmp(config->buffer, rsp, strlen(rsp));
+
+        pr_debug_str_msg("BT: wanted rsp: ", rsp);
+        pr_debug_str_msg("BT: actual rsp: ", config->buffer);
+        pr_debug_int_msg("BT: matched: ", res);
+
+        /* Put a little time between commands for the BT unit to catch up */
+        delayMs(BT_CMD_BACKOFF_MS);
+
+        return res;
 }
 
 static int sendCommand(DeviceConfig *config, const char * cmd)
 {
-    pr_debug_str_msg("BT: cmd: ", cmd);
-    return sendBtCommandWait(config, cmd, COMMAND_WAIT);
+        return sendBtCommandWaitResponse(config, cmd, "OK", COMMAND_WAIT);
 }
 
 static const char * baudConfigCmdForRate(unsigned int baudRate)
 {
-    switch (baudRate) {
-    case 9600:
-        return "AT+BAUD4";
-        break;
-    case 115200:
-        return "AT+BAUD8";
-        break;
-    case 230400:
-        return "AT+BAUD9";
-        break;
-    default:
-        break;
-    }
-    pr_error_int_msg("invalid BT baud", baudRate);
-    return "";
+        switch (baudRate) {
+        case 9600:
+                return "AT+BAUD4";
+        case 57600:
+                return "AT+BAUD7";
+        case 115200:
+                return "AT+BAUD8";
+        case 230400:
+                return "AT+BAUD9";
+        }
+
+        pr_error_int_msg("invalid BT baud", baudRate);
+        return "";
 }
 
-static int configureBt(DeviceConfig *config, unsigned int targetBaud, const char * deviceName)
+static int set_check_bt_serial_baud(DeviceConfig *config, int baud)
 {
-    pr_info_int_msg("BT: Configuring baud Rate", targetBaud);
-    //set baud rate
-    if (!sendCommand(config, baudConfigCmdForRate(targetBaud)))
-        return -1;
-    config->serial->init(8, 0, 1, targetBaud);
-
-    //set Device Name
-    char btName[30];
-    strcpy(btName, "AT+NAME");
-    strcat(btName, deviceName);
-    pr_info_str_msg("BT: Configuring name", btName);
-    if (!sendBtCommandWaitResponse(config, btName, "OK", COMMAND_WAIT))
-        return -2;
-    return 0;
+        /* Change the baud and give things a bit to catch up */
+        config->serial->init(8, 0, 1, baud);
+        delayMs(BT_CMD_BACKOFF_MS);
+        return sendCommand(config, "AT");
 }
 
-static int bt_probe_config(unsigned int probeBaud, unsigned int targetBaud, const char * deviceName,
-                           DeviceConfig *config)
+static int bt_set_baud(DeviceConfig *config, unsigned int targetBaud)
 {
-    pr_info_int_msg("BT: Probing baud ", probeBaud);
-    config->serial->init(8, 0, 1, probeBaud);
-    int rc;
-    if (sendCommand(config, "AT")
-        && (targetBaud == probeBaud || configureBt(config, targetBaud, deviceName) == 0)) {
-        rc = DEVICE_INIT_SUCCESS;
-    } else {
-        rc = DEVICE_INIT_FAIL;
-    }
-    pr_info_str_msg("BT: Provision ", rc == DEVICE_INIT_SUCCESS ? "win" : "fail");
-    return rc;
+        pr_info_int_msg("BT: Setting baud to ", targetBaud);
+
+        if (!sendCommand(config, "AT+PN"))
+                return -2;
+
+        if (!sendCommand(config, baudConfigCmdForRate(targetBaud)))
+                return -1;
+
+        return set_check_bt_serial_baud(config, targetBaud);
+}
+
+static bool bt_get_version(DeviceConfig *config)
+{
+        pr_info("BT: Retrieving version info\r\n");
+
+        char *msg = "AT+VERSION";
+        if (!sendCommand(config, msg))
+                return false;
+
+        /* Strip the leading "OK" */
+        pr_info_str_msg("BT: Version Info: ", config->buffer + 2);
+        return strlen(config->buffer) > 0;
+}
+
+static int bt_set_name(DeviceConfig *config, const char *bt_name)
+{
+        pr_info_str_msg("BT: Setting name: ", bt_name);
+
+        char buf[BT_MAX_NAME_LEN + 7 + 1] = "AT+NAME";
+        strlcpy(buf + 7, bt_name, BT_MAX_NAME_LEN + 1);
+
+        return sendBtCommandWaitResponse(config, buf, "OKsetname",
+                                         COMMAND_WAIT);
+}
+
+static int bt_set_pin(DeviceConfig *config, const char *pin_str)
+{
+        pr_info_str_msg("BT: Setting pin: ", pin_str);
+
+        char buf[BT_MAX_PIN_LEN + 6 + 1] = "AT+PIN";
+        strlcpy(buf + 6, pin_str, BT_MAX_PIN_LEN + 1);
+
+        return sendBtCommandWaitResponse(config, buf, "OKsetPIN", COMMAND_WAIT);
+}
+
+
+static bool bt_find_working_baud(DeviceConfig *config, const int targetBaud)
+{
+        pr_info("BT: Searching for working baud rate...\r\n");
+
+        const int rates[] = {targetBaud, 230400, 115200, 57600, 9600};
+        size_t i = 0;
+        for (; i < sizeof(rates); ++i) {
+                if(set_check_bt_serial_baud(config, rates[i]))
+                        break;
+        }
+
+        /* Check that we didn't fail to find a workable rate */
+        if (i == sizeof(rates)) {
+                pr_info("BT: Unable to communicate with device.\r\n");
+                return false;
+        }
+
+        pr_info_int_msg("BT: Talking with BT device.  Baud: ", rates[i]);
+        return true;
 }
 
 int bt_disconnect(DeviceConfig *config)
@@ -138,27 +187,33 @@ int bt_init_connection(DeviceConfig *config)
     BluetoothConfig *btConfig = &(getWorkingLoggerConfig()->ConnectivityConfigs.bluetoothConfig);
     unsigned int targetBaud = btConfig->baudRate;
     const char *deviceName = btConfig->deviceName;
+    const char *pin = btConfig->passcode;
 
-    //give a chance for BT module to init
+    /* give a chance for BT module to init */
     delayMs(BT_INIT_DELAY);
 
-    // Zero terminated
-    const int rates[] = { 115200, 9600, 230400, 0 };
-    const int *rate = rates;
-    for (; *rate != 0; ++rate) {
-        const int status = bt_probe_config(*rate, targetBaud, deviceName, config);
-        if (status == 0)
-            break;
-    }
+    /*
+     * The HC-O6 seems to sometimes have trouble dealing with long AT commands.
+     * Namely at high speed it seems that the device can't process certain AT
+     * commands fast enough, causing an empty response.  To get past this, we
+     * set the baud rate while programming down to factory level (9600).  This
+     * ensures things go slow enough for the HC-06 processor + code.
+     */
+    const bool status =
+            bt_find_working_baud(config, targetBaud) &&
+            bt_set_baud(config, BT_AT_CMD_BAUD) &&
+            bt_get_version(config) &&
+            bt_set_name(config, deviceName) &&
+            bt_set_pin(config, pin) &&
+            bt_set_baud(config, targetBaud);
 
-    if (*rate > 0) {
+    if (status) {
         pr_info("BT: Init complete\r\n");
         g_bluetooth_status = BT_STATUS_PROVISIONED;
     } else {
-        pr_info("BT: Failed to provision module. Assuming already connected.\r\n");
+        pr_info("BT: Failed to provision module.\r\n");
         g_bluetooth_status = BT_STATUS_ERROR;
     }
-    config->serial->init(8, 0, 1, targetBaud);
 
     return DEVICE_INIT_SUCCESS;
 }

--- a/src/devices/bluetooth.c
+++ b/src/devices/bluetooth.c
@@ -63,7 +63,7 @@ void putsBt(DeviceConfig *config, const char *data)
 static int sendBtCommandWaitResponse(DeviceConfig *config, const char *cmd,
                                      const char *rsp, const size_t wait)
 {
-        pr_debug_str_msg("BT: cmd: ", cmd);
+        pr_trace_str_msg("BT: cmd: ", cmd);
 
         flushBt(config);
         putsBt(config, cmd);
@@ -71,9 +71,9 @@ static int sendBtCommandWaitResponse(DeviceConfig *config, const char *cmd,
 
         const bool res = 0 == strncmp(config->buffer, rsp, strlen(rsp));
 
-        pr_debug_str_msg("BT: wanted rsp: ", rsp);
-        pr_debug_str_msg("BT: actual rsp: ", config->buffer);
-        pr_debug_int_msg("BT: matched: ", res);
+        pr_trace_str_msg("BT: wanted rsp: ", rsp);
+        pr_trace_str_msg("BT: actual rsp: ", config->buffer);
+        pr_trace_int_msg("BT: matched: ", res);
 
         /* Put a little time between commands for the BT unit to catch up */
         delayMs(BT_CMD_BACKOFF_MS);
@@ -162,7 +162,7 @@ static int bt_set_pin(DeviceConfig *config, const char *pin_str)
 
 static bool bt_find_working_baud(DeviceConfig *config, const int targetBaud)
 {
-        pr_info("BT: Searching for working baud rate...\r\n");
+        pr_info("BT: Detecting baud rate...\r\n");
 
         const int rates[] = {targetBaud, 230400, 115200, 57600, 9600};
         size_t i = 0;
@@ -173,11 +173,11 @@ static bool bt_find_working_baud(DeviceConfig *config, const int targetBaud)
 
         /* Check that we didn't fail to find a workable rate */
         if (i == sizeof(rates)) {
-                pr_info("BT: Unable to communicate with device.\r\n");
+                pr_info("BT: Could not detect on known baud rates.\r\n");
                 return false;
         }
 
-        pr_info_int_msg("BT: Talking with BT device.  Baud: ", rates[i]);
+        pr_info_int_msg("BT: Device responds at baud ", rates[i]);
         return true;
 }
 
@@ -217,9 +217,8 @@ int bt_init_connection(DeviceConfig *config)
                 pr_info("BT: Init complete\r\n");
                 g_bluetooth_status = BT_STATUS_PROVISIONED;
         } else {
-                pr_info("BT: Failed to provision module.  This may "
-                        "be caused by a device connecting to the BT "
-                        "module.\r\n");
+                pr_info("BT: Failed to provision module. A client may "
+                        "already be connected.\r\n");
                 g_bluetooth_status = BT_STATUS_ERROR;
         }
 

--- a/src/devices/bluetooth.c
+++ b/src/devices/bluetooth.c
@@ -217,7 +217,9 @@ int bt_init_connection(DeviceConfig *config)
                 pr_info("BT: Init complete\r\n");
                 g_bluetooth_status = BT_STATUS_PROVISIONED;
         } else {
-                pr_info("BT: Failed to provision module.\r\n");
+                pr_info("BT: Failed to provision module.  This may "
+                        "be caused by a device connecting to the BT "
+                        "module.\r\n");
                 g_bluetooth_status = BT_STATUS_ERROR;
         }
 

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -19,6 +19,7 @@
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "cpu.h"
 #include "loggerConfig.h"
 #include "memory.h"
 #include "mod_string.h"
@@ -167,9 +168,36 @@ static void resetTrackConfig(TrackConfig *cfg)
     cfg->auto_detect = DEFAULT_TRACK_AUTO_DETECT;
 }
 
+static void generate_bt_name(char *buf, const size_t len)
+{
+        const char *pfx = DEFAULT_BT_DEVICE_NAME;
+        strlcpy(buf, pfx, len);
+
+        const char *serial = cpu_get_serialnumber();
+        if (NULL == serial)
+                return;
+
+        const size_t pfx_len = strlen(pfx);
+        const size_t serial_len = strlen(serial);
+        if (len - pfx_len < 5 || serial_len < 4)
+                return;
+
+        /*
+         * Add "-XXXX" as a suffix where X denotes the last 4 characters
+         * of the CPU serial number.  By this point we know it exists.
+         */
+        buf += pfx_len;
+        *buf = '-';
+        strcpy(++buf, serial + serial_len - 4);
+}
+
 static void resetBluetoothConfig(BluetoothConfig *cfg)
 {
-    *cfg = (BluetoothConfig) DEFAULT_BT_CONFIG;
+        *cfg = (BluetoothConfig) DEFAULT_BT_CONFIG;
+
+        char buf[sizeof(cfg->deviceName)];
+        generate_bt_name(buf, sizeof(buf));
+        strlcpy(cfg->deviceName, buf, sizeof(buf));
 }
 
 static void resetCellularConfig(CellularConfig *cfg)


### PR DESCRIPTION
This patch set improves our BT stack by

* Making BT device names unique by appending last 4 digits of device serial.
* Fixes up issues observed while programming BT unit
* Adds support for programming BT PIN
* Fixes various minor bugs.

This is safe to merge against 2.8.6 as this change does not adjust the LoggerConfig struct size in any way.  The BT name change will only apply after the device undergoes a reset.