### PR TITLE
Properly check for mailbox on no timeout CAN tx

### DIFF
--- a/platform/mk2/hal/CAN_stm32/CAN_device_stm32.c
+++ b/platform/mk2/hal/CAN_stm32/CAN_device_stm32.c
@@ -286,9 +286,12 @@ int CAN_device_tx_msg(uint8_t channel, CAN_msg * msg, unsigned int timeoutMs)
         CAN_TypeDef* chan = channel == 0 ? CAN1 : CAN2;
         uint8_t mailbox = CAN_Transmit(chan, &TxMessage);
 
-        /* Then they don't want to wait.  Just assume successful */
-        if (!timeoutMs)
-                return 1;
+        /*
+         * Then they don't want to wait.  Ok.  Let caller know if they
+         * got a mailbox then.  If not, message was unable to be sent.
+         */
+        if (0 == timeoutMs)
+                return mailbox != CAN_TxStatus_NoMailBox;
 
         /* Using ticks avoids a race-condition */
         size_t ticks = getCurrentTicks();


### PR DESCRIPTION
If a user called CAN Tx and specified a timeout value of 0, then we
would always return true.  This was bad beacuse its possible that
the message never made it into a mailbox, and thus will never be sent.
This trivial patch checks the return value of the CAN tx value so that
we return true if a mailbox was obtained, and false if none were available.
This will enable stronger confidence in our CAN Tx abilities.

Fixes Issue #549