### PR TITLE
Support faster onTick, Improve setTickRate method

### DIFF
--- a/include/lua/luaTask.h
+++ b/include/lua/luaTask.h
@@ -38,7 +38,7 @@ void* getLua(void);
  */
 size_t get_lua_mem_size();
 
-void set_ontick_freq(size_t freq);
+size_t set_ontick_freq(const size_t freq);
 size_t get_ontick_freq();
 void initialize_lua();
 void terminate_lua();

--- a/src/lua/luaTask.c
+++ b/src/lua/luaTask.c
@@ -22,6 +22,7 @@
 #include "FreeRTOS.h"
 #include "GPIO.h"
 #include "LED.h"
+#include "capabilities.h"
 #include "lauxlib.h"
 #include "lua.h"
 #include "luaBaseBinding.h"
@@ -112,10 +113,12 @@ static void unlockLua(void)
     xSemaphoreGive(xLuaLock);
 }
 
-void set_ontick_freq(size_t freq)
+size_t set_ontick_freq(const size_t freq)
 {
-        if (freq <= LUA_MAXIMUM_ONTICK_HZ)
-                onTickSleepInterval = msToTicks(1000 / freq);
+        if (LUA_MAXIMUM_ONTICK_HZ < freq || 0 == freq)
+                return 0;
+
+        return onTickSleepInterval = msToTicks(TICK_RATE_HZ / freq);
 }
 
 size_t get_ontick_freq()

--- a/src/lua/luaTask.c
+++ b/src/lua/luaTask.c
@@ -19,7 +19,6 @@
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #include "FreeRTOS.h"
 #include "GPIO.h"
 #include "LED.h"
@@ -43,9 +42,9 @@
 #include <math.h>
 #include <stdbool.h>
 
-#define DEFAULT_ONTICK_HZ 1
-#define MAX_ONTICK_HZ 30
 /* Set this high as the parser can get very stack hungry.  Issue #411 */
+#define LUA_MAXIMUM_ONTICK_HZ	1000
+#define LUA_DEFAULT_ONTICK_HZ	1
 #define LUA_STACK_SIZE 1536
 #define LUA_PERIODIC_FUNCTION "onTick"
 
@@ -115,7 +114,8 @@ static void unlockLua(void)
 
 void set_ontick_freq(size_t freq)
 {
-    if (freq <= MAX_ONTICK_HZ) onTickSleepInterval = msToTicks(1000 / freq);
+        if (freq <= LUA_MAXIMUM_ONTICK_HZ)
+                onTickSleepInterval = msToTicks(1000 / freq);
 }
 
 size_t get_ontick_freq()
@@ -314,7 +314,7 @@ cleanup:
 
 static void luaTask(void *params)
 {
-        set_ontick_freq(DEFAULT_ONTICK_HZ);
+        set_ontick_freq(LUA_DEFAULT_ONTICK_HZ);
         initialize_script();
 
         const bool should_bypass_lua = (watchdog_is_watchdog_reset() && user_bypass_requested());

--- a/test/logger_mock/luaTask_mock.c
+++ b/test/logger_mock/luaTask_mock.c
@@ -19,7 +19,7 @@
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+#include "capabilities.h"
 #include "luaTask.h"
 
 void lockLua(void)
@@ -77,10 +77,11 @@ void setShouldReloadScript(int reload)
 
 }
 
-void set_ontick_freq(size_t freq)
+size_t set_ontick_freq(size_t freq)
 {
-
+        return freq ? TICK_RATE_HZ / freq : 0;
 }
+
 size_t get_ontick_freq()
 {
     return 1;


### PR DESCRIPTION
To be able to play better with customers who want faster Lua rates, I am adjusting our setTickRate method to allow higher invocation rates.  This is sane because Lua is our lowest priority process (only idle task is lower).  So it will never block a task that isn't more important.

This patch also improves the setTickRate to return the time (in ms) it will sleep between onTick invocations and enables the ability to send back errors to Lua when folks invoke the commands improperly.