### PR TITLE
Add hooks for the poorly designed ESP8266 URC AT msgs

### DIFF
--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -22,6 +22,7 @@
 #ifndef _ESP8266_H_
 #define _ESP8266_H_
 
+#include "at.h"
 #include "cpp_guard.h"
 #include "net/protocol.h"
 #include "serial.h"
@@ -42,7 +43,18 @@ enum dev_init_state {
         DEV_INIT_STATE_FAILED,
 };
 
+typedef void client_wifi_disconnect_cb_t();
+typedef void socket_connect_cb_t(const size_t chan_id);
+typedef void socket_closed_cb_t(const size_t chan_id);
+
+struct esp8266_event_hooks {
+        client_wifi_disconnect_cb_t *client_wifi_disconnect_cb;
+        socket_connect_cb_t *socket_connect_cb;
+        socket_closed_cb_t *socket_closed_cb;
+};
+
 bool esp8266_init(struct Serial *s, const size_t max_cmd_len,
+                  const struct esp8266_event_hooks hooks,
                   void (*cb)(enum dev_init_state));
 
 enum dev_init_state esp1866_get_dev_init_state();

--- a/include/modem/at.h
+++ b/include/modem/at.h
@@ -142,7 +142,7 @@ struct at_urc_list {
  * @return true if the callback was able to parse the message,
  *         false otherwise.
  */
-typedef bool unhandled_urc_cb_t(const char* msg);
+typedef bool unhandled_urc_cb_t(char* msg);
 
 struct at_info {
         /*

--- a/include/modem/at.h
+++ b/include/modem/at.h
@@ -127,6 +127,23 @@ struct at_urc_list {
         struct at_urc urcs[AT_URC_MAX_URCS];
 };
 
+/**
+ * Callback for unhandled URCs.  This is designed to handle cases
+ * where AT commands introduce odd messages that would be difficult
+ * to register a callback for.  An example would be `0,CONNECTED`,
+ * this is hard to register since the 0 indicates the multiplexed
+ * channel, and in this case there are 5 potential combinations.
+ * Really this is a broken AT URC, so we use as sort of broken way
+ * to handle it.  A proper URC would have something like
+ * `+CONNINF: 0,"CONNECTED".  Then you would be able to handle this
+ * with a URC handler since you could match the prefix.  Oh well,
+ * imperfect solution for an imperfect world.
+ * @param msg The message that was received.
+ * @return true if the callback was able to parse the message,
+ *         false otherwise.
+ */
+typedef bool unhandled_urc_cb_t(const char* msg);
+
 struct at_info {
         /*
          * All of this is really read only.  Don't alter directly.
@@ -144,10 +161,12 @@ struct at_info {
         struct at_timing timing;
         struct at_cmd_queue cmd_queue;
         struct at_urc_list urc_list;
+        unhandled_urc_cb_t *unhandled_urc_cb;
 };
 
 bool init_at_info(struct at_info *ati, struct serial_buffer *sb,
-                  const tiny_millis_t quiet_period_ms, const char *delim);
+                  const tiny_millis_t quiet_period_ms, const char *delim,
+                  unhandled_urc_cb_t *unhandled_urc_cb);
 
 void at_task(struct at_info *ati, const size_t ms_delay);
 

--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -65,6 +65,8 @@ struct Serial* serial_create(const char *name, const size_t tx_cap,
 
 void serial_flush(struct Serial *s);
 
+void serial_clear(struct Serial *s);
+
 bool serial_logging(struct Serial *s, const bool enable);
 
 void serial_set_name(struct Serial *s, const char *name);

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -93,7 +93,7 @@ static bool _setup(struct Serial *s, const size_t max_cmd_len)
 
         /* Init our AT engine here */
         if (!init_at_info(state.ati, state.scb, _AT_DEFAULT_QP_MS,
-                          _AT_CMD_DELIM))
+                          _AT_CMD_DELIM, NULL))
                 return false;
 
         return true;

--- a/src/serial/serial.c
+++ b/src/serial/serial.c
@@ -161,6 +161,16 @@ void serial_flush(struct Serial *s)
         /* STIEG: TODO Figure out how to flush Tx sanely */
 }
 
