### PR TITLE
Fix telemetry destination

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,9 @@
   issues observed in BT module during programming as well.
 * Added Lua sleep() function. When called will sleep for the specified number
   of milliseconds
+* Changed telemetry destination from race-capture.com to
+  telemetry.race-capture.com.  This is so that we can better work with
+  Cloudflare.
 
 === 2.8.5 ===
 * Increased GPS task stack size from 200 to 256 to prevent HULK smash.

--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -448,7 +448,7 @@ typedef struct _CellularConfig {
 #define TELEMETRY_SERVER_HOST_LENGTH 100
 
 #define DEFAULT_DEVICE_ID ""
-#define DEFAULT_TELEMETRY_SERVER_HOST "race-capture.com"
+#define DEFAULT_TELEMETRY_SERVER_HOST "telemetry.race-capture.com"
 
 #define BACKGROUND_STREAMING_ENABLED				1
 #define BACKGROUND_STREAMING_DISABLED				0

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -211,7 +211,8 @@ static void resetTelemetryConfig(TelemetryConfig *cfg)
 {
     memset(cfg, 0, sizeof(TelemetryConfig));
     cfg->backgroundStreaming = BACKGROUND_STREAMING_ENABLED;
-    strcpy(cfg->telemetryServerHost, DEFAULT_TELEMETRY_SERVER_HOST);
+    strncpy(cfg->telemetryServerHost, DEFAULT_TELEMETRY_SERVER_HOST,
+            sizeof(cfg->telemetryServerHost));
 }
 
 static void resetConnectivityConfig(ConnectivityConfig *cfg)


### PR DESCRIPTION
Changes the destination of telemetry data to `telemetry.race-capture.com`.  This is so that we may better work with Cloudflare.

This resolves issue https://github.com/autosportlabs/RaceCapture-Pro_firmware/issues/341