### PR TITLE
[RFC] AT Command Engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ TAGS
 *.ihex
 .vagrant
 *.log
+core.*

--- a/RCT/Makefile
+++ b/RCT/Makefile
@@ -170,6 +170,10 @@ inc-y += ../include/logger
 src-y += $(wildcard ../src/messaging/*.c)
 inc-y += ../include/messaging
 
+#modem
+src-y += $(wildcard ../src/modem/*.c)
+inc-y += ../include/modem
+
 # FreeRTOS
 src-y += $(wildcard FreeRTOS/Source/*.c) \
          FreeRTOS/Source/portable/GCC/ARM_CM3/port.c \

--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -1,0 +1,47 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _ESP8266_H_
+#define _ESP8266_H_
+
+#include "cpp_guard.h"
+
+CPP_GUARD_BEGIN
+
+/**
+ * The various initialization states of the device.  Probably should
+ * get put in a more generic file.  Here is good for now.
+ */
+enum dev_init_state {
+        DEV_INIT_STATE_NOT_READY = 0,
+        DEV_INIT_INITIALIZING,
+        DEV_INIT_STATE_READY,
+        DEV_INIT_STATE_FAILED,
+};
+
+bool esp8266_begin_init(struct at_info *ati);
+
+enum dev_init_state esp1866_get_dev_init_state();
+
+
+CPP_GUARD_END
+
+#endif /* _ESP8266_H_ */

--- a/include/modem/at.h
+++ b/include/modem/at.h
@@ -30,6 +30,7 @@ CPP_GUARD_BEGIN
 
 #define AT_CMD_MAX_CMDS	3
 #define AT_CMD_MAX_LEN	64
+#define AT_DEV_CVG_DELIM_MAX_LEN	3
 #define AT_RSP_MAX_MSGS	8
 #define AT_URC_MAX_LEN	16
 #define AT_URC_MAX_URCS	16
@@ -88,7 +89,7 @@ struct at_timing {
 };
 
 struct at_dev_cfg {
-        char delim;
+        char delim[AT_DEV_CVG_DELIM_MAX_LEN];
         tiny_millis_t quiet_period_ms;
 };
 
@@ -131,7 +132,7 @@ struct at_info {
 };
 
 bool init_at_info(struct at_info *ati, struct serial_buffer *sb,
-                  const tiny_millis_t quiet_period_ms, const char delim);
+                  const tiny_millis_t quiet_period_ms, const char *delim);
 
 void at_task(struct at_info *ati, const size_t ms_delay);
 
@@ -145,10 +146,10 @@ struct at_urc* at_register_urc(struct at_info *ati, const char *pfx,
                                void (*rsp_cb)(struct at_rsp *rsp, void *rsp_up),
                                void *rsp_up);
 
-void at_configure_device(struct at_info *ati, const tiny_millis_t qp_ms,
-                         const char delim);
+bool at_configure_device(struct at_info *ati, const tiny_millis_t qp_ms,
+                         const char *delim);
 
-bool at_rsp_ok(struct at_rsp *rsp);
+bool at_ok(struct at_rsp *rsp);
 
 CPP_GUARD_END
 

--- a/include/modem/at.h
+++ b/include/modem/at.h
@@ -1,0 +1,137 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _AT_H_
+#define _AT_H_
+
+#include "cpp_guard.h"
+#include "dateTime.h"
+#include "serial_buffer.h"
+
+CPP_GUARD_BEGIN
+
+#define AT_CMD_MAX_CMDS	3
+#define AT_CMD_MAX_LEN	64
+#define AT_RSP_MAX_MSGS	8
+#define AT_URC_MAX_LEN	16
+#define AT_URC_MAX_URCS	16
+#define AT_URC_TIMEOUT_MS	5
+
+enum at_rx_state {
+        AT_RX_STATE_READY,
+        AT_RX_STATE_CMD,
+        AT_RX_STATE_URC,
+};
+
+enum at_cmd_state {
+        AT_CMD_STATE_READY,
+        AT_CMD_STATE_IN_PROGRESS,
+        AT_CMD_STATE_QUIET,
+};
+
+enum at_rsp_status {
+        AT_RSP_STATUS_UNKNOWN = 0,
+        AT_RSP_STATUS_OK,
+        AT_RSP_STATUS_NONE,
+        AT_RSP_STATUS_TIMEOUT,
+        AT_RSP_STATUS_FAILED,
+        AT_RSP_STATUS_ABORTED,
+};
+
+struct at_rsp {
+        enum at_rsp_status status;
+        tiny_millis_t run_time;
+        size_t msg_count;
+        const char *msgs[AT_RSP_MAX_MSGS];
+};
+
+/* A command to send to our modem */
+struct at_cmd {
+        tiny_millis_t timeout_ms;
+        void (*rsp_cb)(struct at_rsp *rsp);
+        char cmd[AT_CMD_MAX_LEN];
+};
+
+struct at_cmd_queue {
+        size_t count;
+        struct at_cmd *head;
+        struct at_cmd cmds[AT_CMD_MAX_CMDS];
+};
+
+struct at_timing {
+        tiny_millis_t cmd_start_ms;
+        tiny_millis_t urc_start_ms;
+        tiny_millis_t quiet_start_ms;
+        tiny_millis_t quiet_period_ms;
+};
+
+enum at_urc_flags {
+        AT_URC_FLAGS_NONE = 0, /* For init with no flags set */
+        /* Indicates URC is only one msg with no status */
+        AT_URC_FLAGS_NO_RSP_STATUS = 1 << 0,
+};
+
+struct at_urc {
+        void (*rsp_cb)(struct at_rsp *rsp);
+        enum at_urc_flags flags;
+        size_t pfx_len;
+        char pfx[AT_URC_MAX_LEN];
+};
+
+struct at_urc_list {
+        size_t count;
+        struct at_urc urcs[AT_URC_MAX_URCS];
+};
+
+struct at_info {
+        /*
+         * All of this is really read only.  Don't alter directly.
+         * In fact, you should probably never be accessing these directly
+         * unless you are debugging.  Use the methods provided.  They will
+         * keep the state in here sane.
+         */
+        enum at_rx_state rx_state;
+        enum at_cmd_state cmd_state;
+        struct serial_buffer *sb;
+        struct at_cmd *cmd_ip;
+        struct at_urc *urc_ip;
+        struct at_rsp rsp;
+        struct at_timing timing;
+        struct at_cmd_queue cmd_queue;
+        struct at_urc_list urc_list;
+};
+
+bool init_at_info(struct at_info *ati, struct serial_buffer *sb,
+                  const tiny_millis_t quiet_period_ms);
+
+void at_task(struct at_info *ati, const size_t ms_delay);
+
+struct at_cmd* at_put_cmd(struct at_info *ati, const char *cmd,
+                          void (*rsp_cb)(struct at_rsp *rsp),
+                          const tiny_millis_t timeout);
+
+struct at_urc* at_register_urc(struct at_info *ati, const char *pfx,
+                               void (*rsp_cb)(struct at_rsp *rsp),
+                               const enum at_urc_flags flags);
+
+CPP_GUARD_END
+
+#endif /* _AT_H_ */

--- a/include/modem/at.h
+++ b/include/modem/at.h
@@ -47,13 +47,17 @@ enum at_cmd_state {
         AT_CMD_STATE_QUIET,
 };
 
