### PR TITLE
Fixed LED polarity for production board. remapped LED colors

### DIFF
--- a/platform/rct/hal/LED_stm32/led_device_stm32.c
+++ b/platform/rct/hal/LED_stm32/led_device_stm32.c
@@ -55,9 +55,9 @@ static bool led_set_level(struct led_data *ld, const bool on)
 
         ld->level = on;
         if (on) {
-                GPIO_SetBits(GPIO_PORT, ld->mask);
-        } else {
                 GPIO_ResetBits(GPIO_PORT, ld->mask);
+        } else {
+                GPIO_SetBits(GPIO_PORT, ld->mask);
         }
 
         return true;
@@ -105,7 +105,7 @@ bool led_device_init(void)
 
         gpio_conf.GPIO_Speed = GPIO_Speed_50MHz;
         gpio_conf.GPIO_Mode = GPIO_Mode_OUT;
-        gpio_conf.GPIO_OType = GPIO_OType_PP;
+        gpio_conf.GPIO_OType = GPIO_OType_OD;
         gpio_conf.GPIO_Pin = 0;
 
         for (size_t i = 0; i < ARRAY_LEN(leds); ++i) {

--- a/platform/rct/hal/LED_stm32/led_device_stm32.c
+++ b/platform/rct/hal/LED_stm32/led_device_stm32.c
@@ -105,7 +105,7 @@ bool led_device_init(void)
 
         gpio_conf.GPIO_Speed = GPIO_Speed_50MHz;
         gpio_conf.GPIO_Mode = GPIO_Mode_OUT;
-        gpio_conf.GPIO_OType = GPIO_OType_OD;
+        gpio_conf.GPIO_OType = GPIO_OType_PP;
         gpio_conf.GPIO_Pin = 0;
 
         for (size_t i = 0; i < ARRAY_LEN(leds); ++i) {

--- a/platform/rct/hal/LED_stm32/led_device_stm32.c
+++ b/platform/rct/hal/LED_stm32/led_device_stm32.c
@@ -43,9 +43,9 @@ static struct led_data {
         uint16_t mask;
         bool level;
 } leds[] = {
-        {LED_ERROR,     GPIO_Pin_2, 0},
-        {LED_GPS,       GPIO_Pin_1, 0},
-        {LED_TELEMETRY, GPIO_Pin_0, 0},
+        {LED_ERROR,     GPIO_Pin_0, 0},
+        {LED_GPS,       GPIO_Pin_2, 0},
+        {LED_TELEMETRY, GPIO_Pin_1, 0},
 };
 
 static bool led_set_level(struct led_data *ld, const bool on)

--- a/platform/rct/hal/LED_stm32/led_device_stm32.c
+++ b/platform/rct/hal/LED_stm32/led_device_stm32.c
@@ -44,8 +44,8 @@ static struct led_data {
         bool level;
 } leds[] = {
         {LED_ERROR,     GPIO_Pin_0, 0},
-        {LED_GPS,       GPIO_Pin_2, 0},
-        {LED_TELEMETRY, GPIO_Pin_1, 0},
+        {LED_GPS,       GPIO_Pin_1, 0},
+        {LED_TELEMETRY, GPIO_Pin_2, 0},
 };
 
 static bool led_set_level(struct led_data *ld, const bool on)


### PR DESCRIPTION
Green = GPS
Blue = Telemetry activity
Red = error