### PR TITLE
Add in basic WiFi Beacon Support

### DIFF
--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -23,6 +23,7 @@
 #define _ESP8266_H_
 
 #include "cpp_guard.h"
+#include "net/protocol.h"
 #include "serial.h"
 #include <stdbool.h>
 
@@ -79,14 +80,8 @@ bool esp8266_get_client_ap(void (*cb)
 bool esp8266_get_client_ip(void (*cb)
                            (bool, const char*));
 
-enum esp8266_net_proto {
-        ESP8266_NET_PROTO_TCP,
-        ESP8266_NET_PROTO_UDP,
-};
-
-bool esp8266_connect(const int chan_id, const enum esp8266_net_proto proto,
+bool esp8266_connect(const int chan_id, const enum protocol proto,
                      const char *ip_addr, const int dest_port,
-                     const int udp_port, const int udp_mode,
                      void (*cb) (bool, const int));
 
 bool esp8266_send_data(const int chan_id, struct Serial *data,

--- a/include/drivers/esp8266_drv.h
+++ b/include/drivers/esp8266_drv.h
@@ -23,6 +23,7 @@
 #define _ESP8266_DRV_H_
 
 #include "cpp_guard.h"
+#include "net/protocol.h"
 #include "serial.h"
 #include "wifi.h"
 
@@ -35,6 +36,9 @@ bool esp8266_drv_update_client_cfg(const struct wifi_client_cfg *cc);
 bool esp8266_drv_init(struct Serial *s, const int priority,
                       new_conn_func_t new_conn_cb);
 
+struct Serial* esp8266_drv_connect(const enum protocol proto,
+                                   const char* dst_ip,
+                                   const unsigned int dst_port);
 CPP_GUARD_END
 
 #endif /* _ESP8266_DRV_H_ */

--- a/include/drivers/esp8266_drv.h
+++ b/include/drivers/esp8266_drv.h
@@ -23,6 +23,7 @@
 #define _ESP8266_DRV_H_
 
 #include "cpp_guard.h"
+#include "esp8266.h"
 #include "net/protocol.h"
 #include "serial.h"
 #include "wifi.h"
@@ -39,6 +40,9 @@ bool esp8266_drv_init(struct Serial *s, const int priority,
 struct Serial* esp8266_drv_connect(const enum protocol proto,
                                    const char* dst_ip,
                                    const unsigned int dst_port);
+
+const struct esp8266_client_info* esp8266_drv_get_client_info();
+
 CPP_GUARD_END
 
 #endif /* _ESP8266_DRV_H_ */

--- a/include/net/protocol.h
+++ b/include/net/protocol.h
@@ -1,0 +1,36 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _PROTOCOL_H_
+#define _PROTOCOL_H_
+
+#include "cpp_guard.h"
+
+CPP_GUARD_BEGIN
+
+enum protocol {
+        PROTOCOL_TCP,
+        PROTOCOL_UDP,
+};
+
+CPP_GUARD_END
+
+#endif /* _PROTOCOL_H_ */

--- a/main.c
+++ b/main.c
@@ -83,7 +83,7 @@ void setupTask(void *delTask)
         startOBD2Task(RCP_INPUT_PRIORITY);
         startConnectivityTask(RCP_OUTPUT_PRIORITY);
         startLoggerTaskEx(RCP_LOGGING_PRIORITY);
-        /* wifi_init_task(RCP_OUTPUT_PRIORITY, RCP_INPUT_PRIORITY); */
+        wifi_init_task(RCP_OUTPUT_PRIORITY, RCP_INPUT_PRIORITY);
 
 #if defined(USB_SERIAL_SUPPORT)
         startUSBCommTask(RCP_INPUT_PRIORITY);

--- a/main.c
+++ b/main.c
@@ -83,7 +83,10 @@ void setupTask(void *delTask)
         startOBD2Task(RCP_INPUT_PRIORITY);
         startConnectivityTask(RCP_OUTPUT_PRIORITY);
         startLoggerTaskEx(RCP_LOGGING_PRIORITY);
+
+#if defined(WIFI_SUPPORT)
         wifi_init_task(RCP_OUTPUT_PRIORITY, RCP_INPUT_PRIORITY);
+#endif
 
 #if defined(USB_SERIAL_SUPPORT)
         startUSBCommTask(RCP_INPUT_PRIORITY);

--- a/platform/mk2/capabilities.h
+++ b/platform/mk2/capabilities.h
@@ -13,6 +13,7 @@
 #define VIRTUAL_CHANNEL_SUPPORT
 #define SDCARD_SUPPORT
 #define CELLULAR_SUPPORT
+#define WIFI_SUPPORT
 
 //configuration
 #define MAX_TRACKS	240

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -657,10 +657,6 @@ bool esp8266_connect(const int chan_id, const enum protocol proto,
                 proto_str = "UDP";
                 break;
         default:
-                proto_str = NULL;
-        }
-
-        if (!proto_str) {
                 cmd_failure("esp8266_connect", "Invalid protocol");
                 return false;
         }

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -534,3 +534,8 @@ struct Serial* esp8266_drv_connect(const enum protocol proto,
 
         return ch->serial;
 }
+
+const struct esp8266_client_info* esp8266_drv_get_client_info()
+{
+        return &state.client.info;
+}

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -314,6 +314,7 @@ static void set_client_ap_cb(bool status)
         if (!status) {
                 /* Failed. */
                 pr_info(_LOG_PFX "Failed to join network\r\n");
+                memset(&state.client.info, 0, sizeof(state.client.info));
                 cmd_completed(_CMD_UNKNOWN, 0);
         } else {
                 /* If here, we were successful.  Now get client wifi info */


### PR DESCRIPTION
This change adds in basic beacon support for WiFi.  It does this by creating the very minimal set of calls needed to create a connection, then using them to create a Socket.  We then graph a Serial device onto that socket and send the beacon JSON code once every 3 seconds.  Listen on port 7223 and you will hear it.  Here is a netcat command I use: `nc -lu 0.0.0.0 7223`.  While the code is stable enough to run it is not robust by any means.  In its current form it does not handle disconnects.  The only reason I am putting this for review now is because this will effectively unblock our app development for socket based communication.  And as that is developed I will continue making this code more robust so that it can handle disconnects etc.