### PR TITLE
MOAR fixes for BT.  Fast init support. Name + PIN change support.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,8 +7,6 @@
   sensitivity (8x more to be precise).
 * Improve the MK2 compilation routine by adding stricter warning flags and
   by making all warnings into errors.
-* Add uniqueness to BT device name by appending last 4 digits of unit serial
-  to the BT device.  Applies after logger reset.
 * Fix up BT code so that we now properly set BT name and Pin.  Addresses race
   issues observed in BT module during programming as well.
 * Added Lua sleep() function. When called will sleep for the specified number
@@ -21,7 +19,7 @@
   won't move if this block gets resized.
 * Fixes a bug in start logic in the lap_stats code and adds 12 new unit
   tests to better ensure the stability of that code.
-* Added Lua bitOp bitwise operations 
+* Added Lua bitOp bitwise operations
 * Converted Lua base number to double from float (allows 29 bit CAN IDs to work correctly)
 
 === 2.8.6 ===

--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -28,6 +28,7 @@
 #include "capabilities.h"
 #include "versionInfo.h"
 
+#include <stdbool.h>
 #include <stddef.h>
 
 CPP_GUARD_BEGIN
@@ -434,24 +435,15 @@ typedef struct _TrackConfig {
 
 #define BT_DEVICE_NAME_LENGTH 21
 #define BT_PASSCODE_LENGTH 5
-#define DEFAULT_BT_DEVICE_NAME "RaceCapturePro"
-#define DEFAULT_BT_PASSCODE "0000"
 #define DEFAULT_BT_BAUD 115200
 #define DEFAULT_BT_ENABLED 1
 
 typedef struct _BluetoothConfig {
-    unsigned char btEnabled;
-    char deviceName [BT_DEVICE_NAME_LENGTH];
-    char passcode [BT_PASSCODE_LENGTH];
-    unsigned int baudRate;
+        unsigned char btEnabled;
+        unsigned int baudRate;
+        char new_name [BT_DEVICE_NAME_LENGTH];
+        char new_pin [BT_PASSCODE_LENGTH];
 } BluetoothConfig;
-
-#define DEFAULT_BT_CONFIG { \
-	DEFAULT_BT_ENABLED, \
-	DEFAULT_BT_DEVICE_NAME, \
-	DEFAULT_BT_PASSCODE, \
-	DEFAULT_BT_BAUD \
-}
 
 #define CELL_APN_HOST_LENGTH 30
 #define CELL_APN_USER_LENGTH 30

--- a/src/devices/bluetooth.c
+++ b/src/devices/bluetooth.c
@@ -44,6 +44,8 @@
  */
 #define BT_BACKOFF_MS	1000
 #define BT_COMMAND_WAIT	600
+#define BT_DEFAULT_NAME	"RaceCapturePro"
+#define BT_DEFAULT_PIN	"1234"
 #define BT_DBG_LOG_LVL	TRACE
 #define BT_MAX_NAME_LEN	(BT_DEVICE_NAME_LENGTH - 1)
 #define BT_MAX_PIN_LEN	(BT_PASSCODE_LENGTH - 1)
