### PR TITLE
report correct values for min/max in filewriter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+=== 2.8.7 ===
+* Report correct min/max values in logfile 
+
 === 2.8.6 ===
 * Make OBD-II engine report temperature and speed that match channel defaults (deg. F / MPH)
 * Improved accuracy of IMU

--- a/src/logger/fileWriter.c
+++ b/src/logger/fileWriter.c
@@ -145,9 +145,9 @@ static int write_samples_header(const LoggerMessage *msg)
                 append_file_buffer("|");
                 appendQuotedString(sample->cfg->units);
                 append_file_buffer("|");
-                appendFloat(decodeSampleRate(sample->cfg->min), precision);
+                appendFloat(sample->cfg->min, precision);
                 append_file_buffer("|");
-                appendFloat(decodeSampleRate(sample->cfg->max), precision);
+                appendFloat(sample->cfg->max, precision);
                 append_file_buffer("|");
                 appendInt(decodeSampleRate(sample->cfg->sampleRate));
         }


### PR DESCRIPTION
min / max from meta data was incorrectly filtered through sample rate decoder. Fix this defect.