### PR TITLE
Rpm Software Filtering

### DIFF
--- a/include/timer/timer_device.h
+++ b/include/timer/timer_device.h
@@ -29,8 +29,15 @@
 
 CPP_GUARD_BEGIN
 
-int32_t timer_device_init(size_t channel, uint32_t speed, uint32_t slowChannelMode);
-
+/**
+ * Initializes the timer channel.  Causes a reset in the state of
+ * that channel.  Also adjusts the quiet period based on the pulses
+ * per revolution.
+ * @param channel The channel to init
+ * @param speed The Speed enum value.  Controls
+ */
+bool timer_device_init(const size_t channel, const uint32_t speed,
+                       const uint16_t quiet_period_us);
 uint32_t timer_device_get_period(size_t channel);
 uint32_t timer_device_get_usec(size_t channel);
 uint32_t timer_device_get_count(size_t channel);

--- a/include/timer/timer_device.h
+++ b/include/timer/timer_device.h
@@ -24,6 +24,7 @@
 
 #include "cpp_guard.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
 

--- a/src/timer/timer.c
+++ b/src/timer/timer.c
@@ -28,12 +28,22 @@ static Filter g_timer_filter[CONFIG_TIMER_CHANNELS];
 
 int timer_init(LoggerConfig *loggerConfig)
 {
-    for (size_t i = 0; i < CONFIG_TIMER_CHANNELS; i++) {
-        TimerConfig *tc = &loggerConfig->TimerConfigs[i];
-        timer_device_init(i, tc->timerSpeed, tc->mode);
-        init_filter(&g_timer_filter[i], tc->filterAlpha);
-    }
-    return 1;
+        for (size_t i = 0; i < CONFIG_TIMER_CHANNELS; i++) {
+                TimerConfig *tc = &loggerConfig->TimerConfigs[i];
+
+                /*
+                 * Software Filter Hack Represents 20K Max.  For release
+                 * in 2.8.8.  Have to divide value by pulses per revolution
+                 * since this must scale depending on the number of pulses
+                 * per engine rotation.
+                 */
+                const uint16_t qp_us = 3000 / tc->pulsePerRevolution;
+
+                timer_device_init(i, tc->timerSpeed, qp_us);
+                init_filter(&g_timer_filter[i], tc->filterAlpha);
+        }
+
+        return 1;
 }
 
 uint32_t timer_get_raw(size_t channel)

--- a/src/timer/timer.c
+++ b/src/timer/timer.c
@@ -24,6 +24,8 @@
 #include "timer_device.h"
 #include "filter.h"
 
+#define QUIET_PERIOD_US	4500
+
 static Filter g_timer_filter[CONFIG_TIMER_CHANNELS];
 
 static uint16_t get_timer_quiet_period(const TimerConfig *tc)
@@ -38,7 +40,7 @@ static uint16_t get_timer_quiet_period(const TimerConfig *tc)
          * since this must scale depending on the number of pulses
          * per engine rotation.
          */
-        return 4500 / tc->pulsePerRevolution;
+        return QUIET_PERIOD_US / tc->pulsePerRevolution;
 }
 
 int timer_init(LoggerConfig *loggerConfig)

--- a/src/timer/timer.c
+++ b/src/timer/timer.c
@@ -33,12 +33,12 @@ static uint16_t get_timer_quiet_period(const TimerConfig *tc)
                 return 0;
 
         /*
-         * Software Filter Hack Represents 20K Max.  For release
+         * Software Filter Hack Represents 15K Max.  For release
          * in 2.8.8.  Have to divide value by pulses per revolution
          * since this must scale depending on the number of pulses
          * per engine rotation.
          */
-        return 3000 / tc->pulsePerRevolution;
+        return 4500 / tc->pulsePerRevolution;
 }
 
 int timer_init(LoggerConfig *loggerConfig)