@@ -138,9 +140,6 @@ static int bt_set_baud(DeviceConfig *config, unsigned int targetBaud)
 
 static bool bt_set_name(DeviceConfig *config, const char *new_name)
 {
-        if ('\0' == *new_name)
-                return true;
-
         pr_info_str_msg("BT: Setting name: ", new_name);
 
         char buf[BT_MAX_NAME_LEN + 7 + 1] = "AT+NAME";
@@ -152,9 +151,6 @@ static bool bt_set_name(DeviceConfig *config, const char *new_name)
 
 static bool bt_set_pin(DeviceConfig *config, const char *new_pin)
 {
-        if ('\0' == *new_pin)
-                return true;
-
         pr_info_str_msg("BT: Setting pin: ", new_pin);
 
         char buf[BT_MAX_PIN_LEN + 6 + 1] = "AT+PIN";
@@ -239,15 +235,15 @@ int bt_init_connection(DeviceConfig *config)
                 pr_info("BT: Detected factory settings.  Assuming not "
                         "configured. Initializing...\r\n");
                 /* Doing this allows us to set the name without reflashing */
-                new_name = "RaceCapturePro";
-                new_pin = "1234";
+                new_name = BT_DEFAULT_NAME;
+                new_pin = BT_DEFAULT_PIN;
                 break;
         }
 
         const bool status =
                 baud &&
-                bt_set_name(config, new_name) &&
-                bt_set_pin(config, new_pin) &&
+                ('\0' == *new_name || bt_set_name(config, new_name)) &&
+                ('\0' == *new_pin ||bt_set_pin(config, new_pin)) &&
                 (baud == targetBaud || bt_set_baud(config, targetBaud));
 
         if (status) {

--- a/src/devices/bluetooth.c
+++ b/src/devices/bluetooth.c
@@ -30,12 +30,25 @@
 
 #include <stdbool.h>
 
-#define BT_AT_CMD_BAUD	9600
-#define BT_CMD_BACKOFF_MS	5
-#define BT_INIT_DELAY   100
-#define BT_MAX_NAME_LEN	20
-#define BT_MAX_PIN_LEN	4
-#define COMMAND_WAIT 	600
+/*
+ * https://www.olimex.com/Products/Components/RF/BLUETOOTH-SERIAL-HC-06/resources/hc06.pdf
+ *
+ * Doc specifies 1000ms between commands.  Unit need ~500ms pause to then
+ * parse the command and send a reply.  Give it 100ms to reply so that makes
+ * the BT_COMMAND_WAIT time 600ms.  Give it 3 chances to respond to an AT
+ * ping before we try another baud.
+ *
+ * BE WARNED... it took a bit of trial and error to come to these parameters
+ * but they seem to be very stable (even with name + pin changes).  Adjust at
+ * your own peril.
+ */
+#define BT_BACKOFF_MS	1000
+#define BT_COMMAND_WAIT	600
+#define BT_DBG_LOG_LVL	TRACE
+#define BT_MAX_NAME_LEN	(BT_DEVICE_NAME_LENGTH - 1)
+#define BT_MAX_PIN_LEN	(BT_PASSCODE_LENGTH - 1)
+#define BT_PING_TRIES	3
+
 
 static bluetooth_status_t g_bluetooth_status = BT_STATUS_NOT_INIT;
 
@@ -64,7 +77,8 @@ void putsBt(DeviceConfig *config, const char *data)
 static int sendBtCommandWaitResponse(DeviceConfig *config, const char *cmd,
                                      const char *rsp, const size_t wait)
 {
-        pr_trace_str_msg("BT: cmd: ", cmd);
+        /* Put a little time between commands for the BT unit to catch up */
+        delayMs(BT_BACKOFF_MS);
 
         flushBt(config);
         putsBt(config, cmd);
@@ -72,19 +86,17 @@ static int sendBtCommandWaitResponse(DeviceConfig *config, const char *cmd,
 
         const bool res = 0 == strncmp(config->buffer, rsp, strlen(rsp));
 
-        pr_trace_str_msg("BT: wanted rsp: ", rsp);
-        pr_trace_str_msg("BT: actual rsp: ", config->buffer);
-        pr_trace_int_msg("BT: matched: ", res);
-
-        /* Put a little time between commands for the BT unit to catch up */
-        delayMs(BT_CMD_BACKOFF_MS);
+        printk_str_msg(BT_DBG_LOG_LVL, "BT: cmd given: ", cmd);
+        printk_str_msg(BT_DBG_LOG_LVL, "BT: rsp expected: ", rsp);
+        printk_str_msg(BT_DBG_LOG_LVL, "BT: rsp received: ", config->buffer);
+        printk_str_msg(BT_DBG_LOG_LVL, "BT: match: ", res ? "YES" : "NO");
 
         return res;
 }
 
 static int sendCommand(DeviceConfig *config, const char * cmd)
 {
-        return sendBtCommandWaitResponse(config, cmd, "OK", COMMAND_WAIT);
+        return sendBtCommandWaitResponse(config, cmd, "OK", BT_COMMAND_WAIT);
 }
 
 static const char * baudConfigCmdForRate(unsigned int baudRate)
@@ -96,8 +108,6 @@ static const char * baudConfigCmdForRate(unsigned int baudRate)
                 return "AT+BAUD7";
         case 115200:
                 return "AT+BAUD8";
-        case 230400:
-                return "AT+BAUD9";
         }
 
         pr_error_int_msg("invalid BT baud", baudRate);
@@ -106,18 +116,19 @@ static const char * baudConfigCmdForRate(unsigned int baudRate)
 
 static int set_check_bt_serial_baud(DeviceConfig *config, int baud)
 {
+        int rc = false;
+
         /* Change the baud and give things a bit to catch up */
         config->serial->init(8, 0, 1, baud);
-        delayMs(BT_CMD_BACKOFF_MS);
-        return sendCommand(config, "AT");
+        for (size_t tries = BT_PING_TRIES; 0 < tries && !rc; --tries)
+                rc = sendCommand(config, "AT");
+
+        return rc;
 }
 
 static int bt_set_baud(DeviceConfig *config, unsigned int targetBaud)
 {
         pr_info_int_msg("BT: Setting baud to ", targetBaud);
-
-        if (!sendCommand(config, "AT+PN"))
-                return -2;
 
         if (!sendCommand(config, baudConfigCmdForRate(targetBaud)))
                 return -1;
@@ -125,66 +136,82 @@ static int bt_set_baud(DeviceConfig *config, unsigned int targetBaud)
         return set_check_bt_serial_baud(config, targetBaud);
 }
 
-static bool bt_get_version(DeviceConfig *config)
+static bool bt_set_name(DeviceConfig *config, const char *new_name)
 {
-        pr_info("BT: Retrieving version info\r\n");
+        if ('\0' == *new_name)
+                return true;
 
-        char *msg = "AT+VERSION";
-        if (!sendCommand(config, msg))
-                return false;
-
-        /* Strip the leading "OK" */
-        pr_info_str_msg("BT: Version Info: ", config->buffer + 2);
-        return strlen(config->buffer) > 0;
-}
-
-static int bt_set_name(DeviceConfig *config, const char *bt_name)
-{
-        pr_info_str_msg("BT: Setting name: ", bt_name);
+        pr_info_str_msg("BT: Setting name: ", new_name);
 
         char buf[BT_MAX_NAME_LEN + 7 + 1] = "AT+NAME";
-        strlcpy(buf + 7, bt_name, BT_MAX_NAME_LEN + 1);
+        strlcpy(buf + 7, new_name, BT_MAX_NAME_LEN + 1);
 
         return sendBtCommandWaitResponse(config, buf, "OKsetname",
-                                         COMMAND_WAIT);
+                                         BT_COMMAND_WAIT);
 }
 
-static int bt_set_pin(DeviceConfig *config, const char *pin_str)
+static bool bt_set_pin(DeviceConfig *config, const char *new_pin)
 {
-        pr_info_str_msg("BT: Setting pin: ", pin_str);
+        if ('\0' == *new_pin)
+                return true;
+
+        pr_info_str_msg("BT: Setting pin: ", new_pin);
 
         char buf[BT_MAX_PIN_LEN + 6 + 1] = "AT+PIN";
-        strlcpy(buf + 6, pin_str, BT_MAX_PIN_LEN + 1);
+        strlcpy(buf + 6, new_pin, BT_MAX_PIN_LEN + 1);
 
         return sendBtCommandWaitResponse(config, buf, "OKsetPIN",
-                                         COMMAND_WAIT);
+                                         BT_COMMAND_WAIT);
 }
 
