### PR TITLE
Remove de-init code in USB driver when USB gets suspended

### DIFF
--- a/stm32_base/hal/usb_stm32/usbd_cdc_vcp.c
+++ b/stm32_base/hal/usb_stm32/usbd_cdc_vcp.c
@@ -310,20 +310,8 @@ void OTG_FS_IRQHandler(void)
 {
     USBD_OTG_ISR_Handler (&USB_OTG_dev);
     deinit_if_needed();
-    /*
-     * If we were previous connected, and are now suspended, deinit
-     *
-     * Removing this code since this causes the device to never re-awaken
-     * when the OS enforces an aggressive USB sleep mode.  Power consumption
-     * is not an issue we care to spend too much time on now, so removing it
-     * rather than looking up a better fix.  Patches with a proper fix are
-     * most welcome here. --Stieg
-     *
-     * if (connected && is_usb_suspended())
-     *    VCP_DeInit();
-     *
-     */
 }
+
 #ifdef USB_OTG_HS_DEDICATED_EP1_ENABLED
 /**
   * @brief  This function handles EP1_IN Handler.

--- a/stm32_base/hal/usb_stm32/usbd_cdc_vcp.c
+++ b/stm32_base/hal/usb_stm32/usbd_cdc_vcp.c
@@ -189,7 +189,7 @@ static bool check_tx_overrun(void)
 static bool is_usb_suspended(void)
 {
         /* Checks to see if the USB bus is suspended */
-        return !!(USB_OTG_dev.regs.DREGS->DSTS & 0x1);
+        return (bool) (USB_OTG_dev.regs.DREGS->DSTS & 0x1);
 }
 
 /**


### PR DESCRIPTION
This causes the device to never return to an awake state when the
USB subsustem goes into sleep mode.  The simple fix here is to
remove the call since power consumption is not a high priority for
us.  The better fix would be to fix it so that we return from sleep
when we move away from suspend.  Patches welcome.

Fixes issue #426