### PR TITLE
Adjust USB and I2C Priorities

### DIFF
--- a/platform/rct/hal/i2c_stm32/i2c_device_stm32.c
+++ b/platform/rct/hal/i2c_stm32/i2c_device_stm32.c
@@ -42,6 +42,7 @@
 #include <i2c_device_stm32.h>
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+#define I2C_IRQ_PRIORITY 5
 
 struct rcc_params {
 	void (*clock_cmd)(uint32_t, FunctionalState);
@@ -259,7 +260,7 @@ static void i2c_nvic_setup(struct i2c_priv *p)
 
 	/* Enable the I2Cx Interrupt */
 	NVIC_InitStructure.NVIC_IRQChannel = p->ev_irqn;
-	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
+	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = I2C_IRQ_PRIORITY;
 	NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
 	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&NVIC_InitStructure);

--- a/platform/rct/hal/usb_stm32/hw_config.c
+++ b/platform/rct/hal/usb_stm32/hw_config.c
@@ -34,7 +34,7 @@
 #include "hw_config.h"
 #include "usb_pwr.h"
 
-
+#define USB_IRQ_PRIORITY 7
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
@@ -235,7 +235,7 @@ void USB_Interrupts_Config(void)
 
 #else
   NVIC_InitStructure.NVIC_IRQChannel = USB_LP_CAN1_RX0_IRQn;
-  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 2;
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = USB_IRQ_PRIORITY;
   NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
   NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
   NVIC_Init(&NVIC_InitStructure);


### PR DESCRIPTION
Adjust I2C/USB interrupt priorities so they don't clash with the FreeRTOS minimum