### PR TITLE
Move LUA Magic Number to front of struct

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,8 @@
   telemetry.race-capture.com.  This is so that we can better work with
   Cloudflare.
 * Remove MK1 code from mainstream dev tree and migrate to legacy branch.
+* Moves LUA magic number to the front of the LUA memory block so that the number
+  won't move if this block gets resized.
 
 === 2.8.5 ===
 * Increased GPS task stack size from 200 to 256 to prevent HULK smash.

--- a/include/lua/luaScript.h
+++ b/include/lua/luaScript.h
@@ -45,8 +45,8 @@ enum script_add_mode {
 #define MAX_SCRIPT_PAGES	(SCRIPT_MEMORY_LENGTH / SCRIPT_PAGE_SIZE)
 
 typedef struct _ScriptConfig {
-        char script[SCRIPT_MEMORY_LENGTH - 4];
         uint32_t magicInit;
+        char script[SCRIPT_MEMORY_LENGTH - 4];
 } ScriptConfig;
 
 void initialize_script();

--- a/src/lua/luaScript.c
+++ b/src/lua/luaScript.c
@@ -29,7 +29,8 @@
 #ifndef RCP_TESTING
 static const volatile ScriptConfig g_scriptConfig  __attribute__((section(".script\n\t#")));
 #else
-static ScriptConfig g_scriptConfig = {DEFAULT_SCRIPT, MAGIC_NUMBER_SCRIPT_INIT};
+static ScriptConfig g_scriptConfig = {MAGIC_NUMBER_SCRIPT_INIT,
+                                      DEFAULT_SCRIPT};
 #endif
 
 void initialize_script()


### PR DESCRIPTION
This way if the size of the LUA data area changes the location of the magic number won't change.  Fixes #176 