### PR TITLE
P/stieg/better bt telemetry

### DIFF
--- a/include/logger/connectivityTask.h
+++ b/include/logger/connectivityTask.h
@@ -36,16 +36,17 @@
 CPP_GUARD_BEGIN
 
 typedef struct _ConnParams {
-    bool always_streaming;
-    uint8_t isPrimary;
-    char * connectionName;
-    int (*disconnect)(DeviceConfig *config);
-    int (*init_connection)(DeviceConfig *config);
-    int (*check_connection_status)(DeviceConfig *config);
-    serial_id_t serial;
-    size_t periodicMeta;
-    uint32_t connection_timeout;
-    xQueueHandle sampleQueue;
+        bool always_streaming;
+        uint8_t isPrimary;
+        char * connectionName;
+        int (*disconnect)(DeviceConfig *config);
+        int (*init_connection)(DeviceConfig *config);
+        int (*check_connection_status)(DeviceConfig *config);
+        serial_id_t serial;
+        size_t periodicMeta;
+        uint32_t connection_timeout;
+        xQueueHandle sampleQueue;
+        int max_sample_rate;
 } ConnParams;
 
 void queueTelemetryRecord(const LoggerMessage *msg);

--- a/include/logger/sampleRecord.h
+++ b/include/logger/sampleRecord.h
@@ -89,9 +89,9 @@ struct sample {
 };
 
 typedef struct _LoggerMessage {
-    enum LoggerMessageType type;
-    size_t ticks;
-    struct sample *sample;
+        enum LoggerMessageType type;
+        size_t ticks;
+        struct sample *sample;
 } LoggerMessage;
 
 /**
@@ -114,10 +114,11 @@ void free_sample_buffer(struct sample *s);
 /**
  * Creates a LoggerMessage for use in the messaging between threads.
  * @param t The messaget type.
+ * @param ticks The logger tick value.
  * @param s The associated sample object (if any).
  */
 LoggerMessage create_logger_message(const enum LoggerMessageType t,
-                                    struct sample *s);
+                                    const size_t ticks, struct sample *s);
 
 /**
  * Tests if the given LoggerMessage points to valid data by comparing

--- a/src/devices/bluetooth.c
+++ b/src/devices/bluetooth.c
@@ -42,8 +42,8 @@
  * but they seem to be very stable (even with name + pin changes).  Adjust at
  * your own peril.
  */
-#define BT_BACKOFF_MS	1000
-#define BT_BAUD_RATES	{115200, 57600, 9600}
+#define BT_BACKOFF_MS	500
+#define BT_BAUD_RATES	{115200, 9600}
 #define BT_COMMAND_WAIT	600
 #define BT_DEFAULT_NAME	"RaceCapturePro"
 #define BT_DEFAULT_PIN	"1234"
@@ -51,7 +51,6 @@
 #define BT_MAX_NAME_LEN	(BT_DEVICE_NAME_LENGTH - 1)
 #define BT_MAX_PIN_LEN	(BT_PASSCODE_LENGTH - 1)
 #define BT_PING_TRIES	3
-
 
 static bluetooth_status_t g_bluetooth_status = BT_STATUS_NOT_INIT;
 
@@ -157,6 +156,10 @@ static int bt_find_working_baud(DeviceConfig *config, BluetoothConfig *btc)
                         rate = targetBaud;
 
         for (size_t i = 0; rate == 0 && i < sizeof(rates)/sizeof(*rates); ++i) {
+                /* Skip the baud rate if we have already tried it */
+                if (rates[i] == targetBaud)
+                        continue;
+
                 pr_info_int_msg("BT: Trying Baudrate: ", rates[i]);
                 if (set_check_bt_serial_baud(config, rates[i]))
                         rate = rates[i];
@@ -220,6 +223,7 @@ int bt_init_connection(DeviceConfig *config)
                 pr_info("BT: Failed to communicate with device.\r\n");
 
                 /* Restore the targetBaud rate in case already in command mode */
+                pr_info_int_msg("[BT] Restoring to target baud: ", targetBaud);
                 set_check_bt_serial_baud(config, targetBaud);
 
                 break;

--- a/src/logger/loggerTaskEx.c
+++ b/src/logger/loggerTaskEx.c
@@ -58,12 +58,12 @@ static struct sample g_sample_buffer[LOGGER_MESSAGE_BUFFER_SIZE];
 
 static LoggerMessage getLogStartMessage()
 {
-        return create_logger_message(LoggerMessageType_Start, NULL);
+        return create_logger_message(LoggerMessageType_Start, 0, NULL);
 }
 
 static LoggerMessage getLogStopMessage()
 {
-        return create_logger_message(LoggerMessageType_Stop, NULL);
+        return create_logger_message(LoggerMessageType_Stop, 0, NULL);
 }
 
 /**
@@ -235,7 +235,7 @@ void loggerTaskEx(void *params)
 
                 /* If here, create the LoggerMessage to send with the sample */
                 const LoggerMessage msg = create_logger_message(
-                        LoggerMessageType_Sample, sample);
+                        LoggerMessageType_Sample, currentTicks, sample);
 
                 /*
                  * We only log to file if the user has manually pushed the
@@ -254,11 +254,10 @@ void loggerTaskEx(void *params)
 
 
                 /*
-                 * If we're at the telemetry sample rate or lower
-                 * send it on to the telemetry task.
+                 * The task is responsible for determining if it should use the
+                 * sample or if it should drop it due to rate limitations.
                  */
-                if (should_sample(currentTicks, telemetrySampleRate))
-                        queueTelemetryRecord(&msg);
+                queueTelemetryRecord(&msg);
 
                 ++bufferIndex;
                 bufferIndex %= buffer_size;

--- a/src/logger/sampleRecord.c
+++ b/src/logger/sampleRecord.c
@@ -85,9 +85,8 @@ xQueueHandle create_logger_message_queue()
 }
 
 LoggerMessage create_logger_message(const enum LoggerMessageType t,
-                                    struct sample *s)
+                                    const size_t ticks, struct sample *s)
 {
-        const size_t ticks = getCurrentTicks();
         LoggerMessage msg;
 
         msg.type = t;

--- a/test/sampleRecord_test.cpp
+++ b/test/sampleRecord_test.cpp
@@ -402,7 +402,7 @@ void SampleRecordTest::testIsValidLoggerMessage() {
         struct sample s;
 
         /* Test the non sample case.  This always passes */
-        lm = create_logger_message(LoggerMessageType_Start, NULL);
+        lm = create_logger_message(LoggerMessageType_Start, 0, NULL);
         lm.ticks = 42;
         s.ticks = 42;
         CPPUNIT_ASSERT_EQUAL(true, is_sample_data_valid(&lm));
@@ -410,7 +410,7 @@ void SampleRecordTest::testIsValidLoggerMessage() {
         CPPUNIT_ASSERT_EQUAL(true,  is_sample_data_valid(&lm));
 
         /* Test the sample case. */
-        lm = create_logger_message(LoggerMessageType_Sample, &s);
+        lm = create_logger_message(LoggerMessageType_Sample, 0,&s);
         lm.ticks = 42;
         s.ticks = 42;
         CPPUNIT_ASSERT_EQUAL(true, is_sample_data_valid(&lm));


### PR DESCRIPTION
Ignore the BT init improvement change here as that is already part of a separate change.  The main change here is the placement of the max telemetry limits into the ConnParameters struct.  This allows us to more granularity control whether or not we should send a telemetry message when compared against the old method where we just naively set the lower of the two rates.