### PR TITLE
Fix the Lua timing issue so that it invokes the onTick method regularly.

### DIFF
--- a/src/lua/luaTask.c
+++ b/src/lua/luaTask.c
@@ -326,9 +326,9 @@ static void luaTask(void *params)
         }
 
         int fales = 0;
-        for(;;) {
-                portTickType xLastWakeTime = xTaskGetTickCount();
-                vTaskDelayUntil(&xLastWakeTime, onTickSleepInterval);
+        for(portTickType xLastWakeTime;;
+            vTaskDelayUntil(&xLastWakeTime, onTickSleepInterval)) {
+                xLastWakeTime = xTaskGetTickCount();
 
                 if (LUA_ENABLED != lua_run_state)
                         continue;


### PR DESCRIPTION
There was a bug in the code that was effectively like using `sleep(1000)`
at the top of the `onTick` invocation method.  This fixes the execution
order so that we properly invoke onTick on regular intervals, regardless
of how long it took to execute the previous Lua code.