### PR TITLE
Factor the sample rates of virtual channels into our calculations

### DIFF
--- a/include/virtual_channel/virtual_channel.h
+++ b/include/virtual_channel/virtual_channel.h
@@ -45,6 +45,11 @@ void set_virtual_channel_value(size_t id, float value);
 float get_virtual_channel_value(int id);
 void reset_virtual_channels(void);
 
+/**
+ * @return The highest sample rate among all the virtual channels
+ */
+int get_virtual_channel_high_sample_rate(void);
+
 CPP_GUARD_END
 
 #endif /* VIRTUAL_CHANNEL_H_ */

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -590,6 +590,7 @@ unsigned int getHighestSampleRate(LoggerConfig *config)
     sr = gpsConfig->DOP.sampleRate;
     s = getHigherSampleRate(sr, s);
 
+
     LapConfig *trackCfg = &(config->LapConfigs);
     sr = trackCfg->lapCountCfg.sampleRate;
     s = getHigherSampleRate(sr, s);
@@ -611,6 +612,11 @@ unsigned int getHighestSampleRate(LoggerConfig *config)
 
     sr = trackCfg->current_lap_cfg.sampleRate;
     s = getHigherSampleRate(sr, s);
+
+
+    /* Now check our Virtual Channels */
+    sr = get_virtual_channel_high_sample_rate();
+    s = getHigherSampleRate(s, sr);
 
     return s;
 }

--- a/src/virtual_channel/virtual_channel.c
+++ b/src/virtual_channel/virtual_channel.c
@@ -88,3 +88,15 @@ void reset_virtual_channels(void)
 {
     g_virtualChannelCount = 0;
 }
+
+int get_virtual_channel_high_sample_rate(void)
+{
+        int sr = 0;
+
+        for (size_t i = 0; i < g_virtualChannelCount; ++i) {
+                const int vc_sr = g_virtualChannels[i].config.sampleRate;
+                sr = getHigherSampleRate(sr, vc_sr);
+        }
+
+        return sr;
+}


### PR DESCRIPTION
It would seem that we forgot to include virtual channels into our
sample rate values.  As a result, logging to the fileWriter was
failing to work.  This ticket fixes that issue by factoring in
virtual channels when we calculate those values.

Addresses issue #444 