### PR TITLE
Get the reset logic working on logical timer 2 (Physical 2)

### DIFF
--- a/stm32_base/hal/timer_stm32/timer_device_stm32.c
+++ b/stm32_base/hal/timer_stm32/timer_device_stm32.c
@@ -381,15 +381,16 @@ void TIM1_BRK_TIM9_IRQHandler(void)
 void TIM2_IRQHandler(void)
 {
     static uint32_t last;
-    static uint32_t sigs;
+    static uint32_t cc4_irqs;
 
     if (TIM_GetITStatus(TIM2, TIM_IT_Update) != RESET) {
         /* Overflow interrupt */
             TIM_ClearITPendingBit(TIM2, TIM_IT_Update);
 
-            if (0 == sigs)
+            if (0 == cc4_irqs)
                     timer2_period = 0;
-            sigs = 0;
+
+            cc4_irqs = 0;
     }
 
     if (TIM_GetITStatus(TIM2, TIM_IT_CC4) != RESET) {
@@ -403,7 +404,7 @@ void TIM2_IRQHandler(void)
                 timer2_period = TIMER_PERIOD - last + current;
         }
         last = current;
-        ++sigs;
+        ++cc4_irqs;
         TIM_ClearITPendingBit(TIM2, TIM_IT_CC4);
     }
 }


### PR DESCRIPTION
Due to the hardware wiring bug we have no way to have the slave
controller reset the counter when an interrupt comes in.  Thus
the only way we can reset the counter is... not.  This patch
adds code so that we account for roll over, count the ticks per
overflow period, and wisely choose when to reset the output vs
not.  This way we emulate the effects of the slave reset without
having one.