### PR TITLE
Fix Lua Stack Smash. Improve OpenOCD Debug capabilities.

### DIFF
--- a/src/lua/luaTask.c
+++ b/src/lua/luaTask.c
@@ -45,7 +45,8 @@
 
 #define DEFAULT_ONTICK_HZ 1
 #define MAX_ONTICK_HZ 30
-#define LUA_STACK_SIZE 1000
+/* Set this high as the parser can get very stack hungry.  Issue #411 */
+#define LUA_STACK_SIZE 1536
 #define LUA_PERIODIC_FUNCTION "onTick"
 
 #define LUA_BYPASS_FLASH_DELAY 250

--- a/src/util/FreeRTOS-openocd.c
+++ b/src/util/FreeRTOS-openocd.c
@@ -1,0 +1,20 @@
+/*
+ * Since at least FreeRTOS V7.5.3 uxTopUsedPriority is no longer
+ * present in the kernel, so it has to be supplied by other means for
+ * OpenOCD's threads awareness.
+ *
+ * Add this file to your project, and, if you're using --gc-sections,
+ * ``--undefined=uxTopUsedPriority'' (or
+ * ``-Wl,--undefined=uxTopUsedPriority'' when using gcc for final
+ * linking) to your LDFLAGS; same with all the other symbols you need.
+ */
+
+#include "FreeRTOS.h"
+
+#ifdef __GNUC__
+#define USED __attribute__((used))
+#else
+#define USED
+#endif
+
+const int USED uxTopUsedPriority = configMAX_PRIORITIES;

--- a/stm32_base/FreeRTOSConfig.h
+++ b/stm32_base/FreeRTOSConfig.h
@@ -52,10 +52,13 @@
 #define configQUEUE_REGISTRY_SIZE	10
 #define configGENERATE_RUN_TIME_STATS	0
 #define configUSE_STATS_FORMATTING_FUNCTIONS 1
-#define configCHECK_FOR_STACK_OVERFLOW	0
 #define configUSE_RECURSIVE_MUTEXES	1
 #define configUSE_MALLOC_FAILED_HOOK	0
 #define configUSE_APPLICATION_TASK_TAG	0
+
+#if defined(_DEBUG)
+#define configCHECK_FOR_STACK_OVERFLOW	2
+#endif /* _DEBUG */
 
 /* Co-routine definitions. */
 #define configUSE_CO_ROUTINES 		0

--- a/stm32_base/Makefile
+++ b/stm32_base/Makefile
@@ -64,6 +64,11 @@ INCLUDES += $(CPU_INCLUDES) $(BOARD_INCLUDES) $(LIB_INCLUDES) $(APP_INCLUDES) $(
 CFLAGS += $(INCLUDES) $(CPU_DEFINES) $(BOARD_DEFINES) $(APP_DEFINES) $(CPU_FLAGS)
 ASFLAGS += -mcpu=$(CPU_TYPE) $(FPU) -g -Wa,--warn
 
+ifdef DEBUG
+CFLAGS += -D_DEBUG
+endif
+
+
 LIBS = -lnosys
 LIBS += $(addprefix -l,$(BASE_LIBS))
 LIBS += $(addprefix -l,$(LUA_LIBS))

--- a/stm32_base/Makefile
+++ b/stm32_base/Makefile
@@ -68,10 +68,12 @@ LIBS = -lnosys
 LIBS += $(addprefix -l,$(BASE_LIBS))
 LIBS += $(addprefix -l,$(LUA_LIBS))
 
+FREERTOS_LD_FLAGS := -Wl,--undefined=uxTopUsedPriority
+
 LDFLAGS ?= --specs=nano.specs -lc -lgcc $(LIBS) -mcpu=$(CPU_TYPE) -g -ggdb \
-	-L. -Lcpu/common -L$(LUA_LIB_DIR) -L$(CPU_BASE) -T$(CPU_LINK_MEM) -Tlink_sections.ld \
-	-nostartfiles -Wl,--gc-sections -mthumb -mcpu=$(CPU_TYPE) \
-	-msoft-float
+	-L. -Lcpu/common -L$(LUA_LIB_DIR) -L$(CPU_BASE) -T$(CPU_LINK_MEM) \
+	-Tlink_sections.ld -nostartfiles -Wl,--gc-sections -mthumb \
+	-mcpu=$(CPU_TYPE) -msoft-float $(FREERTOS_LD_FLAGS)
 
 # Be silent per default, but 'make V=1' will show all compiler calls.
 ifneq ($(V),1)

--- a/stm32_base/config.mk
+++ b/stm32_base/config.mk
@@ -104,6 +104,7 @@ APP_SRC = 	$(APP_PATH)/main.c \
 			$(RCP_SRC)/virtual_channel/virtual_channel.c \
 			$(RCP_SRC)/memory/memory.c \
 			$(RCP_SRC)/util/linear_interpolate.c \
+			$(RCP_SRC)/util/FreeRTOS-openocd.c \
 			$(RCP_SRC)/util/modp_atonum.c \
 			$(RCP_SRC)/util/modp_numtoa.c \
 			$(RCP_SRC)/util/byteswap.c \

--- a/stm32_base/gdb_stlinkv2.gdb
+++ b/stm32_base/gdb_stlinkv2.gdb
@@ -1,5 +1,5 @@
 # Sets up GDB for remote debugging
-target extended-remote | openocd -f openocd_stlinkv2.cfg -c "gdb_port pipe; log_output openocd.log"
+target extended-remote | openocd -c "gdb_port pipe; log_output openocd.log" -f openocd_stlinkv2_gdb.cfg
 file main.elf
 
 # Matches the output from openocd.  Must be set manually.

--- a/stm32_base/openocd_stlinkv2_gdb.cfg
+++ b/stm32_base/openocd_stlinkv2_gdb.cfg
@@ -1,0 +1,6 @@
+source openocd_stlinkv2.cfg
+
+$_TARGETNAME configure -rtos auto
+
+init
+reset halt


### PR DESCRIPTION
Fixes #411 by upping the stack size on the LuaTask.

To trace the issue back to this, had to improve how we debug in OpenOCD. These changes are included as well (but are in separate commits). This PR also introduces a 'DEBUG' make variable so that we can build DEBUG builds that are useful for tracing down issues like this without having to make many many changes.