--- a/stm32_base/hal/timer_stm32/timer_device_stm32.c
+++ b/stm32_base/hal/timer_stm32/timer_device_stm32.c
@@ -30,36 +30,34 @@
 
 #include <stdbool.h>
 
-#define TIMER_CHANNELS	3
-
+#define INPUT_CAPTURE_FILTER 	0X0
+#define MK2_TIMER_CHANNELS	3
+#define PRESCALER_FAST		84
+#define PRESCALER_MEDIUM	168
+#define PRESCALER_SLOW		1680
 #define TIMER_IRQ_PRIORITY 	4
 #define TIMER_IRQ_SUB_PRIORITY 	0
-#define TIMER_PERIOD	0xFFFF
-
-#define PRESCALER_SLOW		1680
-#define PRESCALER_MEDIUM	168
-#define PRESCALER_FAST		84
-
-#define INPUT_CAPTURE_FILTER 	0X0
+#define TIMER_PERIOD		0xFFFF
 
 static struct state {
         uint16_t period;
         uint16_t duty_cycle;
         uint16_t q_period_ticks;
-} g_state[TIMER_CHANNELS];
+} g_state[MK2_TIMER_CHANNELS];
 
 static struct config {
         uint16_t prescaler;
         uint16_t q_period_us;
-} g_config[TIMER_CHANNELS];
+} g_config[MK2_TIMER_CHANNELS];
 
