### PR TITLE
Add timeout support to the CAN Tx method on MK2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 === 2.9.0 ===
+* Add timeout support for CAN Tx method on MK2.  A value of 0 means
+  never timeout.
 * Improve the USART code for MK1 by removing duplicated code,
   eliminating externs, and cleaning up the handling of character
   queues.


### PR DESCRIPTION
Previously ignored the timeout value and always assumed that the
message would send in time.  Now we will pay attention to the value
and will cancel the message if it has not sent in the specified
timeout.

A timeout value of 0 means we don't care whether it sent or not and
will always return success.

Issue: #404