-
-static bool bt_find_working_baud(DeviceConfig *config, const int targetBaud)
+static int bt_find_working_baud(DeviceConfig *config, BluetoothConfig *btc)
 {
         pr_info("BT: Detecting baud rate...\r\n");
 
-        const int rates[] = {targetBaud, 230400, 115200, 57600, 9600};
-        size_t i = 0;
-        for (; i < sizeof(rates); ++i) {
-                if(set_check_bt_serial_baud(config, rates[i]))
+        const int targetBaud = btc->baudRate;
+        const int rates[] = {targetBaud, 115200, 57600, 9600};
+        int rate = 0;
+        for (size_t i = 0; i < sizeof(rates)/sizeof(*rates); ++i) {
+                pr_info_int_msg("BT: Trying Baudrate: ", rates[i]);
+                if(set_check_bt_serial_baud(config, rates[i])) {
+                        rate = rates[i];
                         break;
+                }
         }
 
         /* Check that we didn't fail to find a workable rate */
-        if (i == sizeof(rates)) {
-                pr_info("BT: Could not detect on known baud rates.\r\n");
-                return false;
-        }
+        if (!rate)
+                pr_info("BT: Could not detect device using known baud "
+                        "rates.\r\n");
+        else
+                pr_info_int_msg("BT: Device responds at baud ", rate);
 
-        pr_info_int_msg("BT: Device responds at baud ", rates[i]);
-        return true;
+        return rate;
+}
+
+static void bt_clear_new_vals(BluetoothConfig *btc)
+{
+        /* If these values aren't set, then no action is required */
+        if ('\0' == btc->new_name[0] && '\0' == btc->new_pin[0])
+                return;
+
+        btc->new_name[0] = '\0';
+        btc->new_pin[0] = '\0';
+
+        /*
+         * Have to do this to ensure that we reset the new_name and new_pin
+         * variables after we change them in the BT device.  This is so
+         * we don't constantly re-program the BT unit (which causes it
+         * to unpair with any paired devices).
+         */
+        pr_info("BT: Resetting name/pin values in NVRAM\r\n");
+        flashLoggerConfig();
+        return;
 }
 
 int bt_disconnect(DeviceConfig *config)
 {
-        return 0; //NOOP
+        return 0; /* NOOP */
 }
 
 int bt_init_connection(DeviceConfig *config)
@@ -192,11 +219,8 @@ int bt_init_connection(DeviceConfig *config)
         BluetoothConfig *btConfig =
                 &(getWorkingLoggerConfig()->ConnectivityConfigs.bluetoothConfig);
         unsigned int targetBaud = btConfig->baudRate;
-        const char *deviceName = btConfig->deviceName;
-        const char *pin = btConfig->passcode;
-
-        /* give a chance for BT module to init */
-        delayMs(BT_INIT_DELAY);
+        const char *new_name = btConfig->new_name;
+        const char *new_pin = btConfig->new_pin;
 
         /*
          * The HC-O6 seems to sometimes have trouble dealing with long AT
@@ -206,16 +230,29 @@ int bt_init_connection(DeviceConfig *config)
          * factory level (9600).  This ensures things go slow enough for the
          * HC-06 processor + code to handle it.
          */
+        int baud = bt_find_working_baud(config, btConfig);
+        switch (baud) {
+        case 0:
+                pr_info("BT: Failed to communicate with device.\r\n");
+                break;
+        case 9600:
+                pr_info("BT: Detected factory settings.  Assuming not "
+                        "configured. Initializing...\r\n");
+                /* Doing this allows us to set the name without reflashing */
+                new_name = "RaceCapturePro";
+                new_pin = "1234";
+                break;
+        }
+
         const bool status =
-                bt_find_working_baud(config, targetBaud) &&
-                bt_set_baud(config, BT_AT_CMD_BAUD) &&
-                bt_get_version(config) &&
-                bt_set_name(config, deviceName) &&
-                bt_set_pin(config, pin) &&
-                bt_set_baud(config, targetBaud);
+                baud &&
+                bt_set_name(config, new_name) &&
+                bt_set_pin(config, new_pin) &&
+                (baud == targetBaud || bt_set_baud(config, targetBaud));
 
         if (status) {
                 pr_info("BT: Init complete\r\n");
+                bt_clear_new_vals(btConfig);
                 g_bluetooth_status = BT_STATUS_PROVISIONED;
         } else {
                 pr_info("BT: Failed to provision module. A client may "

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -839,8 +839,8 @@ int api_getBluetoothConfig(Serial *serial, const jsmntok_t *json)
     BluetoothConfig *cfg = &(getWorkingLoggerConfig()->ConnectivityConfigs.bluetoothConfig);
     json_objStart(serial);
     json_objStartString(serial, "btCfg");
-    json_string(serial, "name", cfg->deviceName, 1);
-    json_string(serial, "pass", cfg->passcode, 0);
+    json_string(serial, "name", cfg->new_name, 1);
+    json_string(serial, "pass", cfg->new_pin, 0);
     json_objEnd(serial, 0);
     json_objEnd(serial, 0);
     return API_SUCCESS_NO_RETURN;
@@ -888,8 +888,8 @@ static void setBluetoothConfig(const jsmntok_t *root)
         btCfgNode++;
         BluetoothConfig *btCfg = &(getWorkingLoggerConfig()->ConnectivityConfigs.bluetoothConfig);
         setUnsignedCharValueIfExists(btCfgNode, "btEn", &btCfg->btEnabled, NULL);
-        setStringValueIfExists(btCfgNode, "name", btCfg->deviceName, BT_DEVICE_NAME_LENGTH);
-        setStringValueIfExists(btCfgNode, "pass", btCfg->passcode, BT_PASSCODE_LENGTH);
+        setStringValueIfExists(btCfgNode, "name", btCfg->new_name, BT_DEVICE_NAME_LENGTH);
+        setStringValueIfExists(btCfgNode, "pass", btCfg->new_pin, BT_PASSCODE_LENGTH);
     }
 }
 
@@ -922,8 +922,8 @@ int api_getConnectivityConfig(Serial *serial, const jsmntok_t *json)
 
     json_objStartString(serial, "btCfg");
     json_int(serial, "btEn", cfg->bluetoothConfig.btEnabled, 1);
-    json_string(serial, "name", cfg->bluetoothConfig.deviceName, 1);
-    json_string(serial, "pass", cfg->bluetoothConfig.passcode, 0);
+    json_string(serial, "name", cfg->bluetoothConfig.new_name, 1);
+    json_string(serial, "pass", cfg->bluetoothConfig.new_pin, 0);
     json_objEnd(serial, 1);
 
     json_objStartString(serial, "cellCfg");

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -169,36 +169,12 @@ static void resetTrackConfig(TrackConfig *cfg)
     cfg->auto_detect = DEFAULT_TRACK_AUTO_DETECT;
 }
 
