### PR TITLE
Add ccache support in our firmware builds

### DIFF
--- a/lib/lua/src/Makefile
+++ b/lib/lua/src/Makefile
@@ -16,7 +16,7 @@ PLAT= none
 ifeq ($(PLAT), stm32)
 	MCU   = cortex-m4
 	THUMB = -mthumb
-	CC = arm-none-eabi-gcc
+	CC = $(CCACHE) arm-none-eabi-gcc
 	CFLAGS= -mcpu=$(MCU) $(THUMB) -ggdb -Os -Wall $(MYCFLAGS) -DLUA_OPTIMIZE_MEMORY=0 -DLUA_USE_MKSTEMP=1
 	AR = arm-none-eabi-ar rcu
 	RANLIB= arm-none-eabi-ranlib

--- a/make/ccache.mk
+++ b/make/ccache.mk
@@ -1,0 +1,38 @@
+# Race Capture Firmware
+#
+# Copyright (C) 2016 Autosport Labs
+#
+# This file is part of the Race Capture firmware suite
+#
+# This is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See the GNU General Public License for more details. You should
+# have received a copy of the GNU General Public License along with
+# this code. If not, see <http://www.gnu.org/licenses/>.
+
+#
+# HOW TO USE...
+#
+# To use ccache with our builds, simply export the CCACHE variable in
+# your shell environment.  It looks something like this:
+#
+# export CCACHE=ccache
+#
+# Doing this allows the developer to explicitly be able to use a
+# program that speeds up compilation, but also forces the developer to
+# realize that they are using it instead of doing it automaticlly.
+# this will help save sanity should something go wrong with CCACHE.
+#
+# Users can always ensure that use of CCACHE is bypassed by simply
+# passing CCACHE= as a make argument or by simply undefining it
+# in their environment.
+#
+
+export CCACHE

--- a/platform/mk2/Makefile
+++ b/platform/mk2/Makefile
@@ -127,19 +127,19 @@ $(TARGET).ihex: $(TARGET).bin
 
 $(TARGET).bin: $(TARGET).elf
 	@printf "  OBJCOPY $(subst $(shell pwd)/,,$(@))\n"
-	$(Q)$(PREFIX)-objcopy -Obinary $< $@
+	$(Q) $(PREFIX)-objcopy -Obinary $< $@
 
 $(TARGET).elf: $(OBJS)
 	@printf "  LD      $(subst $(shell pwd)/,,$(@))\n"
-	$(Q)$(CC) $(OBJS) $(LDFLAGS) -o $@
+	$(Q) $(CC) $(OBJS) $(LDFLAGS) -o $@
 
 .c.o:
 	@printf "  CC      $(subst $(shell pwd)/,,$(@))\n"
-	$(Q)$(CC) $(CFLAGS) -D_RCP_BASE_FILE_="\"$(notdir $<): \"" $< -o $@
+	$(Q) $(CCACHE) $(CC) $(CFLAGS) -D_RCP_BASE_FILE_="\"$(notdir $<): \"" $< -o $@
 
 .s.o:
 	@printf "  AS      $(subst $(shell pwd)/,,$(@))\n"
-	$(Q)$(CC) $(ASFLAGS) -c $< -o $@
+	$(Q) $(CCACHE) $(CC) $(ASFLAGS) -c $< -o $@
 
 clean:
 	$(Q)rm -f *.o *.a *.d ../*.o ../*.d \

--- a/platform/rct/Makefile
+++ b/platform/rct/Makefile
@@ -275,12 +275,12 @@ AFLAGS := $(CFLAGS)
 $(OUTDIR)/%.o: %.c
 	@echo "[CC] $(@F)"
 	mkdir -p $(@D)
-	$(CC) $(CFLAGS) -c -o $@ $<
+	$(CCACHE) $(CC) $(CFLAGS) -c -o $@ $<
 
 $(OUTDIR)/%.o: %.s
 	@echo "[AS] $(@F)"
 	mkdir -p $(@D)
-	$(AS) $(AFLAGS) -c -o $@ $<
+	$(CCACHE) $(AS) $(AFLAGS) -c -o $@ $<
 
 $(OUTDIR)/%.elf: $(obj-y)
 	@echo "[LD] $(@F)"

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,3 +1,22 @@
+# Race Capture Firmware
+#
+# Copyright (C) 2016 Autosport Labs
+#
+# This file is part of the Race Capture firmware suite
+#
+# This is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See the GNU General Public License for more details. You should
+# have received a copy of the GNU General Public License along with
+# this code. If not, see <http://www.gnu.org/licenses/>.
+
 #-----Macros---------------------------------
 NAME=rcptest
 SIMNAME = rcpsim
@@ -90,15 +109,15 @@ dir_guard=@mkdir -p $(@D)
 
 build/%.o: %.c
 	$(dir_guard)
-	$(CC) $(CFLAGS) -c -D_RCP_BASE_FILE_="\"$(notdir $<): \"" $< -o $@
+	$(CCACHE) $(CC) $(CFLAGS) -c -D_RCP_BASE_FILE_="\"$(notdir $<): \"" $< -o $@
 
 build/%.o: %.cpp
 	$(dir_guard)
-	$(CPP) $(CPPFLAGS) -c -D_RCP_BASE_FILE_="\"$(notdir $<): \"" $< -o $@
+	$(CCACHE) $(CPP) $(CPPFLAGS) -c -D_RCP_BASE_FILE_="\"$(notdir $<): \"" $< -o $@
 
 build/rcp_base/%.o: ../%.c
 	$(dir_guard)
-	$(CC) $(CFLAGS) -D_RCP_BASE_FILE_="\"$(notdir $<): \"" -c $< -o $@
+	$(CCACHE) $(CC) $(CFLAGS) -D_RCP_BASE_FILE_="\"$(notdir $<): \"" -c $< -o $@
 
 #-----File Dependencies----------------------
 


### PR DESCRIPTION
Because I like my builds to be quicker than Flash himself, I have
added support for ccache.  This drastically speeds up our build
process, turning builds that can take 30 - 40 seconds to builds that
will take 5 - 7 seconds depending on how much has changed.

By default it is disabled.  To use it simply define the following in
your .bashrc file after installing ccache:

export CCACHE=ccache

Once the CCACHE environment variable is defined, it will be used
during the build process.  That's it.