### PR TITLE
Remove "obd2SampleRate" value from OBD2Config struct

### DIFF
--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -315,18 +315,14 @@ typedef struct _PidConfig {
 
 typedef struct _OBD2Config {
     unsigned char enabled;
-    unsigned char obd2SampleRate;
     unsigned short enabledPids;
     PidConfig pids[OBD2_CHANNELS];
 } OBD2Config;
 
 #define DEFAULT_ENABLED_PIDS 1
-#define DEFAULT_OBD2_SAMPLE_RATE SAMPLE_10Hz
-
 #define DEFAULT_OBD2_CONFIG \
 { \
 	CONFIG_FEATURE_NOT_INSTALLED, \
-	DEFAULT_OBD2_SAMPLE_RATE, \
 	DEFAULT_ENABLED_PIDS, \
 	{ \
 		{{"RPM", "", 0, 10000, SAMPLE_10Hz, 0, 0}, 12}, \

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -143,7 +143,6 @@ static void resetCanConfig(CANConfig *cfg)
 static void resetOBD2Config(OBD2Config *cfg)
 {
     memset(cfg, 0, sizeof(OBD2Config));
-    cfg->obd2SampleRate = SAMPLE_10Hz;
 
     for (int i = 0; i < OBD2_CHANNELS; ++i) {
         PidConfig *c = &cfg->pids[i];


### PR DESCRIPTION
Its not used.  So nuke it from orbit.

Issues: #164