+/**
+ * All failure status values are < 0.  All successful ones are > 0.
+ */
 enum at_rsp_status {
-        AT_RSP_STATUS_UNKNOWN = 0,
-        AT_RSP_STATUS_OK,
-        AT_RSP_STATUS_NONE,
-        AT_RSP_STATUS_TIMEOUT,
-        AT_RSP_STATUS_FAILED,
-        AT_RSP_STATUS_ABORTED,
+        AT_RSP_STATUS_TIMEOUT = -4,
+        AT_RSP_STATUS_FAILED  = -3,
+        AT_RSP_STATUS_ABORTED = -2,
+        AT_RSP_STATUS_ERROR   = -1,
+        AT_RSP_STATUS_UNKNOWN =  0,
+        AT_RSP_STATUS_OK      =  1,
+        AT_RSP_STATUS_NONE    =  2,
 };
 
 struct at_rsp {
@@ -141,7 +145,10 @@ struct at_urc* at_register_urc(struct at_info *ati, const char *pfx,
                                void (*rsp_cb)(struct at_rsp *rsp, void *rsp_up),
                                void *rsp_up);
 
-void at_set_quiet_period(struct at_info *ati, const tiny_millis_t qp_ms);
+void at_configure_device(struct at_info *ati, const tiny_millis_t qp_ms,
+                         const char delim);
+
+bool at_rsp_ok(struct at_rsp *rsp);
 
 CPP_GUARD_END
 

--- a/include/serial/serial_buffer.h
+++ b/include/serial/serial_buffer.h
@@ -22,9 +22,12 @@
 #ifndef _SERIAL_BUFFER_H_
 #define _SERIAL_BUFFER_H_
 
+#include "cpp_guard.h"
 #include "serial.h"
 
 #include <stdbool.h>
+
+CPP_GUARD_BEGIN
 
 struct serial_buffer {
         Serial *serial;
@@ -67,5 +70,6 @@ size_t serial_buffer_append(struct serial_buffer *sb, const char *buff);
 size_t serial_buffer_printf_append(struct serial_buffer *sb,
                                    const char *format_str, ...);
 
+CPP_GUARD_END
 
 #endif /* _SERIAL_BUFFER_H_ */

--- a/include/serial/serial_buffer.h
+++ b/include/serial/serial_buffer.h
@@ -38,8 +38,8 @@ bool serial_buffer_create(struct serial_buffer *sb,
                           const size_t size,
                           char *buffer);
 
-int serial_buffer_rx(struct serial_buffer *sb,
-                     const size_t ms_delay);
+char* serial_buffer_rx(struct serial_buffer *sb,
+                       const size_t ms_delay);
 
 size_t serial_buffer_rx_msgs(struct serial_buffer *sb,
                              const size_t ms_delay,

--- a/include/tasks/wifi.h
+++ b/include/tasks/wifi.h
@@ -1,0 +1,33 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _WIFI_H_
+#define _WIFI_H_
+
+#include "cpp_guard.h"
+
+CPP_GUARD_BEGIN
+
+void start_wifi_task(const int priority);
+
+CPP_GUARD_END
+
+#endif /* _WIFI_H_ */

--- a/include/util/mod_string.h
+++ b/include/util/mod_string.h
@@ -24,6 +24,7 @@
 
 #include "cpp_guard.h"
 
+#include <stdbool.h>
 #include <stddef.h>
 
 CPP_GUARD_BEGIN
@@ -59,6 +60,10 @@ char *strcat(char * s1, const char * s2);
 char *strstr (const char *phaystack, const char *pneedle);
 
 char * strchr(const char *s, const int c);
+
+char * strip(const char *s);
+
+char* trim(char *str);
 
 CPP_GUARD_END
 

--- a/include/util/mod_string.h
+++ b/include/util/mod_string.h
@@ -61,8 +61,6 @@ char *strstr (const char *phaystack, const char *pneedle);
 
 char * strchr(const char *s, const int c);
 
-char * strip(const char *s);
-
 char* trim(char *str);
 
 CPP_GUARD_END

--- a/include/util/mod_string.h
+++ b/include/util/mod_string.h
@@ -61,8 +61,6 @@ char *strstr (const char *phaystack, const char *pneedle);
 
 char * strchr(const char *s, const int c);
 
-char* trim(char *str);
-
 CPP_GUARD_END
 
 #endif /* MOD_STRING_H_ */

--- a/main.c
+++ b/main.c
@@ -46,6 +46,7 @@
 #include "printk.h"
 #include "task.h"
 #include "usb_comm.h"
+#include "wifi.h"
 #include "watchdog.h"
 
 #include <app_info.h>
@@ -153,7 +154,7 @@ void setupTask(void *delTask)
         startOBD2Task(RCP_INPUT_PRIORITY);
         startConnectivityTask(RCP_OUTPUT_PRIORITY);
         startLoggerTaskEx(RCP_LOGGING_PRIORITY);
-
+        start_wifi_task(RCP_OUTPUT_PRIORITY);
 #if defined(USB_SERIAL_SUPPORT)
         startUSBCommTask(RCP_INPUT_PRIORITY);
 #endif

--- a/src/devices/cellular.c
+++ b/src/devices/cellular.c
@@ -413,8 +413,7 @@ static bool auth_telem_stream(struct serial_buffer *sb,
         jsmntok_t toks[TELEM_AUTH_JSMN_TOKENS];
 
         for (size_t tries = TELEM_AUTH_RX_TRIES; tries; --tries) {
-                const int chars = serial_buffer_rx(sb, TELEM_AUTH_RX_WAIT_MS);
-                if (!chars)
+                if (!serial_buffer_rx(sb, TELEM_AUTH_RX_WAIT_MS))
                         continue;
 
                 jsmn_init(&parser);

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -1,0 +1,230 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "at.h"
+#include "esp8266.h"
+#include "printk.h"
+
+#include <stdbool.h>
+
+#define ESP8266_AUTOBAUD_TRIES	20
+#define ESP8266_CMD_DELIM	"\r\n"
+#define ESP8266_QP_PRE_INIT_MS	500
+#define ESP8266_QP_STANDARD_MS	1	/* Can probably be 0 */
+#define TIMEOUT_LONG_MS		100
+#define TIMEOUT_SHORT_MS	10
+
+static const enum log_level serial_dbg_lvl = INFO;
+
+/**
+ * Internal state of our driver.
+ */
+static struct {
+        enum dev_init_state init_state;
+        struct at_info *ati;
+} state;
+
+/**
+ * Call the if the init routine fails.
+ * @param msg The message to print.
+ */
+static void init_failed(const char *msg)
+{
+        state.init_state = DEV_INIT_STATE_FAILED;
+
+        if (msg)
+                pr_info_str_msg("[esp8266] Init failure: ", msg);
+}
+
+static void init_success()
+{
+        pr_info("[esp8266] Initialized\r\n");
+        state.init_state = DEV_INIT_STATE_READY;
+}
+
+static void get_version_cb(struct at_rsp *rsp, void *up)
+{
+        if (!at_ok(rsp)) {
+                /* WTF Mate */
+                init_failed("Failed to get version info");
+                return;
+        }
+
+        /*
+         * AT version:0.25.0.0(Jun  5 2015 16:27:16)
+         * SDK version:1.1.1
+         * Ai-Thinker Technology Co. Ltd.
+         * Jun 23 2015 23:23:50
+         *
+         * Print for now beacuse I am lazy
+         */
+        pr_info("[esp8266] Version info:\r\n");
+        for (size_t i = 0; i < rsp->msg_count - 1; ++i)
+                pr_info_str_msg("\t", rsp->msgs[i]);
+
+        init_success();
+}
+
+static void get_version()
+{
+        at_put_cmd(state.ati, "AT+GMR", TIMEOUT_LONG_MS,
+                   get_version_cb, NULL);
+}
+
+static void set_echo_cb(struct at_rsp *rsp, void *up)
+{
+        if (at_ok(rsp))
+                return;
+
+        /* Failure. :( */
+        init_failed("Set echo failed.");
+}
+
+static void set_echo(const bool on)
+{
+        const char *cmd = on ? "ATE1" : "ATE0";
+        at_put_cmd(state.ati, cmd, TIMEOUT_SHORT_MS,
+                   set_echo_cb, NULL);
+}
+
+/**
+ * Callback for Autobauding.  Also used when starting
+ */
+static void autobaud_cb(struct at_rsp *rsp, void *tries)
+{
+        /* Check if we got an OK reply.  If so, move to next step */
+        if (at_ok(rsp)) {
+                /* Set normal quiet period since we have auto-bauded */
+                at_configure_device(state.ati, ESP8266_QP_STANDARD_MS,
+                                    ESP8266_CMD_DELIM);
+                set_echo(false);
+                get_version();
+                return;
+        }
+
+        --tries;
+        if (!tries) {
+                /* Out of tries.  We are done */
+                init_failed("Autobaud failed.");
+                return;
+        }
+
+        at_put_cmd(state.ati, "AT", TIMEOUT_LONG_MS, autobaud_cb, tries);
+}
+
+/**
+ * Kicks off the autobauding process.  We configure the AT engine to use
+ * the callback method for both call backs and the initilazation routine.
+ * Saves us a method.  Its like recursion, except without the stack overflows.
+ */
+static void begin_autobaud_cmd()
+{
+        at_configure_device(state.ati, ESP8266_QP_PRE_INIT_MS,
+                            ESP8266_CMD_DELIM);
+        autobaud_cb(NULL, (void*) ESP8266_AUTOBAUD_TRIES);
+}
+
+static bool is_init_in_progress()
+{
+        return state.init_state == DEV_INIT_INITIALIZING;
+}
+
+static void serial_tx_cb(const char *data)
+{
+        static bool pr_tx_pfx = true;
+
+        for(; *data; ++data) {
+                if (pr_tx_pfx) {
+                        printk(serial_dbg_lvl, "[esp8266] tx: ");
+                        pr_tx_pfx = false;
+                }
+
+                switch(*data) {
+                case('\r'):
+                        printk(serial_dbg_lvl, "\\r");
+                        break;
+                case('\n'):
+                        printk(serial_dbg_lvl, "\\n\r\n");
+                        pr_tx_pfx = true;
+                        break;
+                default:
+                        printk_char(serial_dbg_lvl, *data);
+                        break;
+                }
+        }
+}
+
+static void serial_rx_cb(const char *data)
+{
+        static bool new_line = true;
+
+        if (NULL == data)
+                return;
+
+        for(; *data; ++data) {
+                if (new_line) {
+                        printk(serial_dbg_lvl, "[esp8266] rx: ");
+                        new_line = false;
+                }
+
+                switch(*data) {
+                case('\r'):
+                        printk(serial_dbg_lvl, "\\r");
+                        break;
+                case('\n'):
+                        printk(serial_dbg_lvl, "\\n\r\n");
+                        new_line = true;
+                        break;
+                default:
+                        printk_char(serial_dbg_lvl, *data);
+                        break;
+                }
+        }
+}
+
+/**
+ * Kicks off the initilization process.
+ */
+bool esp8266_begin_init(struct at_info *ati)
+{
+        if (is_init_in_progress())
+                return false;
+
+        if (!ati)
+                return false;
+
+        /* HACK: Remove me later */
+        ati->sb->serial->tx_callback = serial_tx_cb;
+        ati->sb->serial->rx_callback = serial_rx_cb;
+
+        state.init_state = DEV_INIT_INITIALIZING;
+        state.ati = ati;
+        begin_autobaud_cmd();
+        return true;
+}
+
+/**
+ * @return The initialization state of the device.
+ */
+enum dev_init_state esp1866_get_dev_init_state()
+{
+        return state.init_state;
+}

--- a/src/modem/at.c
+++ b/src/modem/at.c
@@ -37,6 +37,7 @@ static const struct at_rsp_status_msgs {
         AT_STATUS_MSG("OK", AT_RSP_STATUS_OK),
         AT_STATUS_MSG("FAILED", AT_RSP_STATUS_FAILED),
         AT_STATUS_MSG("ABORTED", AT_RSP_STATUS_ABORTED),
+        AT_STATUS_MSG("ERROR", AT_RSP_STATUS_ERROR),
 };
 
 static bool is_timed_out(const tiny_millis_t t_start,
@@ -421,7 +422,20 @@ struct at_urc* at_register_urc(struct at_info *ati, const char *pfx,
         return aturc;
 }
 
-void at_set_quiet_period(struct at_info *ati, const tiny_millis_t qp_ms)
+/**
+ * Sets device specific settings that are unique per device.
+ * @param ati The pointer to the at_info struct.
+ * @param qp_ms The quiet period in milliseconds.
+ * @param delim The command delimeter character.  Normally this is '\r'.
+ */
+void at_configure_device(struct at_info *ati, const tiny_millis_t qp_ms,
+                         const char delim)
 {
         ati->dev_cfg.quiet_period_ms = qp_ms;
+        ati->dev_cfg.delim = delim;
+}
+
+bool at_ok(struct at_rsp *rsp)
+{
+        return rsp && AT_RSP_STATUS_OK == rsp->status;
 }

--- a/src/modem/at.c
+++ b/src/modem/at.c
@@ -1,0 +1,414 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "array_utils.h"
+#include "at.h"
+#include "dateTime.h"
+#include "mod_string.h"
+#include "printk.h"
+#include "serial_buffer.h"
+
+static const enum log_level dbg_lvl = INFO;
+
+#define AT_STATUS_MSG(a, b)	{(a), sizeof(a), (b)}
+static const struct at_rsp_status_msgs {
+        const char* str;
+        size_t str_len;
+        enum at_rsp_status status;
+} at_status_msgs[] = {
+        AT_STATUS_MSG("OK", AT_RSP_STATUS_OK),
+        AT_STATUS_MSG("FAILED", AT_RSP_STATUS_FAILED),
+        AT_STATUS_MSG("ABORTED", AT_RSP_STATUS_ABORTED),
+};
+
+static bool is_timed_out(const tiny_millis_t t_start,
+                         const tiny_millis_t t_len)
+{
+        return t_start + t_len <= getUptime();
+}
+
+static void _complete_msg_cleanup(struct at_info *ati)
+{
+        serial_buffer_clear(ati->sb);
+        memset(&ati->rsp, 0, sizeof(ati->rsp));
+        ati->rx_state = AT_RX_STATE_READY;
+}
+
+static void complete_urc(struct at_info *ati, const enum at_rsp_status status)
+{
+        ati->rsp.status = status;
+        ati->rsp.run_time = getUptime() - ati->timing.urc_start_ms;
+
+        if (ati->urc_ip->rsp_cb)
+                ati->urc_ip->rsp_cb(&ati->rsp);
+
+        /* Post URC, cleanup is a wee bit different than of cmd */
+        _complete_msg_cleanup(ati);
+        ati->urc_ip = NULL;
+}
+
+static void complete_cmd(struct at_info *ati, const enum at_rsp_status status)
+{
+        ati->rsp.status = status;
+        ati->rsp.run_time = getUptime() - ati->timing.cmd_start_ms;
+
+        if (ati->cmd_ip->rsp_cb)
+                ati->cmd_ip->rsp_cb(&ati->rsp);
+
+        /* Do all post command cleanup here */
+        _complete_msg_cleanup(ati);
+        ati->cmd_ip = NULL;
+
+        /* Begin the quiet period post command */
+        ati->cmd_state = AT_CMD_STATE_QUIET;
+        ati->timing.quiet_start_ms = getUptime();
+}
+
+
+static void at_task_run_no_bytes(struct at_info *ati)
+{
+        if (AT_RX_STATE_URC == ati->rx_state) {
+                /*
+                 * Then we are waiting for the rest of a URC response.
+                 * Ensure that we have not passed the URC timeout period.
+                 * Honestly, we should NEVER really get here, or if we do,
+                 * we should never timeout on a URC.  Doing so likely
+                 * indicates a bug in usage or architecture.
+                 */
+                if (is_timed_out(ati->timing.urc_start_ms,
+                                 AT_URC_TIMEOUT_MS)) {
+                        pr_warning("[at] Timed out in a URC!?!. "
+                                   "Should never happen. Likely a bug.\r\n");
+                        complete_urc(ati, AT_RSP_STATUS_TIMEOUT);
+                }
+        } else if (AT_CMD_STATE_IN_PROGRESS == ati->cmd_state) {
+                /*
+                 * If here, then we received no data, but a command is in
+                 * progress.  In this case, ensure that the command hasn't
+                 * reached its timeout period.
+                 */
+                if (is_timed_out(ati->timing.cmd_start_ms,
+                                 ati->cmd_ip->timeout_ms)) {
+                        printk(dbg_lvl, "Command timed out\r\n");
+                        complete_cmd(ati, AT_RSP_STATUS_TIMEOUT);
+                }
+        }
+
+        /*
+         * If here, then either we are not in the correct state or nothing
+         * has timed out.  Move along.
+         */
+}
+
+static struct at_urc* is_urc_msg(struct at_info *ati, char *msg)
+{
+        /*
+         * To figure this out, lets see if we have a URC call that
+         * matches it.
+         */
+        for (size_t i = 0; i < ati->urc_list.count; ++i) {
+                struct at_urc *urc = ati->urc_list.urcs + i;
+                if (0 == strncmp(msg, urc->pfx, urc->pfx_len))
+                        return urc;
+        }
+
+        return NULL;
+}
+
+static bool is_rsp_status(enum at_rsp_status *status, const char *msg)
+{
+        for (size_t i = 0; i < ARRAY_LEN(at_status_msgs); ++i) {
+                const struct at_rsp_status_msgs *sms = at_status_msgs + i;
+                if (0 == strcmp(msg, sms->str)) {
+                        *status = sms->status;
+                        return true;
+                }
+        }
+
+        return false;
+}
+
+static bool _process_msg_generic(struct at_info *ati,
+                                 const enum at_rx_state state,
+                                 const char *msg)
+{
+        if (AT_RSP_MAX_MSGS <= ati->rsp.msg_count) {
+                pr_error("[at] BUG: Received more messages than can "
+                         "handle. Dropping.");
+                return false;
+        }
+
+        ati->rx_state = state;
+        ati->rsp.msgs[ati->rsp.msg_count] = msg;
+        ++ati->rsp.msg_count;
+
+        return true;
+}
+
+static void process_urc_msg(struct at_info *ati, char *msg)
+{
+        _process_msg_generic(ati, AT_RX_STATE_URC, msg);
+
+        const bool no_status = ati->urc_ip->flags & AT_URC_FLAGS_NO_RSP_STATUS;
+        enum at_rsp_status status = AT_RSP_STATUS_NONE;
+        if (no_status || is_rsp_status(&status, msg))
+                complete_urc(ati, status);
+}
+
+static void process_cmd_msg(struct at_info *ati, char *msg)
+{
+        _process_msg_generic(ati, AT_RX_STATE_CMD, msg);
+
+        enum at_rsp_status status;
+        if (is_rsp_status(&status, msg))
+                complete_cmd(ati, status);
+}
+
+static void begin_urc_msg(struct at_info *ati, struct at_urc *urc)
+{
+        ati->urc_ip = urc;
+        ati->timing.urc_start_ms = getUptime();
+}
+
+static void at_task_run_bytes_read(struct at_info *ati, char *msg)
+{
+        /*
+         * If here, then we have read a message.  Now we have to process it.
+         * Our rx state will dictate how we process this message beacuse that
+         * allows us to know previous messages and what message type to expect.
+         */
+        switch (ati->rx_state) {
+        case AT_RX_STATE_CMD:
+                /* We are in the middle of receiving a command message. */
+                process_cmd_msg(ati, msg);
+        case AT_RX_STATE_URC:
+                /* We are in the middle of receiving a unexpected message. */
+                process_urc_msg(ati, msg);
+        case AT_RX_STATE_READY:
+                /*
+                 * We are starting a new message series.  Gotta figure out what
+                 * type of message this is before we process it.  Then we process
+                 * it appropriately.
+                 */
+                ; /* C is stupid after labels.  Workaround :\ */
+                struct at_urc *urc = is_urc_msg(ati, msg);
+                if (urc) {
+                        begin_urc_msg(ati, urc);
+                        process_urc_msg(ati, msg);
+                } else if (ati->cmd_ip) { /* Is there a command in progress */
+                        /* If so, then cmd_ip is already set */
+                        process_cmd_msg(ati, msg);
+                } else {
+                        /* We got data but have no URC or CMD for it */
+                        pr_warning_str_msg("[at] Unhandled msg received: ",
+                                           msg);
+                        /* Need a clean buffer for expected msgs */
+                        serial_buffer_clear(ati->sb);
+                }
+        }
+}
+
+/**
+ * Keeps an eye on the at command state.  If we are in the quiet period, this
+ * method will keep an eye on the time so that we will change state back to
+ * the READY state once the timeout has expired.
+ */
+void at_task_quiet_period_handler(struct at_info *ati)
+{
+        if (AT_CMD_STATE_QUIET == ati->cmd_state &&
+            is_timed_out(ati->timing.quiet_start_ms,
+                         ati->timing.quiet_period_ms))
+                ati->cmd_state = AT_CMD_STATE_READY;
+}
+
+/**
+ * @return The pointer to the next command if available, NULL otherwise.
+ */
+static struct at_cmd* at_task_get_next_cmd(struct at_info *ati)
+{
+        if (ati->cmd_queue.count == 0)
+                return NULL; /* No commands to queue up */
+
+        struct at_cmd *cmd = ati->cmd_queue.head;
+
+        /* Increment and wrap if needed */
+        if (++ati->cmd_queue.head >= ati->cmd_queue.cmds + AT_CMD_MAX_CMDS)
+                ati->cmd_queue.head = ati->cmd_queue.cmds;
+
+        --ati->cmd_queue.count;
+        return cmd;
+}
+
+static bool at_task_cmd_handler(struct at_info *ati)
+{
+        if (AT_CMD_STATE_READY != ati->cmd_state)
+                return false; /* Not in proper state for a new command */
+
+        struct at_cmd* next_cmd = at_task_get_next_cmd(ati);
+        if (NULL == next_cmd)
+                return false; /* No command to queue. */
+
+        /* If here, then we get a command rolling */
+        ati->cmd_ip = next_cmd;
+        ati->cmd_state = AT_CMD_STATE_IN_PROGRESS;
+
+        serial_buffer_clear(ati->sb);
+        serial_buffer_append(ati->sb, ati->cmd_ip->cmd);
+        serial_buffer_tx(ati->sb);
+
+        /* Cleanup after we send our message */
+        serial_buffer_clear(ati->sb);
+
+        ati->timing.cmd_start_ms = getUptime();
+        return true;
+}
+
+/**
+ * Runs the at_task loop.  This loop listens for incomming messages and
+ * handles them appropriately, checks for timeouts and handles them if
+ * needed, handles quiet periods between AT commands and submits AT
+ * commands that have been queued up.
+ */
+void at_task(struct at_info *ati, const size_t ms_delay)
+{
+        char *msg = serial_buffer_rx(ati->sb, ms_delay);
+
+        if (msg)
+                at_task_run_bytes_read(ati, trim(msg));
+        else
+                at_task_run_no_bytes(ati);
+
+        at_task_quiet_period_handler(ati);
+        at_task_cmd_handler(ati);
+}
+
+/**
+ * Initializes an at_info struct for use with the AT system.
+ * @param ati The at_info structure to initialize.
+ * @param sb The serial_buffer to use for tx/rx.  Data is kept in the buffer
+ *           and is referenced until the command completes.  Then its gone.
+ * @param quiet_period_ms The quiet period to wait between the end of a
+ *        command and when to start the next.  Some modems need time to recover
+ *        and send URCs.
+ */
+bool init_at_info(struct at_info *ati, struct serial_buffer *sb,
+                  const tiny_millis_t quiet_period_ms)
+{
+        if (!ati || !sb)
+                return false;
+
+        /* Clear everything.  We don't know where at_info has been */
+        memset(ati, 0, sizeof(*ati));
+
+        ati->rx_state = AT_RX_STATE_READY;
+        ati->cmd_state = AT_CMD_STATE_READY;
+        ati->sb = sb;
+        ati->timing.quiet_period_ms = quiet_period_ms;
+
+        /* Init the HEAD pointer of our queue... else segfault */
+        ati->cmd_queue.head = ati->cmd_queue.cmds;
+
+        return true;
+}
+
+/**
+ * Puts a new AT command in the execute queue.
+ * @param ati The at_info state struct.
+ * @param cmd The string command to execute.
+ * @param rsp_cb The callback to execute when the command completes.  May
+ *        be NULL if you want no callback (not advised).
+ * @param timeout_ms The amount of time to wait for a response in ms.
+ * @return The pointer to the location of the at_cmd struct in the queue,
+ *         else NULL if submisison failed.
+ */
+struct at_cmd* at_put_cmd(struct at_info *ati, const char *cmd,
+                          void (*rsp_cb)(struct at_rsp *rsp),
+                          const tiny_millis_t timeout_ms)
+{
+        if (ati->cmd_queue.count >= AT_CMD_MAX_CMDS) {
+                 /* Full up */
+                pr_warning("[at] Command queue full");
+                return NULL;
+        }
+
+        if (strlen(cmd) >= AT_CMD_MAX_LEN) {
+                /* Command too long */
+                pr_warning_str_msg("[at] Command too long: ", cmd);
+                return NULL;
+        }
+
+        /* If here, we have space and its ok.  Add it */
+        struct at_cmd *atcmd = ati->cmd_queue.head + ati->cmd_queue.count;
+        if (atcmd >= ati->cmd_queue.cmds + AT_CMD_MAX_CMDS)
+                atcmd -= AT_CMD_MAX_CMDS;
+
+        ++ati->cmd_queue.count;
+        atcmd->timeout_ms = timeout_ms;
+        atcmd->rsp_cb = rsp_cb;
+        strcpy(atcmd->cmd, cmd); /* Sane b/c len check above */
+
+        return atcmd;
+}
+
+/**
+ * Registers a URC with the AT engine.  URC stands for unsolicited result
+ * code.  These are asynchronous commands that can appear at any time,
+ * except when a command is already in progress (defined as the point between
+ * when the control character of the command is sent to when the response
+ * message returns from the command).  The idea is that when you register
+ * a command and it is seen, then you will get a call back to the handler.
+ * This allows you to sanely handle state changes as they occur and avoid
+ * unnecessary polling for status when URCs can provide interrupt based
+ * updates for you.
+ * @param ati An at_info structure.
+ * @param pfx The URC prefix.  These often look like "+SOMECMD:"
+ * @param rsp_cb The callback to invoke when a URC is received.
+ * @return The pointer to the URC entry in our list, or NULL if we failed
+ *         to register the URC.
+ */
+struct at_urc* at_register_urc(struct at_info *ati, const char *pfx,
+                               void (*rsp_cb)(struct at_rsp *rsp),
+                               const enum at_urc_flags flags)
+{
+        if (ati->urc_list.count >= AT_URC_MAX_URCS) {
+                 /* Full up */
+                pr_warning("[at] URC list full");
+                return NULL;
+        }
+
+        const size_t pfx_len = strlen(pfx);
+        if (pfx_len >= AT_URC_MAX_LEN) {
+                /* URC prefix is too long */
+                pr_warning_str_msg("[at] URC prefix too long: ", pfx);
+                return NULL;
+        }
+
+        /* If here, we have space and its ok.  Add it */
+        struct at_urc *aturc = ati->urc_list.urcs + ati->urc_list.count;
+        ++ati->urc_list.count;
+
+        aturc->rsp_cb = rsp_cb;
+        aturc->flags = flags;
+        aturc->pfx_len = pfx_len;
+        strcpy(aturc->pfx, pfx); /* Sane b/c len check above */
+
+        return aturc;
+}

--- a/src/serial/serial_buffer.c
+++ b/src/serial/serial_buffer.c
@@ -63,8 +63,8 @@ bool serial_buffer_create(struct serial_buffer *sb,
         return false;
 }
 
-int serial_buffer_rx(struct serial_buffer *sb,
-                     const size_t ms_delay)
+char* serial_buffer_rx(struct serial_buffer *sb,
+                       const size_t ms_delay)
 {
         const size_t available = sb->length - sb->curr_len;
         char *ptr = sb->buffer + sb->curr_len;
@@ -74,39 +74,29 @@ int serial_buffer_rx(struct serial_buffer *sb,
                 const int read = serial_get_line_wait(
                         sb->serial, ptr, available, msToTicks(ms_delay));
 
-                if (!read) {
-                        pr_trace("[serial_buffer] msg timeout\r\n");
-                        return 0;
-                }
+                if (!read)
+                        return NULL;
 
                 ctrl_char_strip(ptr);
                 msg_len = strlen(ptr);
         }
 
-        pr_trace("[serial_buffer] Msg (offset = ");
-        pr_trace_int(sb->curr_len);
-        pr_trace("): \"");
-        pr_trace(ptr);
-        pr_trace("\"\r\n");
-
         sb->curr_len += msg_len + 1;
-        return msg_len + 1;
+        return ptr;
 }
 
 size_t serial_buffer_rx_msgs(struct serial_buffer *sb, const size_t ms_delay,
                              const char *msgs[], size_t msgs_len)
 {
-        size_t rx_bytes = 0;
         size_t msgs_rx = 0;
 
         for (; msgs_len; --msgs_len, ++msgs_rx) {
-                const size_t read = serial_buffer_rx(sb, ms_delay);
+                const char* msg = serial_buffer_rx(sb, ms_delay);
 
-                if (0 == read)
+                if (!msg)
                         break;
 
-                *msgs++ = sb->buffer + rx_bytes;
-                rx_bytes += read;
+                *msgs++ = msg;
         }
 
         return msgs_rx;

--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -1,0 +1,121 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "FreeRTOS.h"
+#include "at.h"
+#include "esp8266.h"
+#include "printk.h"
+#include "serial.h"
+#include "serial_buffer.h"
+#include "task.h"
+#include "wifi.h"
+
+#define WIFI_TASK_THREAD_NAME	"WiFi Task"
+#define WIFI_TASK_STACK_SIZE	512
+#define WIFI_SERIAL_PORT	SERIAL_AUX
+#define WIFI_SERIAL_BAUD	115200
+#define WIFI_SERIAL_BITS	8
+#define WIFI_SERIAL_STOP_BITS	1
+#define WIFI_SERIAL_PARITY	0
+#define WIFI_SERIAL_BUFF_SIZE	512
+#define WIFI_AT_DEFAULT_QP_MS	250
+#define WIFI_AT_DEFAULT_DELIM	"\r\n"
+#define WIFI_AT_TASK_TIMEOUT_MS	5
+
+static struct {
+        Serial *serial;
+        struct serial_buffer serial_buff;
+        struct at_info ati;
+} state;
+
+static bool init_task_state()
+{
+        /* Get our serial port setup */
+        state.serial = get_serial(WIFI_SERIAL_PORT);
+        state.serial->init(WIFI_SERIAL_BITS, WIFI_SERIAL_PARITY,
+                           WIFI_SERIAL_STOP_BITS, WIFI_SERIAL_BAUD);
+        if (!state.serial)
+                return false;
+
+        /*
+         * Initialize the serial buffer.  I put the s_buff here because
+         * this way it is not accessible outside of this method.  And
+         * since it is not on the stack (because static), it is safe to
+         * do.
+         */
+        static char s_buff[WIFI_SERIAL_BUFF_SIZE];
+        serial_buffer_create(&state.serial_buff, state.serial,
+                             WIFI_SERIAL_BUFF_SIZE, s_buff);
+
+        /* Init our AT engine here */
+        init_at_info(&state.ati, &state.serial_buff,
+                     WIFI_AT_DEFAULT_QP_MS, WIFI_AT_DEFAULT_DELIM);
+        return true;
+}
+
+static void init_status_complete(const char *msg)
+{
+        pr_info_str_msg("[wifi] Device init status: ", msg);
+        vTaskDelete(NULL);
+        return; /* Panic */
+}
+
+static void wifi_task_loop()
+{
+        at_task(&state.ati, WIFI_AT_TASK_TIMEOUT_MS);
+
+        switch(esp1866_get_dev_init_state()) {
+        case DEV_INIT_STATE_NOT_READY:
+                /* Then lets get it going */
+                esp8266_begin_init(&state.ati);
+                break;
+        case DEV_INIT_INITIALIZING:
+                /* Its in progress.  Nothing to do */
+                break;
+        case DEV_INIT_STATE_READY:
+                /* W00t.  Success */
+                return init_status_complete("Success!");
+        case DEV_INIT_STATE_FAILED:
+                return init_status_complete("Failure :(");
+        }
+}
+
+static void wifi_task(void *params)
+{
+        if (!init_task_state()) {
+                pr_error("[wifi] Failed to init\r\n");
+                vTaskDelete(NULL);
+                return; /* Panic! */
+        }
+
+        for(;;)
+                wifi_task_loop();
+
+        /* Panic! */
+}
+
+void start_wifi_task(const int priority)
+{
+        const signed char * const task_name =
+                (const signed char *) WIFI_TASK_THREAD_NAME;
+        const size_t stack_size = WIFI_TASK_STACK_SIZE;
+        xTaskCreate(wifi_task, task_name, stack_size, NULL, priority, NULL);
+}

--- a/src/util/mod_string.c
+++ b/src/util/mod_string.c
@@ -19,8 +19,10 @@
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #include "mod_string.h"
+
+#include <stdbool.h>
+#include <ctype.h>
 
 void * memcpy(void * __restrict s1, const void * __restrict s2, size_t n)
 {
@@ -289,4 +291,27 @@ char * strchr(const char *s, const int i)
     } while (*s++);
 
     return NULL;
+}
+
+char* trim(char *str)
+{
+        /*
+         * Shamelessly borrowed and modified from
+         * http://stackoverflow.com/questions/122616/how-do-i-trim-leading-trailing-whitespace-in-a-standard-way
+         */
+
+        /* Trim leading space */
+        while(isspace(*str))
+                ++str;
+
+        if(!*str)
+                return str; /* All spaces */
+
+        /* Trim trailing space */
+        char *end = str + strlen(str) - 1;
+        while(end > str && isspace(*end))
+                --end;
+
+        *++end = '\0';
+        return str;
 }

--- a/src/util/mod_string.c
+++ b/src/util/mod_string.c
@@ -22,7 +22,6 @@
 #include "mod_string.h"
 
 #include <stdbool.h>
-#include <ctype.h>
 
 void * memcpy(void * __restrict s1, const void * __restrict s2, size_t n)
 {
@@ -291,27 +290,4 @@ char * strchr(const char *s, const int i)
     } while (*s++);
 
     return NULL;
-}
-
-char* trim(char *str)
-{
-        /*
-         * Shamelessly borrowed and modified from
-         * http://stackoverflow.com/questions/122616/how-do-i-trim-leading-trailing-whitespace-in-a-standard-way
-         */
-
-        /* Trim leading space */
-        while(isspace(*str))
-                ++str;
-
-        if(!*str)
-                return str; /* All spaces */
-
-        /* Trim trailing space */
-        char *end = str + strlen(str) - 1;
-        while(end > str && isspace(*end))
-                --end;
-
-        *++end = '\0';
-        return str;
 }

--- a/stm32_base/config.mk
+++ b/stm32_base/config.mk
@@ -101,6 +101,7 @@ APP_SRC = 	$(APP_PATH)/main.c \
 			$(RCP_SRC)/tracks/tracks.c \
 			$(RCP_SRC)/auto_config/auto_track.c \
 			$(RCP_SRC)/messaging/messaging.c \
+			$(RCP_SRC)/modem/at.c \
 			$(RCP_SRC)/LED/LED.c \
 			$(RCP_SRC)/PWM/PWM.c \
 			$(RCP_SRC)/logging/printk.c \
@@ -178,6 +179,7 @@ APP_INCLUDES += -I. \
 				-I$(INCLUDE_DIR)/lua \
 				-I$(INCLUDE_DIR)/imu \
 				-I$(INCLUDE_DIR)/messaging \
+				-I$(INCLUDE_DIR)/modem \
 				-I$(INCLUDE_DIR)/predictive_timer \
 				-I$(INCLUDE_DIR)/util \
 				-I$(INCLUDE_DIR)/devices \

--- a/stm32_base/config.mk
+++ b/stm32_base/config.mk
@@ -62,6 +62,7 @@ APP_SRC = 	$(APP_PATH)/main.c \
 			$(RCP_SRC)/ADC/ADC.c \
 			$(RCP_SRC)/GPIO/GPIO.c \
 			$(RCP_SRC)/GPIO/gpioTasks.c \
+			$(RCP_SRC)/tasks/wifi.c \
 			$(RCP_SRC)/watchdog/watchdog.c \
 			$(RCP_SRC)/launch_control.c \
 			$(RCP_SRC)/lap_stats/lap_stats.c \
@@ -93,6 +94,7 @@ APP_SRC = 	$(APP_PATH)/main.c \
 			$(RCP_SRC)/logger/luaLoggerBinding.c \
 			$(RCP_SRC)/logger/sampleRecord.c \
 			$(RCP_SRC)/devices/bluetooth.c \
+			$(RCP_SRC)/devices/esp8266.c \
 			$(RCP_SRC)/devices/sara_u280.c \
 			$(RCP_SRC)/devices/sim900.c \
 			$(RCP_SRC)/devices/null_device.c \
@@ -158,6 +160,7 @@ APP_INCLUDES += -I. \
 				-I$(INCLUDE_DIR)/api \
 				-I$(INCLUDE_DIR)/logger \
 				-I$(INCLUDE_DIR)/channels \
+				-I$(INCLUDE_DIR)/tasks \
 				-I$(INCLUDE_DIR)/tracks \
 				-I$(INCLUDE_DIR)/logging \
 				-I$(INCLUDE_DIR)/filter \

--- a/test/AtTest.cpp
+++ b/test/AtTest.cpp
@@ -426,3 +426,34 @@ void AtTest::test_is_timed_out_ok()
 {
         CPPUNIT_ASSERT(is_timed_out(getUptime(), 0));
 }
+
+void AtTest::test_at_configure_device()
+{
+        const tiny_millis_t qp = 5;
+        const char delim = '\b';
+
+        at_configure_device(&g_ati, qp, delim);
+
+        CPPUNIT_ASSERT_EQUAL(qp, g_ati.dev_cfg.quiet_period_ms);
+        CPPUNIT_ASSERT_EQUAL(delim, g_ati.dev_cfg.delim);
+}
+
+void AtTest::test_at_ok()
+{
+        CPPUNIT_ASSERT(!at_ok(NULL));
+
+
+        struct at_rsp rsp;
+        rsp.status = AT_RSP_STATUS_ERROR;
+        CPPUNIT_ASSERT(!at_ok(&rsp));
+
+        rsp.status = AT_RSP_STATUS_UNKNOWN;
+        CPPUNIT_ASSERT(!at_ok(&rsp));
+
+        rsp.status = AT_RSP_STATUS_NONE;
+        CPPUNIT_ASSERT(!at_ok(&rsp));
+
+
+        rsp.status = AT_RSP_STATUS_OK;
+        CPPUNIT_ASSERT(at_ok(&rsp));
+}

--- a/test/AtTest.cpp
+++ b/test/AtTest.cpp
@@ -1,0 +1,416 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AtTest.hh"
+#include "array_utils.h"
+#include "at.h"
+#include "cpp_guard.h"
+#include "serial_buffer.h"
+#include "serial.h"
+
+#include <stdbool.h>
+
+/* Inclue the code to test here */
+extern "C" {
+#include "at.c"
+}
+
+CPPUNIT_TEST_SUITE_REGISTRATION( AtTest );
+
+CPP_GUARD_BEGIN
+
+void flush(void) {};
+void put_c(char c) {};
+void put_s(const char *c) {};
+static Serial g_serial = {
+        .rx_callback = NULL,
+        .tx_callback = NULL,
+        .flush = flush,
+        .get_c = NULL,
+        .get_c_wait = NULL,
+        .get_line = NULL,
+        .get_line_wait = NULL,
+        .init = NULL,
+        .put_c = put_c,
+        .put_s = put_s,
+};
+
+static const size_t g_sb_buff_size = 64;
+static char g_sb_buff[g_sb_buff_size];
+static struct serial_buffer g_sb = {
+        .serial = &g_serial,
+        .length = g_sb_buff_size,
+        .buffer = g_sb_buff,
+};
+
+static struct at_info g_ati;
+static struct at_urc g_urc;
+
+bool g_cb_called;
+void cb(struct at_rsp *rsp) {
+        g_cb_called = true;
+}
+
+CPP_GUARD_END
+
+void AtTest::setUp()
+{
+        /* Always init our structs */
+        init_at_info(&g_ati, &g_sb, 1);
+        g_cb_called = false;
+}
+
+void AtTest::test_init_at_info()
+{
+        /* Setup some random data to ensure it gets wiped */
+        g_ati.cmd_state = AT_CMD_STATE_IN_PROGRESS;
+        g_ati.rx_state = AT_RX_STATE_CMD;
+        g_ati.timing.quiet_period_ms = 42;
+        g_ati.urc_list.count = 57;
+
+        CPPUNIT_ASSERT_EQUAL(true, init_at_info(&g_ati, &g_sb, 1));
+        CPPUNIT_ASSERT_EQUAL(AT_CMD_STATE_READY, g_ati.cmd_state);
+        CPPUNIT_ASSERT_EQUAL(AT_RX_STATE_READY, g_ati.rx_state);
+        CPPUNIT_ASSERT_EQUAL(1, g_ati.timing.quiet_period_ms);
+        CPPUNIT_ASSERT_EQUAL((size_t) 0, g_ati.urc_list.count);
+        CPPUNIT_ASSERT_EQUAL(&g_sb, g_ati.sb);
+}
+
+void AtTest::test_init_at_info_failures()
+{
+        /* No Serial Buffer should fail */
+        CPPUNIT_ASSERT_EQUAL(false, init_at_info(&g_ati, NULL, 0));
+        CPPUNIT_ASSERT_EQUAL(false, init_at_info(NULL, &g_sb, 0));
+}
+
+void AtTest::test_at_put_cmd_full()
+{
+        g_ati.cmd_queue.count = AT_CMD_MAX_CMDS;
+        CPPUNIT_ASSERT(!at_put_cmd(&g_ati, "F", cb, 0));
+}
+
+void AtTest::test_at_put_cmd_too_long()
+{
+        char cmd[AT_CMD_MAX_LEN + 1] = {};
+        memset(cmd, 'A', AT_CMD_MAX_LEN);
+        CPPUNIT_ASSERT(!at_put_cmd(&g_ati, cmd, cb, 0));
+}
+
+void AtTest::test_at_put_cmd_ok()
+{
+        tiny_millis_t to = 42;
+        const char *str = "ABC123";
+        struct at_cmd *cmd = at_put_cmd(&g_ati, str, cb, to);
+        CPPUNIT_ASSERT(cmd);
+
+        CPPUNIT_ASSERT_EQUAL((size_t) 1, g_ati.cmd_queue.count);
+        CPPUNIT_ASSERT_EQUAL(cmd, g_ati.cmd_queue.head);
+        CPPUNIT_ASSERT_EQUAL(to, cmd->timeout_ms);
+        CPPUNIT_ASSERT_EQUAL(&cb, cmd->rsp_cb);
+        CPPUNIT_ASSERT(0 == strcmp(str, cmd->cmd));
+}
+
+void AtTest::test_at_get_next_cmd_ok()
+{
+        tiny_millis_t to = 46;
+        const char *str = "123ABC";
+        struct at_cmd *put_cmd = at_put_cmd(&g_ati, str, cb, to);
+        struct at_cmd *get_cmd = at_task_get_next_cmd(&g_ati);
+
+        CPPUNIT_ASSERT_EQUAL((size_t) 0, g_ati.cmd_queue.count);
+        CPPUNIT_ASSERT_EQUAL(put_cmd, get_cmd);
+}
+
+void AtTest::test_at_get_next_cmd_no_cmd()
+{
+        CPPUNIT_ASSERT(!at_task_get_next_cmd(&g_ati));
+}
+
+void AtTest::test_cmd_ring_buff_logic()
+{
+        /*
+         * Loop over the put and get commands a couple of times to ensure
+         * that the values we get match what we expect.
+         */
+        tiny_millis_t to = 23;
+        const char *str = "AT+BEERME NOW,SIERRA_NEVADA,TORPEDO";
+
+        for (size_t i = 0; i < AT_CMD_MAX_CMDS * 2; ++i) {
+                struct at_cmd *put_cmd = at_put_cmd(&g_ati, str, cb, to);
+                struct at_cmd *get_cmd = at_task_get_next_cmd(&g_ati);
+                CPPUNIT_ASSERT_EQUAL((size_t) 0, g_ati.cmd_queue.count);
+                CPPUNIT_ASSERT_EQUAL(put_cmd, get_cmd);
+        }
+}
+
+void AtTest::test_at_task_cmd_handler_bad_state()
+{
+        g_ati.cmd_state = AT_CMD_STATE_QUIET;
+        CPPUNIT_ASSERT(!at_task_cmd_handler(&g_ati));
+}
+
+void AtTest::test_at_task_cmd_handler_no_cmd()
+{
+        /* By default we are in proper state without commands */
+        CPPUNIT_ASSERT(!at_task_cmd_handler(&g_ati));
+}
+
+void AtTest::test_at_task_cmd_handler_ok()
+{
+        /* Puts a command */
+        test_at_put_cmd_ok();
+
+        CPPUNIT_ASSERT(at_task_cmd_handler(&g_ati));
+        CPPUNIT_ASSERT(g_ati.cmd_ip);
+        CPPUNIT_ASSERT_EQUAL(AT_CMD_STATE_IN_PROGRESS, g_ati.cmd_state);
+        CPPUNIT_ASSERT_EQUAL(getUptime(), g_ati.timing.cmd_start_ms);
+}
+
+
+void AtTest::test_at_regisger_urc_full()
+{
+        g_ati.urc_list.count = AT_URC_MAX_URCS;
+        CPPUNIT_ASSERT(!at_register_urc(&g_ati, "F", cb, AT_URC_FLAGS_NONE));
+}
+
+void AtTest::test_at_register_urc_too_long()
+{
+        char pfx[AT_URC_MAX_LEN + 1] = {};
+        memset(pfx, 'U', AT_URC_MAX_LEN);
+        CPPUNIT_ASSERT(!at_register_urc(&g_ati, pfx, cb, AT_URC_FLAGS_NONE));
+}
+
+void AtTest::test_at_register_urc_ok()
+{
+        const enum at_urc_flags flags = AT_URC_FLAGS_NO_RSP_STATUS;
+        const char *pfx = "+FOOBAR:";
+        struct at_urc *urc = at_register_urc(&g_ati, pfx, cb, flags);
+        CPPUNIT_ASSERT(urc);
+
+        CPPUNIT_ASSERT_EQUAL((size_t) 1, g_ati.urc_list.count);
+        CPPUNIT_ASSERT_EQUAL(urc, &g_ati.urc_list.urcs[0]);
+        CPPUNIT_ASSERT_EQUAL(flags, urc->flags);
+        CPPUNIT_ASSERT_EQUAL(&cb, urc->rsp_cb);
+        CPPUNIT_ASSERT(!strcmp(pfx, urc->pfx));
+}
+
+
+void AtTest::test_at_qp_handler_no_change()
+{
+        g_ati.cmd_state = AT_CMD_STATE_IN_PROGRESS;
+        at_task_quiet_period_handler(&g_ati);
+        CPPUNIT_ASSERT_EQUAL(AT_CMD_STATE_IN_PROGRESS, g_ati.cmd_state);
+
+        g_ati.cmd_state = AT_CMD_STATE_QUIET;
+        g_ati.timing.quiet_start_ms = getUptime();
+        g_ati.timing.quiet_period_ms = 1;
+        at_task_quiet_period_handler(&g_ati);
+        CPPUNIT_ASSERT_EQUAL(AT_CMD_STATE_QUIET, g_ati.cmd_state);
+}
+
+void AtTest::test_at_qp_handler_change()
+{
+        g_ati.cmd_state = AT_CMD_STATE_QUIET;
+        g_ati.timing.quiet_start_ms = getUptime();
+        g_ati.timing.quiet_period_ms = 0;
+        at_task_quiet_period_handler(&g_ati);
+        CPPUNIT_ASSERT_EQUAL(AT_CMD_STATE_READY, g_ati.cmd_state);
+}
+
+void AtTest::test_at_begin_urc_msg()
+{
+        tiny_millis_t uptime = getUptime();
+        begin_urc_msg(&g_ati, &g_urc);
+
+        CPPUNIT_ASSERT_EQUAL(&g_urc, g_ati.urc_ip);
+        CPPUNIT_ASSERT_EQUAL(uptime, g_ati.timing.urc_start_ms);
+}
+
+void AtTest::test_at_process_msg_generic()
+{
+        const char *msg = "FOOOOOO";
+        const enum at_rx_state state = AT_RX_STATE_URC;
+        _process_msg_generic(&g_ati, state, msg);
+
+        CPPUNIT_ASSERT_EQUAL(state, g_ati.rx_state);
+        CPPUNIT_ASSERT_EQUAL(msg, g_ati.rsp.msgs[0]);
+        CPPUNIT_ASSERT_EQUAL((size_t) 1, g_ati.rsp.msg_count);
+}
+
+void AtTest::test_at_process_msg_generic_too_many()
+{
+        const char *msg = "FOOOOOO";
+        const enum at_rx_state state = AT_RX_STATE_URC;
+        for(size_t i = 0; i < AT_RSP_MAX_MSGS; ++i)
+                CPPUNIT_ASSERT(_process_msg_generic(&g_ati, state, msg));
+
+        /* Now it should fail because we have too many messages */
+        CPPUNIT_ASSERT(!_process_msg_generic(&g_ati, state, msg));
+}
+
+void AtTest::test_at_process_urc_msg_with_status()
+{
+        const enum at_urc_flags flags = AT_URC_FLAGS_NONE;
+        char pfx[] = "+ABC123";
+        struct at_urc *urc = at_register_urc(&g_ati, pfx, cb, flags);
+        CPPUNIT_ASSERT(urc);
+
+        begin_urc_msg(&g_ati, urc);
+        process_urc_msg(&g_ati, pfx);
+
+         /* No callback yet b/c no status msg yet */
+        CPPUNIT_ASSERT(!g_cb_called);
+        CPPUNIT_ASSERT_EQUAL(AT_RX_STATE_URC, g_ati.rx_state);
+
+        char pfx_status[] = "OK";
+        process_urc_msg(&g_ati, pfx_status);
+
+        /* Now we expecte a callback b/c of status msg */
+        CPPUNIT_ASSERT(g_cb_called);
+        CPPUNIT_ASSERT_EQUAL(AT_RX_STATE_READY, g_ati.rx_state);
+}
+
+void AtTest::test_at_process_urc_msg_no_status()
+{
+        const enum at_urc_flags flags = AT_URC_FLAGS_NO_RSP_STATUS;
+        char pfx[] = "+FOOBAR";
+        struct at_urc *urc = at_register_urc(&g_ati, pfx, cb, flags);
+        CPPUNIT_ASSERT(urc);
+
+        begin_urc_msg(&g_ati, urc);
+        process_urc_msg(&g_ati, pfx);
+
+        /* We expecte a callback b/c of flags value */
+        CPPUNIT_ASSERT(g_cb_called);
+        CPPUNIT_ASSERT_EQUAL(AT_RX_STATE_READY, g_ati.rx_state);
+}
+
+
+void AtTest::test_at_process_cmd_msg()
+{
+        /* This sets up our command and start it */
+        test_at_task_cmd_handler_ok();
+
+        char msg[] = "+BAR: BAX,BIZ";
+        process_cmd_msg(&g_ati, msg);
+        CPPUNIT_ASSERT(g_ati.cmd_ip);
+        CPPUNIT_ASSERT(!g_cb_called);
+        CPPUNIT_ASSERT_EQUAL(AT_RX_STATE_CMD, g_ati.rx_state);
+
+        char status[] = "FAILED";
+        process_cmd_msg(&g_ati, status);
+        /* We expecte a callback b/c of status message */
+        CPPUNIT_ASSERT(g_cb_called);
+        CPPUNIT_ASSERT_EQUAL(AT_RX_STATE_READY, g_ati.rx_state);
+}
+
+
+void AtTest::test_is_urc_msg_none()
+{
+        char msg[] = "+FOO: BAZZ";
+        CPPUNIT_ASSERT(!is_urc_msg(&g_ati, msg));
+}
+
+void AtTest::test_is_urc_msg_no_match()
+{
+        const enum at_urc_flags flags = AT_URC_FLAGS_NONE;
+        const char *pfx = "+FOOBAR:";
+        struct at_urc *urc = at_register_urc(&g_ati, pfx, cb, flags);
+        CPPUNIT_ASSERT(urc);
+
+        char msg[] = "+FOO: BAZZ";
+        CPPUNIT_ASSERT(!is_urc_msg(&g_ati, msg));
+}
+
+void AtTest::test_is_urc_msg_match()
+{
+        const enum at_urc_flags flags = AT_URC_FLAGS_NONE;
+        const char *pfx = "+FOOBAR:";
+        struct at_urc *urc = at_register_urc(&g_ati, pfx, cb, flags);
+        CPPUNIT_ASSERT(urc);
+
+        char msg[] = "+FOOBAR: STATUS, STATUS, STATUS";
+        CPPUNIT_ASSERT(is_urc_msg(&g_ati, msg));
+}
+
+void AtTest::test_is_rsp_status_nope()
+{
+        enum at_rsp_status s;
+
+        char msg1[] = "NOT_A_STATUS";
+        CPPUNIT_ASSERT(!is_rsp_status(&s, msg1));
+
+        char msg2[] = "NOT OK";
+        CPPUNIT_ASSERT(!is_rsp_status(&s, msg2));
+}
+
+void AtTest::test_is_rsp_status_ok()
+{
+        for(size_t i = 0; i < ARRAY_LEN(at_status_msgs); ++i) {
+                enum at_rsp_status s;
+                CPPUNIT_ASSERT(is_rsp_status(&s, at_status_msgs[i].str));
+                CPPUNIT_ASSERT_EQUAL(s, at_status_msgs[i].status);
+        }
+}
+
+void AtTest::test_complete_cmd()
+{
+        g_ati.rx_state = AT_RX_STATE_CMD;
+
+        /* Register and start a command */
+        test_at_task_cmd_handler_ok();
+        CPPUNIT_ASSERT(g_ati.cmd_ip);
+
+        complete_cmd(&g_ati, AT_RSP_STATUS_OK);
+
+        CPPUNIT_ASSERT(!g_ati.cmd_ip);
+        CPPUNIT_ASSERT_EQUAL(AT_CMD_STATE_QUIET, g_ati.cmd_state);
+        CPPUNIT_ASSERT_EQUAL(getUptime(), g_ati.timing.quiet_start_ms);
+        CPPUNIT_ASSERT(g_cb_called);
+}
+
+void AtTest::test_complete_urc()
+{
+        g_ati.rx_state = AT_RX_STATE_URC;
+
+        /* Fake Start a URC */
+        const enum at_urc_flags flags = AT_URC_FLAGS_NO_RSP_STATUS;
+        char pfx[] = "+FOOBAR";
+        struct at_urc *urc = at_register_urc(&g_ati, pfx, cb, flags);
+        CPPUNIT_ASSERT(urc);
+        begin_urc_msg(&g_ati, urc);
+
+        complete_urc(&g_ati, AT_RSP_STATUS_OK);
+
+        CPPUNIT_ASSERT(!g_ati.urc_ip);
+        CPPUNIT_ASSERT_EQUAL(AT_CMD_STATE_READY, g_ati.cmd_state);
+        CPPUNIT_ASSERT(g_cb_called);
+}
+
+void AtTest::test_is_timed_out_fail()
+{
+        CPPUNIT_ASSERT(!is_timed_out(getUptime(), 1));
+}
+
+void AtTest::test_is_timed_out_ok()
+{
+        CPPUNIT_ASSERT(is_timed_out(getUptime(), 0));
+}

--- a/test/AtTest.hh
+++ b/test/AtTest.hh
@@ -58,6 +58,8 @@ class AtTest : public CppUnit::TestFixture
         CPPUNIT_TEST( test_complete_urc );
         CPPUNIT_TEST( test_is_timed_out_fail );
         CPPUNIT_TEST( test_is_timed_out_ok );
+        CPPUNIT_TEST( test_at_configure_device );
+        CPPUNIT_TEST( test_at_ok );
 
         CPPUNIT_TEST_SUITE_END();
 
@@ -94,6 +96,8 @@ public:
         void test_complete_urc();
         void test_is_timed_out_fail();
         void test_is_timed_out_ok();
+        void test_at_configure_device();
+        void test_at_ok();
 };
 
 #endif /* _ATTEST_H_ */

--- a/test/AtTest.hh
+++ b/test/AtTest.hh
@@ -49,6 +49,7 @@ class AtTest : public CppUnit::TestFixture
         CPPUNIT_TEST( test_at_process_urc_msg_with_status );
         CPPUNIT_TEST( test_at_process_urc_msg_no_status );
         CPPUNIT_TEST( test_at_process_cmd_msg );
+        CPPUNIT_TEST( test_at_task_run_bytes_read );
         CPPUNIT_TEST( test_is_urc_msg_none );
         CPPUNIT_TEST( test_is_urc_msg_no_match );
         CPPUNIT_TEST( test_is_urc_msg_match );
@@ -87,6 +88,7 @@ public:
         void test_at_process_urc_msg_with_status();
         void test_at_process_urc_msg_no_status();
         void test_at_process_cmd_msg();
+        void test_at_task_run_bytes_read();
         void test_is_urc_msg_none();
         void test_is_urc_msg_no_match();
         void test_is_urc_msg_match();

--- a/test/AtTest.hh
+++ b/test/AtTest.hh
@@ -1,0 +1,99 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _ATTEST_H_
+#define _ATTEST_H_
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class AtTest : public CppUnit::TestFixture
+{
+        CPPUNIT_TEST_SUITE( AtTest );
+
+        CPPUNIT_TEST( test_init_at_info );
+        CPPUNIT_TEST( test_init_at_info_failures );
+        CPPUNIT_TEST( test_at_put_cmd_full );
+        CPPUNIT_TEST( test_at_put_cmd_too_long );
+        CPPUNIT_TEST( test_at_put_cmd_ok );
+        CPPUNIT_TEST( test_at_get_next_cmd_no_cmd );
+        CPPUNIT_TEST( test_cmd_ring_buff_logic );
+        CPPUNIT_TEST( test_at_task_cmd_handler_bad_state );
+        CPPUNIT_TEST( test_at_task_cmd_handler_no_cmd );
+        CPPUNIT_TEST( test_at_task_cmd_handler_ok );
+        CPPUNIT_TEST( test_at_regisger_urc_full );
+        CPPUNIT_TEST( test_at_register_urc_too_long );
+        CPPUNIT_TEST( test_at_register_urc_ok );
+        CPPUNIT_TEST( test_at_qp_handler_no_change );
+        CPPUNIT_TEST( test_at_qp_handler_change );
+        CPPUNIT_TEST( test_at_begin_urc_msg);
+        CPPUNIT_TEST( test_at_process_msg_generic );
+        CPPUNIT_TEST( test_at_process_msg_generic_too_many );
+        CPPUNIT_TEST( test_at_process_urc_msg_with_status );
+        CPPUNIT_TEST( test_at_process_urc_msg_no_status );
+        CPPUNIT_TEST( test_at_process_cmd_msg );
+        CPPUNIT_TEST( test_is_urc_msg_none );
+        CPPUNIT_TEST( test_is_urc_msg_no_match );
+        CPPUNIT_TEST( test_is_urc_msg_match );
+        CPPUNIT_TEST( test_is_rsp_status_nope );
+        CPPUNIT_TEST( test_is_rsp_status_ok );
+        CPPUNIT_TEST( test_complete_cmd );
+        CPPUNIT_TEST( test_complete_urc );
+        CPPUNIT_TEST( test_is_timed_out_fail );
+        CPPUNIT_TEST( test_is_timed_out_ok );
+
+        CPPUNIT_TEST_SUITE_END();
+
+public:
+        void setUp();
+        void test_init_at_info();
+        void test_init_at_info_failures();
+        void test_at_put_cmd_full();
+        void test_at_put_cmd_too_long();
+        void test_at_put_cmd_ok();
+        void test_at_get_next_cmd_ok();
+        void test_at_get_next_cmd_no_cmd();
+        void test_cmd_ring_buff_logic();
+        void test_at_task_cmd_handler_bad_state();
+        void test_at_task_cmd_handler_no_cmd();
+        void test_at_task_cmd_handler_ok();
+        void test_at_regisger_urc_full();
+        void test_at_register_urc_too_long();
+        void test_at_register_urc_ok();
+        void test_at_qp_handler_no_change();
+        void test_at_qp_handler_change();
+        void test_at_begin_urc_msg();
+        void test_at_process_msg_generic();
+        void test_at_process_msg_generic_too_many();
+        void test_at_process_urc_msg_with_status();
+        void test_at_process_urc_msg_no_status();
+        void test_at_process_cmd_msg();
+        void test_is_urc_msg_none();
+        void test_is_urc_msg_no_match();
+        void test_is_urc_msg_match();
+        void test_is_rsp_status_nope();
+        void test_is_rsp_status_ok();
+        void test_complete_cmd();
+        void test_complete_urc();
+        void test_is_timed_out_fail();
+        void test_is_timed_out_ok();
+};
+
+#endif /* _ATTEST_H_ */

--- a/test/Makefile
+++ b/test/Makefile
@@ -36,6 +36,7 @@ INCLUDES = \
 -I$(RCP_INC)/virtual_channel \
 -I$(RCP_INC)/tracks \
 -I$(RCP_INC)/messaging \
+-I$(RCP_INC)/modem \
 -I$(RCP_INC)/lua \
 -I$(RCP_INC)/command \
 -I$(RCP_INC)/predictive_timer \
@@ -199,6 +200,7 @@ mock_usb_comm.c \
 SIM_C_SRC = \
 $(RCP_SRC)/devices/cellular_api_status_keys.c \
 $(RCP_SRC)/lap_stats/lap_stats.c \
+$(RCP_SRC)/modem/at.c \
 
 OBJ_TEST = $(addprefix build/, $(addsuffix .o, $(subst $(RCP_BASE)/, rcp_base/, $(basename $(SRC) $(T_SRC) RCPTest.cpp))))
 OBJ_SIM = $(addprefix build/, $(addsuffix .o, $(subst $(RCP_BASE)/, rcp_base/, $(basename $(SRC) $(SIM_C_SRC) RCPSim.cpp))))

--- a/test/Makefile
+++ b/test/Makefile
@@ -69,6 +69,7 @@ INCLUDES = \
 -I$(UTIL_DIR) \
 -I$(RCP_SRC)/devices \
 -I$(RCP_SRC)/lap_stats \
+-I$(RCP_SRC)/modem \
 
 # set up compiler and options
 CPP = g++
@@ -110,6 +111,7 @@ $(GPS_DIR)/gps_test.cpp \
 $(LAP_STATS_DIR)/LapStatsTest.cpp \
 $(UTIL_DIR)/atonum_test.cpp \
 $(UTIL_DIR)/numtoa_test.cpp \
+AtTest.cpp \
 CellularApiStatusKeysTest.cpp \
 PredictiveTimeTest2.cpp \
 date_time_test.cpp \


### PR DESCRIPTION
This patchset has a working version of the new AT command engine along with all unit tests.  This engine is what we will use to handle all commands going to and from the various communication devices we support.  WiFi & Cellular will make use of it.  It implements asynchronous call backs so none of the commands are blocking.  It expects the `at_task` method to be invoked frequently as this is what checks for incoming data as well as invokes sends.

This is not intended for merge.  Rather this is a forum for feedback on the code itself.  The full WiFi patch will include all you see here plus the driver for the WiFi chip and the task management.