### PR TITLE
P/jeffc/minor usb fixes

### DIFF
--- a/platform/mk2/libs/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_Device_Library/Class/cdc/src/usbd_cdc_core.c
+++ b/platform/mk2/libs/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_Device_Library/Class/cdc/src/usbd_cdc_core.c
@@ -222,7 +222,7 @@ __ALIGN_BEGIN uint8_t usbd_cdc_CfgDesc[USB_CDC_CONFIG_DESC_SIZ]  __ALIGN_END = {
     0x02,   /* bNumInterfaces: 2 interface */
     0x01,   /* bConfigurationValue: Configuration value */
     0x00,   /* iConfiguration: Index of string descriptor describing the configuration */
-    0xC0,   /* bmAttributes: self powered */
+    0x80,   /* bmAttributes: bus powered */
     0xFA,   /* MaxPower 500 mA */
 
     /*---------------------------------------------------------------------------*/
@@ -325,7 +325,7 @@ __ALIGN_BEGIN uint8_t usbd_cdc_OtherCfgDesc[USB_CDC_CONFIG_DESC_SIZ]  __ALIGN_EN
     0x02,   /* bNumInterfaces: 2 interfaces */
     0x01,   /* bConfigurationValue: */
     0x04,   /* iConfiguration: */
-    0xC0,   /* bmAttributes: self powered */
+    0x80,   /* bmAttributes: bus powered */
     0xFA,   /* MaxPower 500 mA */
 
     /*Interface Descriptor */

--- a/platform/mk2/libs/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_Device_Library/Class/cdc/src/usbd_cdc_core.c
+++ b/platform/mk2/libs/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_Device_Library/Class/cdc/src/usbd_cdc_core.c
@@ -222,8 +222,8 @@ __ALIGN_BEGIN uint8_t usbd_cdc_CfgDesc[USB_CDC_CONFIG_DESC_SIZ]  __ALIGN_END = {
     0x02,   /* bNumInterfaces: 2 interface */
     0x01,   /* bConfigurationValue: Configuration value */
     0x00,   /* iConfiguration: Index of string descriptor describing the configuration */
-    0x80,   /* bmAttributes: bus powered */
-    0x32,   /* MaxPower 0 mA */
+    0xC0,   /* bmAttributes: self powered */
+    0xFA,   /* MaxPower 500 mA */
 
     /*---------------------------------------------------------------------------*/
 
@@ -325,8 +325,8 @@ __ALIGN_BEGIN uint8_t usbd_cdc_OtherCfgDesc[USB_CDC_CONFIG_DESC_SIZ]  __ALIGN_EN
     0x02,   /* bNumInterfaces: 2 interfaces */
     0x01,   /* bConfigurationValue: */
     0x04,   /* iConfiguration: */
-    0xC0,   /* bmAttributes: */
-    0x32,   /* MaxPower 100 mA */
+    0xC0,   /* bmAttributes: self powered */
+    0xFA,   /* MaxPower 500 mA */
 
     /*Interface Descriptor */
     0x09,   /* bLength: Interface Descriptor size */

--- a/platform/rct/hal/usb_stm32/usb_conf.h
+++ b/platform/rct/hal/usb_stm32/usb_conf.h
@@ -69,7 +69,15 @@
 /* IMR_MSK */
 /* mask defining which events has to be handled */
 /* by the device application software */
-#define IMR_MSK (CNTR_CTRM  | CNTR_WKUPM | CNTR_SUSPM | CNTR_ERRM  | CNTR_SOFM \
+
+/* JC: Original configuration
+
+  #define IMR_MSK (CNTR_CTRM  | CNTR_WKUPM | CNTR_SUSPM | CNTR_ERRM  | CNTR_SOFM \
+                | CNTR_ESOFM | CNTR_RESETM )
+*/
+
+/* JC: WKUP/SUSPEND Functionality disabled */
+#define IMR_MSK (CNTR_CTRM | CNTR_ERRM  | CNTR_SOFM \
                  | CNTR_ESOFM | CNTR_RESETM )
 
 /*#define CTR_CALLBACK*/

--- a/platform/rct/hal/usb_stm32/usb_desc.c
+++ b/platform/rct/hal/usb_stm32/usb_desc.c
@@ -62,8 +62,9 @@ const uint8_t Virtual_Com_Port_ConfigDescriptor[] =
     0x00,
     0x02,   /* bNumInterfaces: 2 interface */
     0x01,   /* bConfigurationValue: Configuration value */
-    0x00,   /* iConfiguration: Index of string descriptor describing the configuration */
-    0xC0,   /* bmAttributes: self powered */
+    0x00,   /* iConfiguration: Index of string descriptor describing
+	     * the configuration */
+    0x80,   /* bmAttributes: bus powered */
     0xFA,   /* MaxPower 500 mA */
     /*Interface Descriptor*/
     0x09,   /* bLength: Interface Descriptor size */


### PR DESCRIPTION
Ups current request limit on MK2.  Disables suspend/wakeup on RCT.