### PR TITLE
Make Logging a top priority

### DIFF
--- a/main.c
+++ b/main.c
@@ -136,9 +136,9 @@ void vApplicationStackOverflowHook(xTaskHandle pxTask, char *pcTaskName)
  * info on how to best set these.  0 is lowest priority.
  */
 #define TASK_PRIORITY(v)	(tskIDLE_PRIORITY + v)
-#define RCP_INPUT_PRIORITY	TASK_PRIORITY(4)
-#define RCP_OUTPUT_PRIORITY	TASK_PRIORITY(3)
-#define RCP_LOGGING_PRIORITY	TASK_PRIORITY(2)
+#define RCP_LOGGING_PRIORITY	TASK_PRIORITY(4)
+#define RCP_INPUT_PRIORITY	TASK_PRIORITY(3)
+#define RCP_OUTPUT_PRIORITY	TASK_PRIORITY(2)
 #define RCP_LUA_PRIORITY	TASK_PRIORITY(1)
 
 void setupTask(void *delTask)


### PR DESCRIPTION
Acquiring a data snapshot at the precise time is of high importance
in a telemetry system.  If any one unit is able to prevent the logger
from aqcuiring its information at the precise moment, then the logger
data could be stale and lost.

Thus to prevent this scenario, we need make the logger task have the
highest priority in the system.  When this is the case, the logger
will always trump any other task needing to run when the preemptive
scheduler is invoked.  Thus there is no chance in missing an update.
a data snapshot is determined when our