+/**
+ * Clears the contents of the rx and tx queues.
+ */
+void serial_clear(struct Serial *s)
+{
+        char c;
+        for(; pdTRUE == xQueueReceive(s->rx_queue, &c, 0););
+        for(; pdTRUE == xQueueReceive(s->tx_queue, &c, 0););
+}
+
 bool serial_get_c_wait(struct Serial *s, char *c, const size_t delay)
 {
         if (pdFALSE == xQueueReceive(s->rx_queue, c, delay))

--- a/test/AtTest.cpp
+++ b/test/AtTest.cpp
@@ -58,7 +58,7 @@ bool cb(struct at_rsp *rsp, void *up) {
 }
 
 static bool g_uhurc_cb_called;
-bool uhurc_cb(const char* msg) {
+bool uhurc_cb(char* msg) {
         g_uhurc_cb_called = true;
         return false;
 }

--- a/test/AtTest.cpp
+++ b/test/AtTest.cpp
@@ -57,6 +57,12 @@ bool cb(struct at_rsp *rsp, void *up) {
         return false;
 }
 
+static bool g_uhurc_cb_called;
+bool uhurc_cb(const char* msg) {
+        g_uhurc_cb_called = true;
+        return false;
+}
+
 CPP_GUARD_END
 
 void AtTest::setUp()
@@ -66,9 +72,10 @@ void AtTest::setUp()
         g_sb.serial = s;
 
         /* Always init our structs */
-        init_at_info(&g_ati, &g_sb, 1, "\r\n");
+        init_at_info(&g_ati, &g_sb, 1, "\r\n", uhurc_cb);
         g_cb_called = false;
         g_up = NULL;
+        g_uhurc_cb_called = false;
 }
 
 void AtTest::test_init_at_info()
@@ -79,24 +86,30 @@ void AtTest::test_init_at_info()
         g_ati.dev_cfg.quiet_period_ms = 42;
         g_ati.urc_list.count = 57;
 
-        CPPUNIT_ASSERT_EQUAL(true, init_at_info(&g_ati, &g_sb, 1, "\r"));
+        CPPUNIT_ASSERT_EQUAL(true, init_at_info(&g_ati, &g_sb, 1,
+                                                "\r", uhurc_cb));
         CPPUNIT_ASSERT_EQUAL(AT_CMD_STATE_READY, g_ati.cmd_state);
         CPPUNIT_ASSERT_EQUAL(AT_RX_STATE_READY, g_ati.rx_state);
         CPPUNIT_ASSERT_EQUAL(1, g_ati.dev_cfg.quiet_period_ms);
         CPPUNIT_ASSERT_EQUAL((size_t) 0, g_ati.urc_list.count);
         CPPUNIT_ASSERT_EQUAL(&g_sb, g_ati.sb);
+        CPPUNIT_ASSERT_EQUAL(&uhurc_cb, g_ati.unhandled_urc_cb);
 }
 
 void AtTest::test_init_at_info_failures()
 {
         /* No Serial Buffer */
-        CPPUNIT_ASSERT_EQUAL(false, init_at_info(&g_ati, NULL, 0, "\r"));
+        CPPUNIT_ASSERT_EQUAL(false, init_at_info(&g_ati, NULL, 0,
+                                                 "\r", NULL));
         /* No at_info struct */
-        CPPUNIT_ASSERT_EQUAL(false, init_at_info(NULL, &g_sb, 0, "\n"));
+        CPPUNIT_ASSERT_EQUAL(false, init_at_info(NULL, &g_sb, 0,
+                                                 "\n", NULL));
         /* No delim */
-        CPPUNIT_ASSERT_EQUAL(false, init_at_info(&g_ati, &g_sb, 0, NULL));
+        CPPUNIT_ASSERT_EQUAL(false, init_at_info(&g_ati, &g_sb, 0,
+                                                 NULL, NULL));
         /* Delim is too long here */
-        CPPUNIT_ASSERT_EQUAL(false, init_at_info(&g_ati, &g_sb, 0, "AAA"));
+        CPPUNIT_ASSERT_EQUAL(false, init_at_info(&g_ati, &g_sb, 0,
+                                                 "AAA", NULL));
 }
 
 void AtTest::test_at_put_cmd_full()
@@ -185,7 +198,7 @@ void AtTest::test_at_task_cmd_handler_ok()
 }
 
 
