### PR TITLE
Add retry for CNUM command on Ublox driver

### DIFF
--- a/src/devices/sara_u280.c
+++ b/src/devices/sara_u280.c
@@ -310,9 +310,15 @@ static bool sara_u280_init(struct serial_buffer *sb,
 static bool sara_u280_get_sim_info(struct serial_buffer *sb,
                                    struct cellular_info *ci)
 {
-        return sara_u280_get_imei(sb, ci) &&
-                sara_u280_get_signal_strength(sb, ci) &&
-                sara_u280_get_subscriber_number(sb, ci);
+        bool status = false;
+
+        for (size_t i = 0; i < 3 && !status; ++i)
+                status = sara_u280_get_subscriber_number(sb, ci);
+
+        status = sara_u280_get_imei(sb, ci) && status;
+        status = sara_u280_get_signal_strength(sb, ci) && status;
+
+        return status;
 }
 
 static bool sara_u280_register_on_network(struct serial_buffer *sb,


### PR DESCRIPTION
AT&T cards seem to have some strange behavior that needs additional
setup that isn't entirely clear.  Running CNUM the first time seems
to trigger that setup, but at the cost of the command failing.  This
little hack causes us to try getting the number 3 times before failing.

It also adjusts the code so that the failure to grab any of the SIM
info does not cause other bits of SIM info to fail to be grabbed as
well.