### PR TITLE
Support 100 Virtual Channels

### DIFF
--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -447,8 +447,7 @@ void api_send_sample_record(Serial *serial, struct sample *sample,
                 }
 
                 if (cs->populated) {
-                        channelBitmask[channelBitmaskIndex] =
-                                channelBitmask[channelBitmaskIndex] |
+                        channelBitmask[channelBitmaskIndex] |=
                                 (1 << channelBitPosition);
 
                         const int precision = cs->cfg->precision;
@@ -470,8 +469,9 @@ void api_send_sample_record(Serial *serial, struct sample *sample,
                                 put_double(serial, cs->valueDouble, precision);
                                 break;
                         default:
-                                pr_warning("sendSampleRec: unknown sample "
-                                           "data type\r\n");
+                                pr_warning_int_msg("[loggerApi] Unknown sample"
+                                                   " data type: ",
+                                                   cs->sampleData);
                                 break;
                         }
                         serial->put_c(',');

--- a/src/virtual_channel/virtual_channel.c
+++ b/src/virtual_channel/virtual_channel.c
@@ -48,24 +48,27 @@ int find_virtual_channel(const char * channel_name)
 
 int create_virtual_channel(const ChannelConfig chCfg)
 {
+        /* If the channel exists, return it and be done */
+        if (find_virtual_channel(chCfg.label) != INVALID_VIRTUAL_CHANNEL)
+                return id;
 
-    int virtualChannelId = find_virtual_channel(chCfg.label);
-
-    if (virtualChannelId == INVALID_VIRTUAL_CHANNEL) {
-        if (g_virtualChannelCount < MAX_VIRTUAL_CHANNELS) {
-            virtualChannelId = g_virtualChannelCount;
-            g_virtualChannelCount++;
+        /*
+         * Here we actually try to create a new channel.  But only if we
+         * have the room for it.
+         */
+        if (g_virtualChannelCount >= MAX_VIRTUAL_CHANNELS) {
+                pr_error_int_msg("[vchan] Limit reached: ",
+                                 g_virtualChannelCount);
+                return INVALID_VIRTUAL_CHANNEL;
         }
-    }
-    if (virtualChannelId != INVALID_VIRTUAL_CHANNEL) {
-        VirtualChannel * channel = g_virtualChannels + virtualChannelId;
+
+
+        VirtualChannel * channel = g_virtualChannels + g_virtualChannelCount;
         channel->config = chCfg;
         channel->currentValue = 0;
         configChanged();
-    } else {
-        pr_error("vchan: limit exceeded\r\n");
-    }
-    return virtualChannelId;
+
+        return g_virtualChannelCount++;
 }
 
 void set_virtual_channel_value(size_t id, float value)

--- a/src/virtual_channel/virtual_channel.c
+++ b/src/virtual_channel/virtual_channel.c
@@ -49,7 +49,8 @@ int find_virtual_channel(const char * channel_name)
 int create_virtual_channel(const ChannelConfig chCfg)
 {
         /* If the channel exists, return it and be done */
-        if (find_virtual_channel(chCfg.label) != INVALID_VIRTUAL_CHANNEL)
+        const int id = find_virtual_channel(chCfg.label);
+        if (id != INVALID_VIRTUAL_CHANNEL)
                 return id;
 
         /*

--- a/stm32_base/capabilities.h
+++ b/stm32_base/capabilities.h
@@ -17,7 +17,7 @@
 //configuration
 #define MAX_TRACKS	240
 #define MAX_SECTORS	20
-#define MAX_VIRTUAL_CHANNELS	30
+#define MAX_VIRTUAL_CHANNELS	100
 #define LOGGER_MESSAGE_BUFFER_SIZE	10
 
 /*


### PR DESCRIPTION
Adds support for up to 100 virtual channels.  Also optimizes the virtual channel adding function to not cause unnecessary re-allocations of our logging buffers if a user attempts to add a virtual channel that already exists.

@kosenko-max, I have ported your patch from autosportlabs/RaceCapture-Pro_firmware/pull/440 to here.  I also fixed its title and added a couple of other improvements to virtual channel.  Thanks for your submission.