-//////////////////////////////////////////////////////////////////////
-//logical to hardware mappings for RCP MK2
-//TIMER 0 = PA6 / TIM13_CH1 / **TIM3_CH1** /
-//TIMER 1 = PA2 / TIM2_CH3(32bit) / **TIM9_CH1** / TIM5_CH3(32bit)
-//TIMER 2 = PA3 / **TIM5_CH4(32bit)** / TIM9_CH2 / TIM2_CH4(32bit)
-//TIMER 3 = PA7 / TIM8_CH1N / **TIM14_CH1** / TIM3_CH2 / TIM1_CH1N
-//////////////////////////////////////////////////////////////////////
+/*
+ * Logical to hardware mappings for RCP MK2
+ *
+ * TIMER 0 = PA6 / TIM13_CH1 / **TIM3_CH1** /
+ * TIMER 1 = PA2 / TIM2_CH3(32bit) / **TIM9_CH1** / TIM5_CH3(32bit)
+ * TIMER 2 = PA3 / **TIM5_CH4(32bit)** / TIM9_CH2 / TIM2_CH4(32bit)
+ * TIMER 3 = PA7 / TIM8_CH1N / **TIM14_CH1** / TIM3_CH2 / TIM1_CH1N
+ */
 
 static void set_local_uri_source(TIM_TypeDef *tim)
 {
@@ -255,7 +253,7 @@ static uint16_t speed_to_prescaler(size_t speed)
 
 void reset_device_state(const size_t chan)
 {
-        if (chan >= TIMER_CHANNELS)
+        if (chan >= MK2_TIMER_CHANNELS)
                 return;
 
         struct state *s = &g_state[chan];
@@ -268,7 +266,7 @@ void reset_device_state(const size_t chan)
 bool timer_device_init(const size_t channel, const uint32_t speed,
                        const uint16_t quiet_period_us)
 {
-        if (channel >= TIMER_CHANNELS)
+        if (channel >= MK2_TIMER_CHANNELS)
                 return false;
 
         struct config *c = &g_config[channel];
@@ -323,7 +321,7 @@ uint32_t timer_device_get_usec(size_t channel)
 
 uint32_t timer_device_get_period(size_t channel)
 {
-        return channel < TIMER_CHANNELS ? g_state[channel].period : 0;
+        return channel < MK2_TIMER_CHANNELS ? g_state[channel].period : 0;
 }
 
 

--- a/stm32_base/hal/timer_stm32/timer_device_stm32.c
+++ b/stm32_base/hal/timer_stm32/timer_device_stm32.c
@@ -38,6 +38,7 @@
 #define TIMER_IRQ_PRIORITY 	4
 #define TIMER_IRQ_SUB_PRIORITY 	0
 #define TIMER_PERIOD		0xFFFF
+#define TIMER_POLARITY		TIM_ICPolarity_Falling
 
 static struct state {
         uint16_t period;
@@ -104,7 +105,7 @@ static void init_timer_0(struct config *cfg)
 
     TIM_ICInitTypeDef TIM_ICInitStructure;
     TIM_ICInitStructure.TIM_Channel = TIM_Channel_1;
-    TIM_ICInitStructure.TIM_ICPolarity = TIM_ICPolarity_Rising;
+    TIM_ICInitStructure.TIM_ICPolarity = TIMER_POLARITY;
     TIM_ICInitStructure.TIM_ICSelection = TIM_ICSelection_DirectTI;
     TIM_ICInitStructure.TIM_ICPrescaler = TIM_ICPSC_DIV1;
     TIM_ICInitStructure.TIM_ICFilter = INPUT_CAPTURE_FILTER;
@@ -157,7 +158,7 @@ static void init_timer_1(struct config *cfg)
 
     TIM_ICInitTypeDef TIM_ICInitStructure;
     TIM_ICInitStructure.TIM_Channel = TIM_Channel_1;
-    TIM_ICInitStructure.TIM_ICPolarity = TIM_ICPolarity_Rising;
+    TIM_ICInitStructure.TIM_ICPolarity = TIMER_POLARITY;
     TIM_ICInitStructure.TIM_ICSelection = TIM_ICSelection_DirectTI;
     TIM_ICInitStructure.TIM_ICPrescaler = TIM_ICPSC_DIV1;
     TIM_ICInitStructure.TIM_ICFilter = INPUT_CAPTURE_FILTER;
@@ -216,7 +217,7 @@ static void init_timer_2(struct config *cfg)
 
     TIM_ICInitTypeDef TIM_ICInitStructure;
     TIM_ICInitStructure.TIM_Channel = TIM_Channel_4;
-    TIM_ICInitStructure.TIM_ICPolarity = TIM_ICPolarity_Rising;
+    TIM_ICInitStructure.TIM_ICPolarity = TIMER_POLARITY;
     TIM_ICInitStructure.TIM_ICSelection = TIM_ICSelection_DirectTI;
     TIM_ICInitStructure.TIM_ICPrescaler = TIM_ICPSC_DIV1;
     TIM_ICInitStructure.TIM_ICFilter = INPUT_CAPTURE_FILTER;
@@ -329,8 +330,8 @@ uint32_t timer_device_get_period(size_t channel)
  * = = = IRQ methods below this point = = =
  */
 
-void update_device_state(const size_t chan, const uint16_t p_ticks,
-                         const uint16_t p_h_ticks)
+static void update_device_state(const size_t chan, const uint16_t p_ticks,
+                                const uint16_t p_h_ticks)
 {
         if (0 == p_ticks)
                 return;
@@ -373,7 +374,7 @@ void TIM3_IRQHandler(void)
         }
 }
 
-//logical timer 1
+/* Logical Timer 1 IRQ Handler */
 void TIM1_BRK_TIM9_IRQHandler(void)
 {
         if (TIM_GetITStatus(TIM9, TIM_IT_Update) != RESET) {
@@ -394,7 +395,7 @@ void TIM1_BRK_TIM9_IRQHandler(void)
 }
 
 /*
- * Logical Timer 2 HACK
+ * Logical Timer 2 IRQ Handler with a HACK
  *
  * Unfortunately on MK2 there is a hardware bug where the GPIO input
  * for TIM2 can't trigger the interrupt on the slave controller for

--- a/stm32_base/hal/timer_stm32/timer_device_stm32.c
+++ b/stm32_base/hal/timer_stm32/timer_device_stm32.c
@@ -330,10 +330,20 @@ uint32_t timer_device_get_period(size_t channel)
  * = = = IRQ methods below this point = = =
  */
 
+/**
+ * Updates the device state based on the period ticks (p_ticks) and the
+ * duty cycle based on both period ticks and high-level ticks (h_ticks).
+ * If in the quiet time, it saves the period ticks value to be used later.
+ * otherwise it updates the period and duty_cycle values and clears the
+ * buffer used for ticks read during the quiet period.
+ * @param chan The timer channel index.
+ * @param p_ticks The tick count for the entire period.
+ * @param h_ticks The tick count for the length of the high signal level.
+ */
 static void update_device_state(const size_t chan, const uint16_t p_ticks,
-                                const uint16_t p_h_ticks)
+                                const uint16_t h_ticks)
 {
-        if (0 == p_ticks)
+        if (chan >= MK2_TIMER_CHANNELS || 0 == p_ticks)
                 return;
 
         struct state *s = &g_state[chan];
@@ -351,7 +361,7 @@ static void update_device_state(const size_t chan, const uint16_t p_ticks,
 
         /* If here, then past quiet period.  Update complete state */
         s->period = total_ticks;
-        s->duty_cycle = 100 * (uint32_t) p_h_ticks / total_ticks;
+        s->duty_cycle = 100 * (uint32_t) h_ticks / total_ticks;
         s->q_period_ticks = 0;
 }
 

--- a/test/logger_mock/timer_device_mock.c
+++ b/test/logger_mock/timer_device_mock.c
@@ -19,37 +19,39 @@
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+#include "capabilities.h"
 #include "timer_device.h"
 
-#define TIMER_CHANNELS 3
-static int g_timer[TIMER_CHANNELS] = {0,0,0};
+#include <stdbool.h>
 
-int timer_device_init(size_t channel, unsigned int divider, unsigned int slowChannelMode)
+static int g_timer[TIMER_CHANNELS];
+
+bool timer_device_init(const size_t channel, const uint32_t speed,
+                       const uint16_t quiet_period_us)
 {
-    return 1;
+        return 1;
 }
 
 unsigned int timer_device_get_period(size_t channel)
 {
-    return g_timer[channel];
+        return g_timer[channel];
 }
 
 unsigned int timer_device_get_count(size_t channel)
 {
-    return 0;
+        return 0;
 }
 
 void timer_device_reset_count(size_t channel) {}
 
 void timer_device_get_all_periods(unsigned int *t0, unsigned int *t1, unsigned int *t2)
 {
-    *t0 = g_timer[0];
-    *t1 = g_timer[1];
-    *t2 = g_timer[2];
+        *t0 = g_timer[0];
+        *t1 = g_timer[1];
+        *t2 = g_timer[2];
 }
 
 uint32_t timer_device_get_usec(size_t channel)
 {
-    return 0;
+        return 0;
 }


### PR DESCRIPTION
We have seen issues in the field where voltage echos (aka Fly-back) in the sender wires cause our unit to accidentally register an extra RPM pulse.  Here is [one such example from an Acura Integra](https://www.race-capture.com/events/24-hours-of-lemons-where-the-elite-meet-to-cheat-day-1-south-track/device/team-sheen-181?laps[]=96&laps[]=93).  As you can see, those aren't real values.  Unfortunately, this makes things unusable, so we need a fix.

This patch addresses the issue by adding in a "quiet period" into the IRQs that register the triggers.  If an IRQ occurs during this period, then we save the timer counter value locally, but ignore the pulse.  Then when the real pulse comes in, we are able to accurately calculate the period to within a much narrower window.  Multiple fly-back signals can cause a little bit of noise, but nothing so severe that it can't be overcome.

This is currently designed against 2.8.8 so we can get a solution out to the field sooner (since this is a widespread issue).  In 2.9.0 I will add support for adjusting the quiet period as part of the config.  For now I assume that the user's vehicle will not redline at 20,000 or more.