-static void generate_bt_name(char *buf, const size_t len)
-{
-        const char *pfx = DEFAULT_BT_DEVICE_NAME;
-        strlcpy(buf, pfx, len);
-
-        const char *serial = cpu_get_serialnumber();
-        if (NULL == serial)
-                return;
-
-        const size_t pfx_len = strlen(pfx);
-        const size_t serial_len = strlen(serial);
-        if (len - pfx_len < 5 || serial_len < 4)
-                return;
-
-        /*
-         * Add "-XXXX" as a suffix where X denotes the last 4 characters
-         * of the CPU serial number.  By this point we know it exists.
-         */
-        buf += pfx_len;
-        *buf = '-';
-        strcpy(++buf, serial + serial_len - 4);
-}
-
 static void resetBluetoothConfig(BluetoothConfig *cfg)
 {
-        *cfg = (BluetoothConfig) DEFAULT_BT_CONFIG;
-
-        char buf[sizeof(cfg->deviceName)];
-        generate_bt_name(buf, sizeof(buf));
-        strlcpy(cfg->deviceName, buf, sizeof(buf));
+        *cfg = (BluetoothConfig) {
+                .btEnabled = DEFAULT_BT_ENABLED,
+                .baudRate = DEFAULT_BT_BAUD,
+        };
 }
 
 static void resetCellularConfig(CellularConfig *cfg)