-void AtTest::test_at_regisger_urc_full()
+void AtTest::test_at_register_urc_full()
 {
         g_ati.urc_list.count = AT_URC_MAX_URCS;
         CPPUNIT_ASSERT(!at_register_urc(&g_ati, "F", AT_URC_FLAGS_NONE,
@@ -307,7 +320,6 @@ void AtTest::test_at_process_urc_msg_no_status()
         CPPUNIT_ASSERT_EQUAL(AT_RX_STATE_READY, g_ati.rx_state);
 }
 
-
 void AtTest::test_at_process_cmd_msg()
 {
         /* This sets up our command and start it */
@@ -375,6 +387,40 @@ void AtTest::test_is_urc_msg_no_match()
         char msg[] = "+FOO: BAZZ";
         CPPUNIT_ASSERT(!is_urc_msg(&g_ati, msg));
 }
+
+void AtTest::test_urc_unhandled_cb()
+{
+        CPPUNIT_ASSERT(!g_ati.cmd_ip);
+
+        char msg[] = "A,POOR,URC,MSG";
+        process_cmd_or_urc_msg(&g_ati, msg);
+
+        /*
+         * Since no URC match, we should have gone into our unhandled URC
+         * handler.  Ensure that we did.
+         */
+        CPPUNIT_ASSERT(g_uhurc_cb_called);
+}
+
+void AtTest::test_urc_unhandled_cb_cb_undefined()
+{
+        /* Like the test above, except cb is NULL */
+        g_ati.unhandled_urc_cb = NULL;
+
+        CPPUNIT_ASSERT(!g_ati.unhandled_urc_cb);
+        CPPUNIT_ASSERT(!g_ati.cmd_ip);
+
+        char msg[] = "A,POOR,URC,MSG";
+        process_cmd_or_urc_msg(&g_ati, msg);
+
+        /*
+         * Since no URC match, we should have gone into our unhandled URC
+         * handler.  However since one is not defined we should not have
+         * made it in there.
+         */
+        CPPUNIT_ASSERT(!g_uhurc_cb_called);
+}
+
 
 void AtTest::test_is_urc_msg_match()
 {

--- a/test/AtTest.hh
+++ b/test/AtTest.hh
@@ -38,7 +38,7 @@ class AtTest : public CppUnit::TestFixture
         CPPUNIT_TEST( test_at_task_cmd_handler_bad_state );
         CPPUNIT_TEST( test_at_task_cmd_handler_no_cmd );
         CPPUNIT_TEST( test_at_task_cmd_handler_ok );
-        CPPUNIT_TEST( test_at_regisger_urc_full );
+        CPPUNIT_TEST( test_at_register_urc_full );
         CPPUNIT_TEST( test_at_register_urc_too_long );
         CPPUNIT_TEST( test_at_register_urc_ok );
         CPPUNIT_TEST( test_at_qp_handler_no_change );
@@ -53,6 +53,8 @@ class AtTest : public CppUnit::TestFixture
         CPPUNIT_TEST( test_is_urc_msg_none );
         CPPUNIT_TEST( test_is_urc_msg_no_match );
         CPPUNIT_TEST( test_is_urc_msg_match );
+        CPPUNIT_TEST( test_urc_unhandled_cb );
+        CPPUNIT_TEST( test_urc_unhandled_cb_cb_undefined );
         CPPUNIT_TEST( test_is_rsp_status_nope );
         CPPUNIT_TEST( test_is_rsp_status_ok );
         CPPUNIT_TEST( test_complete_cmd );
@@ -79,7 +81,7 @@ public:
         void test_at_task_cmd_handler_bad_state();
         void test_at_task_cmd_handler_no_cmd();
         void test_at_task_cmd_handler_ok();
-        void test_at_regisger_urc_full();
+        void test_at_register_urc_full();
         void test_at_register_urc_too_long();
         void test_at_register_urc_ok();
         void test_at_qp_handler_no_change();
@@ -94,6 +96,8 @@ public:
         void test_is_urc_msg_none();
         void test_is_urc_msg_no_match();
         void test_is_urc_msg_match();
+        void test_urc_unhandled_cb();
+        void test_urc_unhandled_cb_cb_undefined();
         void test_is_rsp_status_nope();
         void test_is_rsp_status_ok();
         void test_complete_cmd();


### PR DESCRIPTION
There are a few URC messages that we need to process to maintain internal stability that aren't presented in a proper AT URC fashion.  They are more along the lines like the modem blurting out what happening when it happens instead of being civil.  In example the modem will blurt out `3,CONNECTED` when a new connection is opened on port 3.  I can't easily handle these with the URC handler because that depends on a prefix (like `+IPD:`, which is the prefix seen for incoming data URCs).  So this creates a generic URC handler and we define a method to process these URCs and call the appropriate hook methods to ensure things are set correctly.