--- a/test/loggerApi_test.cpp
+++ b/test/loggerApi_test.cpp
@@ -470,8 +470,8 @@ void LoggerApiTest::testSetConnectivityCfgFile(string filename){
 	CPPUNIT_ASSERT_EQUAL(string("blorg"), string(connCfg->cellularConfig.apnPass));
 
 	CPPUNIT_ASSERT_EQUAL(1, (int)connCfg->bluetoothConfig.btEnabled);
-	CPPUNIT_ASSERT_EQUAL(string("myRacecar"), string(connCfg->bluetoothConfig.deviceName));
-	CPPUNIT_ASSERT_EQUAL(string("3311"), string(connCfg->bluetoothConfig.passcode));
+	CPPUNIT_ASSERT_EQUAL(string("myRacecar"), string(connCfg->bluetoothConfig.new_name));
+	CPPUNIT_ASSERT_EQUAL(string("3311"), string(connCfg->bluetoothConfig.new_pin));
 
 	CPPUNIT_ASSERT_EQUAL(1, (int)connCfg->telemetryConfig.backgroundStreaming);
 	CPPUNIT_ASSERT_EQUAL(string("xyz123"), string(connCfg->telemetryConfig.telemetryDeviceId));
@@ -486,8 +486,8 @@ void LoggerApiTest::testGetConnectivityCfg(){
 	LoggerConfig *c = getWorkingLoggerConfig();
 	ConnectivityConfig *connCfg = &c->ConnectivityConfigs;
 
-	strcpy(connCfg->bluetoothConfig.deviceName, "btDevName");
-	strcpy(connCfg->bluetoothConfig.passcode, "6543");
+	strcpy(connCfg->bluetoothConfig.new_name, "btDevName");
+	strcpy(connCfg->bluetoothConfig.new_pin, "6543");
 
 	strcpy(connCfg->cellularConfig.apnHost, "apnHost");
 	strcpy(connCfg->cellularConfig.apnUser, "apnUser");
@@ -500,8 +500,8 @@ void LoggerApiTest::testGetConnectivityCfg(){
 	Object &connJson = json["connCfg"];
 
 	CPPUNIT_ASSERT_EQUAL((int)(connCfg->bluetoothConfig.btEnabled), (int)(Number)connJson["btCfg"]["btEn"]);
-	CPPUNIT_ASSERT_EQUAL(string(connCfg->bluetoothConfig.deviceName), string((String)connJson["btCfg"]["name"]));
-	CPPUNIT_ASSERT_EQUAL(string(connCfg->bluetoothConfig.passcode), string((String)connJson["btCfg"]["pass"]));
+	CPPUNIT_ASSERT_EQUAL(string(connCfg->bluetoothConfig.new_name), string((String)connJson["btCfg"]["name"]));
+	CPPUNIT_ASSERT_EQUAL(string(connCfg->bluetoothConfig.new_pin), string((String)connJson["btCfg"]["pass"]));
 
 	CPPUNIT_ASSERT_EQUAL((int)(connCfg->cellularConfig.cellEnabled), (int)(Number)connJson["cellCfg"]["cellEn"]);
 	CPPUNIT_ASSERT_EQUAL(string(connCfg->cellularConfig.apnHost), string((String)connJson["cellCfg"]["apnHost"]));

--- a/test/loggerConfig_test.cpp
+++ b/test/loggerConfig_test.cpp
@@ -231,14 +231,8 @@ void LoggerConfigTest::testLoggerInitConnectivityConfig() {
 
    BluetoothConfig *btc = &lc->ConnectivityConfigs.bluetoothConfig;
 
-   /* Generate the expected name */
-   const char *cpu_serial_str = cpu_get_serialnumber();
-   const size_t len = strlen(cpu_serial_str);
-   string expected_name = string(DEFAULT_BT_DEVICE_NAME) + "-" +
-           string(cpu_serial_str + len - 4);
-
-   CPPUNIT_ASSERT_EQUAL(string(expected_name), string(btc->deviceName));
-   CPPUNIT_ASSERT_EQUAL(string(DEFAULT_BT_PASSCODE), string(btc->passcode));
+   CPPUNIT_ASSERT_EQUAL(string(""), string(btc->new_name));
+   CPPUNIT_ASSERT_EQUAL(string(""), string(btc->new_pin));
    CPPUNIT_ASSERT_EQUAL(DEFAULT_BT_ENABLED, (int) btc->btEnabled);
 
    CellularConfig *cc = &lc->ConnectivityConfigs.cellularConfig;


### PR DESCRIPTION
Ok... so there is a lot happening here.  Here is the brief overview:

* Setting the PIN causes BT to need to re-pair with devices.  Because
  of this, we must only set the PIN when a user requests a change.
  This is implemented here.

* Adjust the init process to be as fast as possible.  This is because
  there is a race condition between the initialization code and a
  BT device trying to pair with the unit.  If the BT device connects,
  it makes init impossible.  Thus this code must do only what is
  necessary.  Killed version info and dropping baud down to 9600
  as a result

* Implement legacy init behavior.  To be inline with what the original
  BT code did, we must detect factory settings on the HC-06 and set
  RCP defaults.  We do this by no longer setting the 9600 baud and
  looking for it during init.  If we see it, we assume its never been
  initialized (beacuse 9600 baud is the default from the factory)
  and initialize it accordingly.

* Add re-try logic to the baud probing.  Because the unit can't move
  as fast as we do.  Thus we need to be a bit flexible.

* Adjust the communication parameters to SANE values.  This thing is
  slow and works in wonkey ways (like expecting a 500ms pause before
  interpreting the AT command).  So this change adjusts those parameters
  to reflect this behavior yet move as fast as the module will allow.
  Adjust these at your own peril.

Did I miss anything... probably.  But that is what you need to know.

Enjoy!

Issues: #379