### PR TITLE
P/stieg/wifi retool state machine

### DIFF
--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -24,6 +24,7 @@
 
 #include "at.h"
 #include "cpp_guard.h"
+#include "dateTime.h"
 #include "net/protocol.h"
 #include "serial.h"
 #include <stdbool.h>
@@ -76,6 +77,7 @@ bool esp8266_set_op_mode(const enum esp8266_op_mode mode,
 bool esp8266_get_op_mode(void (*cb)(bool, enum esp8266_op_mode));
 
 struct esp8266_client_info {
+        tiny_millis_t snapshot_time;
         bool has_ap;
         char ssid[24];
         char mac[18];

--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -22,6 +22,7 @@
 #ifndef _ESP8266_H_
 #define _ESP8266_H_
 
+#include "at.h"
 #include "cpp_guard.h"
 #include "net/protocol.h"
 #include "serial.h"
@@ -42,7 +43,18 @@ enum dev_init_state {
         DEV_INIT_STATE_FAILED,
 };
 
+typedef void client_wifi_disconnect_cb_t();
+typedef void socket_connect_cb_t(const size_t chan_id);
+typedef void socket_closed_cb_t(const size_t chan_id);
+
+struct esp8266_event_hooks {
+        client_wifi_disconnect_cb_t *client_wifi_disconnect_cb;
+        socket_connect_cb_t *socket_connect_cb;
+        socket_closed_cb_t *socket_closed_cb;
+};
+
 bool esp8266_init(struct Serial *s, const size_t max_cmd_len,
+                  const struct esp8266_event_hooks hooks,
                   void (*cb)(enum dev_init_state));
 
 enum dev_init_state esp1866_get_dev_init_state();

--- a/include/modem/at.h
+++ b/include/modem/at.h
@@ -142,7 +142,7 @@ struct at_urc_list {
  * @return true if the callback was able to parse the message,
  *         false otherwise.
  */
-typedef bool unhandled_urc_cb_t(const char* msg);
+typedef bool unhandled_urc_cb_t(char* msg);
 
 struct at_info {
         /*

--- a/include/modem/at.h
+++ b/include/modem/at.h
@@ -127,6 +127,23 @@ struct at_urc_list {
         struct at_urc urcs[AT_URC_MAX_URCS];
 };
 
+/**
+ * Callback for unhandled URCs.  This is designed to handle cases
+ * where AT commands introduce odd messages that would be difficult
+ * to register a callback for.  An example would be `0,CONNECTED`,
+ * this is hard to register since the 0 indicates the multiplexed
+ * channel, and in this case there are 5 potential combinations.
+ * Really this is a broken AT URC, so we use as sort of broken way
+ * to handle it.  A proper URC would have something like
+ * `+CONNINF: 0,"CONNECTED".  Then you would be able to handle this
+ * with a URC handler since you could match the prefix.  Oh well,
+ * imperfect solution for an imperfect world.
+ * @param msg The message that was received.
+ * @return true if the callback was able to parse the message,
+ *         false otherwise.
+ */
+typedef bool unhandled_urc_cb_t(const char* msg);
+
 struct at_info {
         /*
          * All of this is really read only.  Don't alter directly.
@@ -144,10 +161,12 @@ struct at_info {
         struct at_timing timing;
         struct at_cmd_queue cmd_queue;
         struct at_urc_list urc_list;
+        unhandled_urc_cb_t *unhandled_urc_cb;
 };
 
 bool init_at_info(struct at_info *ati, struct serial_buffer *sb,
-                  const tiny_millis_t quiet_period_ms, const char *delim);
+                  const tiny_millis_t quiet_period_ms, const char *delim,
+                  unhandled_urc_cb_t *unhandled_urc_cb);
 
 void at_task(struct at_info *ati, const size_t ms_delay);
 

--- a/include/serial/rx_buff.h
+++ b/include/serial/rx_buff.h
@@ -29,7 +29,6 @@
 CPP_GUARD_BEGIN
 
 struct rx_buff {
-        size_t idx;
         size_t cap;
         char *buff;
 };

--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -65,6 +65,8 @@ struct Serial* serial_create(const char *name, const size_t tx_cap,
 
 void serial_flush(struct Serial *s);
 
+void serial_clear(struct Serial *s);
+
 bool serial_logging(struct Serial *s, const bool enable);
 
 void serial_set_name(struct Serial *s, const char *name);

--- a/platform/mk2/openocd_stlinkv2_gdb.cfg
+++ b/platform/mk2/openocd_stlinkv2_gdb.cfg
@@ -3,4 +3,3 @@ source openocd_stlinkv2.cfg
 $_TARGETNAME configure -rtos auto
 
 init
-reset halt

--- a/src/devices/bluetooth.c
+++ b/src/devices/bluetooth.c
@@ -67,8 +67,9 @@ static int sendBtCommandWaitResponse(DeviceConfig *config, const char *cmd,
 
         serial_flush(config->serial);
         serial_put_s(config->serial, cmd);
-        serial_get_line_wait(config->serial, config->buffer,
-                             config->length, wait);
+        const int len = serial_get_line_wait(config->serial, config->buffer,
+                                             config->length, wait);
+        config->buffer[len] = 0;
 
         const bool res = 0 == strncmp(config->buffer, rsp, strlen(rsp));
 

--- a/src/devices/cellular.c
+++ b/src/devices/cellular.c
@@ -101,7 +101,8 @@ size_t cellular_exec_cmd(struct serial_buffer *sb,
 bool is_rsp(const char **msgs, const size_t count, const char *ans)
 {
         /* Check to ensure last msg we got was an OK */
-        return msgs && count && 0 == strcmp(ans, msgs[count - 1]);
+        return msgs && count && 0 == strncmp(ans, msgs[count - 1],
+                                             strlen(ans));
 }
 
 /**

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -93,7 +93,7 @@ static bool _setup(struct Serial *s, const size_t max_cmd_len)
 
         /* Init our AT engine here */
         if (!init_at_info(state.ati, state.scb, _AT_DEFAULT_QP_MS,
-                          _AT_CMD_DELIM))
+                          _AT_CMD_DELIM, NULL))
                 return false;
 
         return true;

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -546,6 +546,7 @@ static bool get_client_ap_cb(struct at_rsp *rsp, void *up)
         }
 
         struct esp8266_client_info ci;
+        ci.snapshot_time = getUptime();
         char *client_info_rsp = rsp->msgs[rsp->msg_count - 2];
         if (!parse_client_info(client_info_rsp, &ci)) {
                 cmd_failure(cmd_name, "Failed to parse AP info");

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -31,82 +31,145 @@
 #include "queue.h"
 #include "str_util.h"
 #include "task.h"
+#include "taskUtil.h"
 #include "wifi.h"
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
-#define _AT_TASK_TIMEOUT_MS	3
-#define _BAD_STATE_BACKOFF_MS	3000
-#define _CLIENT_BACKOFF_MS	30000
-#define _INIT_FAIL_SLEEP_MS	10000
-#define _LOG_PFX		"[ESP8266 Driver] "
-#define _MAX_CHANNELS		5
-#define _SERIAL_BAUD		115200
-#define _SERIAL_BITS		8
-#define _SERIAL_CMD_MAX_LEN	1024
-#define _SERIAL_PARITY		0
-#define _SERIAL_RX_BUFF_SIZE	256
-#define _SERIAL_STOP_BITS	1
-#define _SERIAL_TX_BUFF_SIZE	256
-#define _TASK_STACK_SIZE	512
-#define _TASK_THREAD_NAME	"ESP8266 Driver"
+#define AT_TASK_TIMEOUT_MS	3
+#define CHECK_DONE_SLEEP_MS	3600000
+#define CLIENT_BACKOFF_MS	30000
+#define INIT_FAIL_SLEEP_MS	10000
+#define LOG_PFX			"[ESP8266 Driver] "
+#define MAX_CHANNELS		5
+#define SERIAL_BAUD		115200
+#define SERIAL_BITS		8
+#define SERIAL_CMD_MAX_LEN	1024
+#define SERIAL_PARITY		0
+#define SERIAL_RX_BUFF_SIZE	256
+#define SERIAL_STOP_BITS	1
+#define SERIAL_TX_BUFF_SIZE	256
+#define TASK_STACK_SIZE		512
+#define TASK_THREAD_NAME	"ESP8266 Driver"
 
-enum _cmd {
-        _CMD_UNKNOWN = 0,
-        _CMD_NOOP,
-        _CMD_INIT,
-        _CMD_CLIENT_AP_GET,
-        _CMD_CLIENT_AP_SET,
-        _CMD_CLIENT_IP_GET,
-        _CMD_DAEMON_SETUP,
+struct device {
+        struct Serial *serial;
+        enum dev_init_state init_state;
 };
 
-struct _client {
-        struct esp8266_client_info info;
+struct client {
         const struct wifi_client_cfg *config;
-        tiny_millis_t next_check_ms;
+        struct esp8266_client_info info;
+        tiny_millis_t next_join_attempt;
 };
 
-struct _daemon {
+struct daemon {
         bool listening;
 };
 
-struct _channel {
+struct channel {
         struct Serial *serial;
         size_t tx_chars_buffered;
         bool in_use;
         bool connected;
+        bool created_externally;
 };
 
-static struct _state {
-        struct Serial *serial;
+struct comm {
         new_conn_func_t *new_conn_cb;
-        struct _channel channels[_MAX_CHANNELS];
-        struct _client client;
-        struct _daemon daemon;
-        bool cmd_ip;
-        enum _cmd cmd;
-        enum dev_init_state dev_state;
-        tiny_millis_t cmd_sleep_until;
+        struct channel channels[MAX_CHANNELS];
+};
+
+/**
+ * These enums define the various thecks we can perform.
+ * Checks can lead to action.  Actions lead to update state,
+ * and then we check again until we hit a completion point in
+ * the check.
+ *
+ * Note that this is in order of priority with the lowest value
+ * being the highest priority.
+ */
+enum check {
+        CHECK_INIT,
+        CHECK_CLIENT,
+        CHECK_DAEMON,
+        CHECK_DATA,
+        __NUM_CHECKS, /* Always the last */
+};
+
+struct cmd {
+        bool in_progress;
+        tiny_millis_t check[__NUM_CHECKS];
+};
+
+static struct {
+        struct device device;
+        struct client client;
+        struct daemon daemon;
+        struct comm comm;
+        struct cmd cmd;
 } state;
 
 static void cmd_started()
 {
-        state.cmd_ip = true;
+        state.cmd.in_progress = true;
 }
 
-static void cmd_completed(const enum _cmd next_cmd,
-                          const tiny_millis_t sleep_ms)
+static void cmd_completed()
 {
-        state.cmd = next_cmd;
-        state.cmd_sleep_until = date_time_uptime_now_plus(sleep_ms);
-        state.cmd_ip = false;
+        state.cmd.in_progress = false;
 }
+
+static void cmd_sleep_until(enum check check,
+                            const tiny_millis_t time)
+{
+        state.cmd.check[check] = time;
+}
+
+static void cmd_sleep(enum check check,
+                      const tiny_millis_t sleep_ms)
+{
+        cmd_sleep_until(check,
+                        date_time_uptime_now_plus(sleep_ms));
+}
+
+static void cmd_set_check(enum check check)
+{
+        state.cmd.check[check] = 0;
+}
+
+/**
+ * Returns the next check we need to perform in order of priority.
+ * The lower the value, the higher the priority.
+ */
+static enum check cmd_get_next_check()
+{
+        for(size_t i = 0; i < __NUM_CHECKS; ++i)
+                if (date_time_is_past(state.cmd.check[i]))
+                        return i;
+
+        return -1;
+}
+
+static void cmd_check_complete(enum check check)
+{
+        state.cmd.check[check] =
+                date_time_uptime_now_plus(CHECK_DONE_SLEEP_MS);
+}
+
+/**
+ * Checks if we are ready to execute a command.
+ */
+static bool cmd_ready() {
+        return !state.cmd.in_progress;
+}
+
+/* Begin code for sending/receiving data */
 
 static bool is_valid_socket_channel_id(const size_t chan_id)
 {
-        return chan_id < ARRAY_LEN(state.channels);
+        return chan_id < ARRAY_LEN(state.comm.channels);
 }
 
 static const char* get_channel_name(const size_t chan_id)
@@ -127,50 +190,32 @@ static const char* get_channel_name(const size_t chan_id)
 
 static void _tx_char_cb(xQueueHandle queue, void *post_tx_arg)
 {
-        struct _channel *ch = post_tx_arg;
-
-        /*
-         * Because we are mimicking a Serial device on top of an actual
-         * socket we need to do some dirty tricks to get the same behavior.
-         * If we have a good connection, then buffer it and send it as
-         * needed.
-         * If we aren't connected we dump all the data on the floor to prevent
-         * the unnecessary stalling of pipelines.  This is on par with
-         * Serial device behavior, but is not ideal for obvious reasons.
-         * We need to move to a socket model before we can fix this properly.
-         * But that will take some work. ITMT this is a good solution until
-         * we get there.
-         */
-        if (ch->connected) {
-                ++ch->tx_chars_buffered;
-        } else {
-                char c;
-                while(pdTRUE == xQueueReceive(queue, &c, 0));
-                ch->tx_chars_buffered = 0;
-        }
+        struct channel *ch = post_tx_arg;
+        ++ch->tx_chars_buffered;
+        cmd_set_check(CHECK_DATA);
 }
 
 static struct Serial* setup_channel_serial(const unsigned int i)
 {
         const char* name = get_channel_name(i);
-        struct _channel* ch =state.channels + i;
-        struct Serial *s = serial_create(name, _SERIAL_TX_BUFF_SIZE,
-                                         _SERIAL_RX_BUFF_SIZE, NULL, NULL,
+        struct channel* ch =state.comm.channels + i;
+        struct Serial *s = serial_create(name, SERIAL_TX_BUFF_SIZE,
+                                         SERIAL_RX_BUFF_SIZE, NULL, NULL,
                                          _tx_char_cb, ch);
         if (s)
                 return s;
 
         /* Fail state */
-        pr_error(_LOG_PFX "Failed to create serial port\r\n");
+        pr_warning(LOG_PFX "Failed to create serial port\r\n");
         return NULL;
 }
 
-static struct _channel* get_channel_for_use(const unsigned int i)
+static struct channel* get_channel_for_use(const unsigned int i)
 {
         if (!is_valid_socket_channel_id(i))
                 return NULL;
 
-        struct _channel* ch =state.channels + i;
+        struct channel* ch =state.comm.channels + i;
         if (!ch->serial) {
                 ch->serial = setup_channel_serial(i);
                 if (!ch->serial)
@@ -180,7 +225,7 @@ static struct _channel* get_channel_for_use(const unsigned int i)
         /* Prep the channel for use */
         ch->tx_chars_buffered = 0;
         ch->in_use = true;
-        ch->connected = false; /* Not connected until we say so */
+        ch->created_externally = false;
 
         return ch;
 }
@@ -188,7 +233,7 @@ static struct _channel* get_channel_for_use(const unsigned int i)
 static int get_next_free_channel_num()
 {
         for (size_t i = 0; is_valid_socket_channel_id(i); ++i) {
-                struct _channel *ch = state.channels + i;
+                struct channel *ch = state.comm.channels + i;
                 if (!ch->in_use)
                         return i;
         }
@@ -196,33 +241,111 @@ static int get_next_free_channel_num()
         return -1;
 }
 
+/**
+ * Callback that gets invoked by the device code whenever new data
+ * comes in.
+ */
 static void rx_data_cb(int chan_id, size_t len, const char* data)
 {
         if (!is_valid_socket_channel_id(chan_id)) {
-                pr_error_int_msg(_LOG_PFX "Channel id to big: ", chan_id);
+                pr_error_int_msg(LOG_PFX "Channel id to big: ", chan_id);
                 return;
         }
 
-        struct _channel *ch = get_channel_for_use((unsigned int) chan_id);
+        struct channel *ch = get_channel_for_use(chan_id);
         if (NULL == ch) {
-                pr_error(_LOG_PFX "No channel available.  Dropping\r\n");
+                pr_error(LOG_PFX "No channel available.  Dropping\r\n");
                 return;
         }
-        ch->connected = true; /* Connected here because request came in */
 
-        /* Call back to listening task to indicate new socket */
-        if (!state.new_conn_cb) {
-                pr_error(_LOG_PFX "No Serial callback defined\r\n");
-                ch->in_use = false; /* Channel is no longer in use */
+        /*
+         * Since these connections are created by an external source,
+         * we set the created_externally flag here.  This way
+         * we know to reap the channel when the connection disappears.
+         */
+        ch->created_externally = true;
+
+        /*
+         * Check that we actually have a call back set to handle the
+         * incomming data.  If not then the socket stays open until it is
+         * closed by our WiFi host.
+         */
+        if (!state.comm.new_conn_cb) {
+                pr_error(LOG_PFX "No Serial callback defined\r\n");
                 return;
         }
-        state.new_conn_cb(ch->serial);
 
-        pr_info_str_msg(_LOG_PFX "Message: ", data);
-        /* STIEG: Make this not portMAX_DELAY to prevent stalling? */
+        state.comm.new_conn_cb(ch->serial);
+
+        /*
+         * Now that the upper layer has been informed about the incomming
+         * data, start sending it said data.  It will unblock and read this
+         * data very shortly.
+         */
+        pr_debug_str_msg(LOG_PFX "Message: ", data);
         xQueueHandle q = serial_get_rx_queue(ch->serial);
         for (size_t i = 0; i < len; ++i)
                 xQueueSend(q, data + i, portMAX_DELAY);
+
+        cmd_set_check(CHECK_DATA);
+}
+
+/**
+ * Callback that is invoked when the send_data method completes.
+ */
+static void _send_data_cb(int bytes_sent)
+{
+        cmd_completed();
+        cmd_set_check(CHECK_DATA);
+
+        if (bytes_sent < 0)
+                /* STIEG: Include channel info here somehow */
+                pr_warning(LOG_PFX "Failed to send data\r\n");
+}
+
+/**
+ * Method that processes outgoing data if any.  If there is, this
+ * will start a command.
+ */
+static void check_data()
+{
+        for (size_t i = 0; i < ARRAY_LEN(state.comm.channels); ++i) {
+                struct channel *ch = state.comm.channels + i;
+                const size_t size = ch->tx_chars_buffered;
+
+                /* If the size is 0, nothing to send */
+                if (0 == size)
+                        continue;
+
+                /*
+                 * If here, then we have data to send.  Check that the
+                 * connection is still active.  If not, dump the data
+                 */
+                if (!ch->connected) {
+                        char c;
+                        xQueueHandle queue = serial_get_tx_queue(ch->serial);
+                        while(pdTRUE == xQueueReceive(queue, &c, 0));
+                        ch->tx_chars_buffered = 0;
+                        continue;
+                }
+
+                /* If here, we have a connection and data to send. Do Eet! */
+                const bool cmd_queued =
+                        esp8266_send_data(i, ch->serial, size, _send_data_cb);
+
+                if (!cmd_queued) {
+                        pr_warning(LOG_PFX "Failed to queue send "
+                                   "data command!!!\r\n");
+                        /* We will retry */
+                        return;
+                }
+
+                cmd_started();
+                ch->tx_chars_buffered -= size;
+                return;
+        }
+
+        cmd_check_complete(CHECK_DATA);
 }
 
 /**
@@ -231,8 +354,12 @@ static void rx_data_cb(int chan_id, size_t len, const char* data)
  */
 static void client_wifi_disconnect_cb()
 {
-        pr_info(_LOG_PFX "WiFi client disconnected from AP\r\n");
+        /* Need to check our client now that a change has occured */
+        cmd_set_check(CHECK_CLIENT);
+        cmd_set_check(CHECK_DATA);
+
         memset(&state.client.info, 0, sizeof(state.client.info));
+        pr_info(LOG_PFX "WiFi client disconnected from AP\r\n");
 }
 
 /**
@@ -242,14 +369,15 @@ static void client_wifi_disconnect_cb()
 static void socket_connect_cb(const size_t chan_id)
 {
         if (!is_valid_socket_channel_id(chan_id)) {
-                pr_error_int_msg(_LOG_PFX "Invalid socket id during "
+                pr_error_int_msg(LOG_PFX "Invalid socket id during "
                                  "connect: ", chan_id);
                 return;
         }
 
-        pr_info_int_msg(_LOG_PFX "Socket connect on channel ", chan_id);
-        struct _channel *ch = state.channels + chan_id;
+        pr_info_int_msg(LOG_PFX "Socket connect on channel ", chan_id);
+        struct channel *ch = state.comm.channels + chan_id;
         ch->connected = true;
+        cmd_set_check(CHECK_DATA);
 }
 
 /**
@@ -260,44 +388,71 @@ static void socket_connect_cb(const size_t chan_id)
 static void socket_closed_cb(const size_t chan_id)
 {
         if (!is_valid_socket_channel_id(chan_id)) {
-                pr_error_int_msg(_LOG_PFX "Invalid socket id during "
+                pr_error_int_msg(LOG_PFX "Invalid socket id during "
                                  "close: ", chan_id);
                 return;
         }
 
-        pr_info_int_msg(_LOG_PFX "Socket closed on channel ", chan_id);
-        struct _channel *ch = state.channels + chan_id;
+        pr_info_int_msg(LOG_PFX "Socket closed on channel ", chan_id);
+        struct channel *ch = state.comm.channels + chan_id;
+
+        /*
+         * If channel created externally, then when closed it means it
+         * is no longer in use
+         */
+        if (ch->created_externally)
+                ch->in_use = false;
+
+        ch->created_externally = false;
         ch->connected = false;
+
+        /*
+         * Clear the serial data out since channel is now closed
+         * we don't want any cruft in there the next time a channel
+         * gets opened.
+         */
         serial_clear(ch->serial);
+        cmd_set_check(CHECK_DATA);
 }
 
+
+/* *** Methods that handle device init and reset *** */
+
+/**
+ * Callback that is invoked when the init_wifi command completes.
+ */
 static void init_wifi_cb(enum dev_init_state dev_state)
 {
-        state.dev_state = dev_state;
-        pr_info_int_msg(_LOG_PFX "Device state: ", dev_state);
+        cmd_completed();
+        pr_info_int_msg(LOG_PFX "Device state: ", dev_state);
+        state.device.init_state = dev_state;
 
-        if (DEV_INIT_STATE_READY != dev_state) {
-                /* Then init failed.  We should sleep and try again */
-                cmd_completed(_CMD_INIT, _INIT_FAIL_SLEEP_MS);
-        } else {
-                /* W00t!  Now we let our state determine next cmd */
-                cmd_completed(_CMD_UNKNOWN, 0);
-        }
+        /* Now that init state has changed, check them */
+        cmd_set_check(CHECK_INIT);
+        cmd_set_check(CHECK_CLIENT);
+        cmd_set_check(CHECK_DAEMON);
+        cmd_set_check(CHECK_DATA);
 }
 
+/**
+ * Use this to initialize the WiFi device.  Device should be in a reset state.
+ * If not, this may fail.
+ */
 static void init_wifi()
 {
+        pr_info(LOG_PFX "Initializing Wifi\r\n");
+
         const struct esp8266_event_hooks hooks = {
                 .client_wifi_disconnect_cb = client_wifi_disconnect_cb,
                 .socket_connect_cb = socket_connect_cb,
                 .socket_closed_cb = socket_closed_cb,
         };
 
-        if (!esp8266_init(state.serial, _SERIAL_CMD_MAX_LEN,
+        if (!esp8266_init(state.device.serial, SERIAL_CMD_MAX_LEN,
                           hooks, init_wifi_cb)) {
                 /* Failed to init critical bits.  */
-                pr_error(_LOG_PFX "Failed to init esp8266 device code.\r\n");
-                cmd_completed(_CMD_INIT, _INIT_FAIL_SLEEP_MS);
+                pr_error(LOG_PFX "Failed to init esp8266 device code.\r\n");
+                cmd_sleep(CHECK_INIT, INIT_FAIL_SLEEP_MS);
                 return;
         }
 
@@ -309,211 +464,293 @@ static void init_wifi()
          * This should only fail if there was an issue with space or config.
          */
         if (!esp8266_register_ipd_cb(rx_data_cb))
-                pr_error(_LOG_PFX "Failed to register IPD callback\r\n");
+                pr_error(LOG_PFX "Failed to register IPD callback\r\n");
 }
 
-static bool is_client_wifi_on_desired_network(const struct esp8266_client_info *ci)
+/**
+ * The method that checks our state machine and ensures that we are in
+ * the proper init state.  If we are not then the logic is here to get
+ * us to the correct state (if possible).
+ */
+static void check_init()
 {
-        if (!ci || !ci->has_ap || !state.client.config)
-                return false;
-
-        return STR_EQ(ci->ssid, state.client.config->ssid);
-}
-
-static void get_client_ap_cb(bool status, const struct esp8266_client_info *ci)
-{
-        memcpy(&state.client.info, ci, sizeof(struct esp8266_client_info));
-        state.client.next_check_ms = date_time_uptime_now_plus(_CLIENT_BACKOFF_MS);
-
-        if (!status) {
-                /* Command failed */
-                cmd_completed(_CMD_UNKNOWN, 0);
-        } else if (!is_client_wifi_on_desired_network(ci)) {
-                /* Not on the network we want to be on.  Set it */
-                pr_info(_LOG_PFX "Client not on correct network\r\n");
-                cmd_completed(_CMD_CLIENT_AP_SET, 0);
-        } else {
-                /* On the network we want to be on.  Get the IP. */
-                pr_info(_LOG_PFX "Client is on desired network\r\n");
-                esp8266_log_client_info(&state.client.info);
-                cmd_completed(_CMD_CLIENT_IP_GET, 0);
+        pr_info(LOG_PFX "Checking Init\r\n");
+        switch(state.device.init_state) {
+        case DEV_INIT_STATE_READY:
+                /* Then we are where we want to be and are done */
+                cmd_check_complete(CHECK_INIT);
+                return;
+        default:
+                /* STIEG: TODO Handle reset here when implemented. */
+                delayMs(CLIENT_BACKOFF_MS);
+        case DEV_INIT_STATE_NOT_READY:
+                init_wifi();
+                return;
         }
 }
 
+static bool device_initialized()
+{
+        return state.device.init_state == DEV_INIT_STATE_READY;
+}
+
+
+/* *** Methods that handle the client WiFi state and actions *** */
+
+/**
+ * Callback that gets invoked with the get_client_ap command completes.
+ */
+static void get_client_ap_cb(bool status, const struct esp8266_client_info *ci)
+{
+        cmd_completed();
+        cmd_set_check(CHECK_CLIENT);
+        cmd_set_check(CHECK_DAEMON);
+
+        memcpy(&state.client.info, ci, sizeof(struct esp8266_client_info));
+        *state.client.info.ip = 0;
+}
+
+/**
+ * Command that will populate our wifi client info with useful data.
+ */
 static void get_client_ap()
 {
+        pr_info(LOG_PFX "Retrieving Wifi Client Info\r\n");
         esp8266_get_client_ap(get_client_ap_cb);
         cmd_started();
 }
 
+/**
+ * Callback that gets invoked when the get_client_ip command completes.
+ */
 static void get_client_ip_cb(bool status, const char* ip)
 {
+        cmd_completed();
+        cmd_set_check(CHECK_CLIENT);
+
+        /* STIEG: This is a HACK.  IP Info should be its own struct */
         if (!status) {
                 /* We don't know the IP */
-                *state.client.info.ip = '\0';
+                *state.client.info.ip = 0;
         } else {
                 /* On the network we want to be on */
-                pr_info_str_msg(_LOG_PFX "Got IP: ", ip);
+                pr_info_str_msg(LOG_PFX "Got IP: ", ip);
                 strncpy(state.client.info.ip, ip,
                         ARRAY_LEN(state.client.info.ip));
-                esp8266_log_client_info(&state.client.info);
         }
-
-        cmd_completed(_CMD_UNKNOWN, 0);
 }
 
+/**
+ * Command that will retrieve the client IP of the WiFi device and stuff it
+ * into our client_info structure.  This is a bit of a hack until we move
+ * the IP info into its own struct.
+ */
 static void get_client_ip()
 {
+        pr_info(LOG_PFX "Retrieving Wifi Client IP\r\n");
         esp8266_get_client_ip(get_client_ip_cb);
         cmd_started();
 }
 
-
+/**
+ * Callback that gets invoked upon completion of set_client_ap command.
+ */
 static void set_client_ap_cb(bool status)
 {
+        cmd_completed();
+        cmd_set_check(CHECK_CLIENT);
+
         if (!status) {
                 /* Failed. */
-                pr_info(_LOG_PFX "Failed to join network\r\n");
-                client_wifi_disconnect_cb();
-                cmd_completed(_CMD_UNKNOWN, 0);
+                pr_info(LOG_PFX "Failed to join network\r\n");
         } else {
-                /* If here, we were successful.  Now get client wifi info */
-                pr_info(_LOG_PFX "Successfully joined network\r\n");
-                cmd_completed(_CMD_CLIENT_AP_GET, 0);
+                /* If here, we were successful. */
+                pr_info(LOG_PFX "Successfully joined network\r\n");
         }
+
+        /* Clear the client info since it has changed. */
+        memset(&state.client.info, 0, sizeof(state.client.info));
 }
 
+/**
+ * Command that will set the wifi client settings as specified in
+ * our settings.
+ */
 static void set_client_ap()
 {
+        pr_info(LOG_PFX "Setting Wifi Client Info\r\n");
         const struct wifi_client_cfg *cc = state.client.config;
-        pr_info_str_msg(_LOG_PFX "Joining network: ", cc->ssid);
+        pr_info_str_msg(LOG_PFX "Joining network: ", cc->ssid);
         esp8266_join_ap(cc->ssid, cc->passwd, set_client_ap_cb);
         cmd_started();
 }
 
-static void server_cmd_cb(bool status)
+/**
+ * Helper method to check_client.  This method tries to join an AP, but
+ * also handles cases where its not reachable or we have other issues
+ * (like an incorrect password).
+ */
+static void client_try_join_ap()
 {
-        if (!status)
-                pr_warning(_LOG_PFX "Failed to setup server\r\n");
-
-        state.daemon.listening = status;
-        cmd_completed(_CMD_UNKNOWN, 0);
+        if (!date_time_is_past(state.client.next_join_attempt)){
+                /* Then we need to backoff */
+                const tiny_millis_t sleep_len =
+                        state.client.next_join_attempt - getUptime();
+                cmd_sleep_until(CHECK_CLIENT, sleep_len);
+        } else {
+                /* If here, then its time to do work */
+                state.client.next_join_attempt =
+                        date_time_uptime_now_plus(CLIENT_BACKOFF_MS);
+                set_client_ap();
+        }
 }
 
-static void setup_server()
+/**
+ * This is the block of logic that manages our WiFi client state.
+ * Its responsible for keeping the client status as close to the
+ * configuration as is reasonably possible.
+ */
+static void check_client()
 {
-        pr_info_int_msg(_LOG_PFX "Starting server on port: ",
+        pr_info(LOG_PFX "Checking Client\r\n");
+
+        /* First check that we are initialized */
+        if (!device_initialized()) {
+                cmd_sleep(CHECK_CLIENT, CLIENT_BACKOFF_MS);
+                return;
+        }
+
+        /*
+         * First check if we have reasonably fresh client info. Have to
+         * have it before we can make any decisions.
+         */
+        const struct esp8266_client_info *ci = &state.client.info;
+        if (0 == ci->snapshot_time) {
+                get_client_ap();
+                return;
+        }
+
+        /* If here, we have fresh client info.  Use it to make decisions. */
+        const struct wifi_client_cfg *cfg = state.client.config;
+        if (cfg->active) {
+                /*
+                 * Config says client should be active. Make it so.
+                 * First check that we have an AP and that we are on
+                 * the correct client network.  If not, try to get on
+                 * the correct network.
+                 */
+                if (!ci->has_ap || !STR_EQ(ci->ssid, cfg->ssid)) {
+                        /* Then we need to try and join the AP */
+                        client_try_join_ap();
+                        return;
+                }
+
+                /* If here, then on correct AP.  Do we have IP info? */
+                if (!*ci->ip) {
+                        /* Then we need to get IP Information */
+                        get_client_ip();
+                        return;
+                }
+
+                /* If here, we are done */
+                cmd_check_complete(CHECK_CLIENT);
+                return;
+        } else {
+                /* Client should be inactive.  Disable as needed */
+                if (ci->has_ap) {
+                        /*
+                         * If here, client is active.  Leave AP.
+                         * STIEG: TODO: Implement Leave AP call. We are done
+                         * for now since code not implemented.
+                         */
+                        cmd_check_complete(CHECK_INIT);
+                        return;
+                }
+
+                /* Then config and reality align.  Done */
+                cmd_check_complete(CHECK_CLIENT);
+                return;
+        }
+}
+
+
+/* *** Methods that handle the Daemon and its actions *** */
+
+static void daemon_cmd_cb(bool status)
+{
+        cmd_completed();
+        state.daemon.listening = status;
+        if (!status)
+                pr_warning(LOG_PFX "Failed to setup daemon\r\n");
+}
+
+static void setup_daemon()
+{
+        pr_info_int_msg(LOG_PFX "Starting daemon on port: ",
                         RCP_SERVICE_PORT);
         esp8266_server_cmd(ESP8266_SERVER_ACTION_CREATE, RCP_SERVICE_PORT,
-                           server_cmd_cb);
+                           daemon_cmd_cb);
         cmd_started();
 }
 
 /**
- * Determines what the next command should be given that we have none that
- * need to explicitly be done.
+ * This logic is responsible for checking the daemon and ensuring that it
+ * is in its correct state.  If its not, then this code will get it there.
  */
-static enum _cmd determine_cmd()
+static void check_daemon()
 {
-        /* Are we initialized.  If not, should do that */
-        /* TODO: Do this when re-init support is added. */
+        pr_info(LOG_PFX "Checking Daemon\r\n");
 
-        /* If client is enabled, ensure setup if not in timeout */
-        /* STIEG: Assume it enabled for now */
-        if (date_time_is_past(state.client.next_check_ms))
-                return _CMD_CLIENT_AP_GET;
-
-        /* If host is enabled, ensure setup if not in timeount*/
-        /* STIEG: Do this later when host implemented */
-
-        /* Start daemon if either host or client is successfully setup. */
-        /* STIEG: Add host logic here when implemented */
-        if (state.client.info.has_ap && !state.daemon.listening)
-                return _CMD_DAEMON_SETUP;
-
-        /* If we get this far, nothing to do. */
-        return _CMD_NOOP;
-}
-
-static void _send_serial_cb(int bytes_sent)
-{
-        if (bytes_sent < 0)
-                /* STIEG: Include channel info here somehow */
-                pr_warning(_LOG_PFX "Failed to send data\r\n");
-
-        cmd_completed(_CMD_UNKNOWN, 0);
-}
-
-static void process_outgoing()
-{
-        /* STIEG: Optimize this for runtime */
-        for (size_t i = 0; i < ARRAY_LEN(state.channels); ++i) {
-                struct _channel *ch = state.channels + i;
-                const size_t size = ch->tx_chars_buffered;
-
-                /* If the size is 0, nothing to send */
-                if (0 == size)
-                        continue;
-
-                /* If here, then we need to queue up a send */
-                const bool cmd_queued =
-                        esp8266_send_data(i, ch->serial,
-                                          ch->tx_chars_buffered,
-                                          _send_serial_cb);
-                if (cmd_queued) {
-                        cmd_started();
-
-                        /* STIEG: Sane?  I guess so for now */
-                        ch->tx_chars_buffered -= size;
-                }
-
+        /* First check that we are initialized */
+        if (!device_initialized()) {
+                cmd_sleep(CHECK_CLIENT, CLIENT_BACKOFF_MS);
                 return;
         }
+
+        if (!state.daemon.listening) {
+                /* Then we need to activate it */
+                setup_daemon();
+                return;
+        }
+
+        /* Then its listening.  We are done */
+        cmd_check_complete(CHECK_DAEMON);
 }
 
-static void _task_loop()
+
+/* *** The all important task loop *** */
+
+static void task_loop()
 {
-        esp8266_do_loop(_AT_TASK_TIMEOUT_MS);
+        esp8266_do_loop(AT_TASK_TIMEOUT_MS);
 
         /* If there is a command in progress, no commands */
-        if (state.cmd_ip)
+        if (!cmd_ready())
                 return;
 
-        /* Check if there is outgoing data that needs processing */
-        process_outgoing();
-
-        /* If we are in a command sleep, do nothing until it expires. */
-        if (!date_time_is_past(state.cmd_sleep_until))
-                return;
-
-        enum _cmd cmd = state.cmd;
-        if (_CMD_UNKNOWN == cmd)
-                cmd = determine_cmd();
-
-        switch(cmd) {
-        case _CMD_INIT:
-                return init_wifi();
-        case _CMD_CLIENT_AP_GET:
-                return get_client_ap();
-        case _CMD_CLIENT_AP_SET:
-                return set_client_ap();
-        case _CMD_CLIENT_IP_GET:
-                return get_client_ip();
-        case _CMD_DAEMON_SETUP:
-                return setup_server();
-        case _CMD_NOOP:
+        switch(cmd_get_next_check()) {
+        case CHECK_INIT:
+                check_init();
+                break;
+        case CHECK_CLIENT:
+                check_client();
+                break;
+        case CHECK_DAEMON:
+                check_daemon();
+                break;
+        case CHECK_DATA:
+                check_data();
                 break;
         default:
-                pr_warning_int_msg(_LOG_PFX "CMD State Unhandled: ", cmd);
-                /* Put a sleep here to prevent log flooding */
-                cmd_completed(_CMD_UNKNOWN, _BAD_STATE_BACKOFF_MS);
+                /* Nothing to do. */
+                break;
         }
 }
 
-static void _task(void *params)
+static void task(void *params)
 {
         for(;;)
-                _task_loop();
+                task_loop();
 
         panic(PANIC_CAUSE_UNREACHABLE);
 }
@@ -524,51 +761,57 @@ bool esp8266_drv_update_client_cfg(const struct wifi_client_cfg *cc)
                 return false;
 
         state.client.config = cc;
-        /* Zero this out so we force the scheduler to check it */
-        state.client.next_check_ms = 0;
+
+        /* Client state changed.  Need to check client */
+        cmd_set_check(CHECK_CLIENT);
+
         return true;
 }
 
 bool esp8266_drv_init(struct Serial *s, const int priority,
                       new_conn_func_t new_conn_cb)
 {
-        if (state.serial)
+        if (state.device.serial)
                 return false; /* Already setup */
 
-        state.serial = s;
+        state.device.serial = s;
 
-        if (!state.serial) {
-                pr_error(_LOG_PFX "NULL serial\r\n");
+        if (!state.device.serial) {
+                pr_error(LOG_PFX "NULL serial\r\n");
                 return false;
         }
 
-        serial_config(state.serial, _SERIAL_BITS, _SERIAL_PARITY,
-                      _SERIAL_STOP_BITS, _SERIAL_BAUD);
+        serial_config(state.device.serial, SERIAL_BITS, SERIAL_PARITY,
+                      SERIAL_STOP_BITS, SERIAL_BAUD);
 
         /* Initialize our WiFi configs here */
         LoggerConfig *lc = getWorkingLoggerConfig();
         const struct wifi_client_cfg *cfg =
                 &lc->ConnectivityConfigs.wifi.client;
         if (!esp8266_drv_update_client_cfg(cfg)) {
-                pr_error(_LOG_PFX "Failed to set WiFi cfg\r\n");
+                pr_error(LOG_PFX "Failed to set WiFi cfg\r\n");
                 return false;
         }
 
-        state.cmd = _CMD_INIT;
-        state.new_conn_cb = new_conn_cb;
+        state.comm.new_conn_cb = new_conn_cb;
 
-        static const signed char task_name[] = _TASK_THREAD_NAME;
-        const size_t stack_size = _TASK_STACK_SIZE;
-        xTaskCreate(_task, task_name, stack_size, NULL, priority, NULL);
+        /* Set all check flags so we check the whole system */
+        for (size_t i = 0; i < __NUM_CHECKS; ++i)
+                cmd_set_check(i);
+
+        static const signed char task_name[] = TASK_THREAD_NAME;
+        const size_t stack_size = TASK_STACK_SIZE;
+        xTaskCreate(task, task_name, stack_size, NULL, priority, NULL);
 
         return true;
 }
 
 static void _connect_cb(bool status, const int chan_id)
 {
-        struct _channel *ch = state.channels + chan_id;
+        struct channel *ch = state.comm.channels + chan_id;
         ch->connected = status;
         ch->in_use = status;
+        cmd_set_check(CHECK_DATA);
 }
 
 struct Serial* esp8266_drv_connect(const enum protocol proto,
@@ -577,22 +820,23 @@ struct Serial* esp8266_drv_connect(const enum protocol proto,
 {
         const int chan_id = get_next_free_channel_num();
         if (chan_id < 0) {
-                pr_warning(_LOG_PFX "Failed to acquire a free channel\r\n");
+                pr_warning(LOG_PFX "Failed to acquire a free channel\r\n");
                 return NULL;
         }
 
-        struct _channel *ch = get_channel_for_use(chan_id);
+        struct channel *ch = get_channel_for_use(chan_id);
         if (NULL == ch) {
-                pr_warning(_LOG_PFX "Can't allocate resources for channel\r\n");
+                pr_warning(LOG_PFX "Can't allocate resources for channel\r\n");
                 return NULL;
         }
 
         if (!esp8266_connect(chan_id, proto, dst_ip, dst_port,
                              _connect_cb)) {
-                pr_warning(_LOG_PFX "Failed to issue connect command\r\n");
+                pr_warning(LOG_PFX "Failed to issue connect command\r\n");
                 return NULL;
         }
 
+        pr_info_int_msg(LOG_PFX "Opened comm channel ", chan_id);
         return ch->serial;
 }
 

--- a/src/gsm/gsm.c
+++ b/src/gsm/gsm.c
@@ -38,8 +38,8 @@ bool gsm_ping_modem(struct serial_buffer *sb)
 
         serial_buffer_reset(sb);
         serial_buffer_append(sb, "AT");
-        const size_t count =cellular_exec_cmd(sb, READ_TIMEOUT, msgs,
-                                              msgs_len);
+        const size_t count = cellular_exec_cmd(sb, READ_TIMEOUT, msgs,
+                                               msgs_len);
         return is_rsp_ok(msgs, count);
 }
 

--- a/src/logging/printk.c
+++ b/src/logging/printk.c
@@ -49,7 +49,7 @@ size_t read_log_to_serial(struct Serial *s, int escape)
                 buff[bytes] = 0;
                 read += bytes;
                 if (escape) {
-                        put_escapedString(s, buff, 1);
+                        put_escapedString(s, buff, bytes);
                 } else {
                         serial_put_s(s, buff);
                 }

--- a/src/lua/luaLoggerBinding.c
+++ b/src/lua/luaLoggerBinding.c
@@ -389,8 +389,11 @@ static int lua_serial_read_line(lua_State *L)
 
         struct Serial *serial = lua_get_serial(L, port);
         /* STIEG: Would be nice to be rid of that tempBuffer */
-        if (serial_get_line_wait(serial, g_tempBuffer, TEMP_BUFFER_LEN,
-                                 timeout)) {
+        const size_t len = serial_get_line_wait(serial, g_tempBuffer,
+                                                TEMP_BUFFER_LEN - 1,
+                                                timeout);
+        g_tempBuffer[len] = 0;
+        if (len) {
                 lua_pushstring(L, g_tempBuffer);
         } else {
                 lua_pushnil(L);

--- a/src/modem/at.c
+++ b/src/modem/at.c
@@ -168,7 +168,7 @@ static bool _process_msg_generic(struct at_info *ati,
 {
         if (AT_RSP_MAX_MSGS <= ati->rsp.msg_count) {
                 pr_error("[at] BUG: Received more messages than can "
-                         "handle. Dropping.");
+                         "handle. Dropping.\r\n");
                 return false;
         }
 

--- a/src/serial/rx_buff.c
+++ b/src/serial/rx_buff.c
@@ -89,16 +89,20 @@ char* rx_buff_read(struct rx_buff *rxb, struct Serial *s,
         xQueueHandle h = serial_get_rx_queue(s);
         size_t i = 0;
         char c;
+        /* pr_info(LOG_PFX "RX Chars: \""); */
         for(bool done = false; i < rxb->cap && !done; ++i) {
                 const bool rx_status = xQueueReceive(h, &c, ticks_to_wait);
 
                 if (!rx_status) {
                         /* If here, we timed out on receiving a message */
+                        /* pr_info("\"\r\n"); */
                         pr_debug(LOG_PFX "Timeout receiving msg\r\n");
                         rx_buff_clear(rxb);
                         return NULL;
                 }
 
+                /* pr_info_int(c); */
+                /* pr_info_char(','); */
                 switch(c) {
                 case '\r':
                 case '\0':
@@ -108,6 +112,7 @@ char* rx_buff_read(struct rx_buff *rxb, struct Serial *s,
 
                 rxb->buff[i] = c;
         }
+        /* pr_info("\"\r\n"); */
 
         /* If there is a \n after the \r, remove it */
         if ('\r' == c && xQueuePeek(h, &c, 0) && '\n' == c)

--- a/src/serial/serial.c
+++ b/src/serial/serial.c
@@ -161,6 +161,16 @@ void serial_flush(struct Serial *s)
         /* STIEG: TODO Figure out how to flush Tx sanely */
 }
 
+/**
+ * Clears the contents of the rx and tx queues.
+ */
+void serial_clear(struct Serial *s)
+{
+        char c;
+        for(; pdTRUE == xQueueReceive(s->rx_queue, &c, 0););
+        for(; pdTRUE == xQueueReceive(s->tx_queue, &c, 0););
+}
+
 bool serial_get_c_wait(struct Serial *s, char *c, const size_t delay)
 {
         if (pdFALSE == xQueueReceive(s->rx_queue, c, delay))

--- a/src/serial/serial_buffer.c
+++ b/src/serial/serial_buffer.c
@@ -60,13 +60,14 @@ bool serial_buffer_create(struct serial_buffer *sb,
 char* serial_buffer_rx(struct serial_buffer *sb,
                        const size_t ms_delay)
 {
-        const size_t available = sb->length - sb->curr_len;
+        const size_t available = sb->length - sb->curr_len - 1;
         char *ptr = sb->buffer + sb->curr_len;
         size_t msg_len = 0;
+        int read;
 
         while (!msg_len) {
-                const int read = serial_get_line_wait(
-                        sb->serial, ptr, available, msToTicks(ms_delay));
+                read  = serial_get_line_wait(sb->serial, ptr, available,
+                                             msToTicks(ms_delay));
 
                 if (!read)
                         return NULL;
@@ -74,8 +75,9 @@ char* serial_buffer_rx(struct serial_buffer *sb,
                 msg_len = serial_msg_strlen(ptr);
         }
 
-        /* If here, got a non-empty msg.  Add on ctrl char len */
-        sb->curr_len += msg_len + strlen(ptr + msg_len) + 1;
+        /* If here, got a non-empty msg.  Terminate it and add the length */
+        ptr[read] = 0;
+        sb->curr_len += ++read;
         return ptr;
 }
 

--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -41,7 +41,7 @@
 #define _THREAD_NAME		"WiFi Task      "
 #define _CONN_WAIT_MS		100
 #define _STACK_SIZE		256
-#define _RX_BUFF_SIZE		1024
+#define _RX_BUFF_SIZE		512
 #define _LOG_PFX		"[wifi] "
 #define _BEACON_PERIOD_MS	3000
 

--- a/src/util/str_util.c
+++ b/src/util/str_util.c
@@ -38,6 +38,7 @@ size_t serial_msg_strlen(const char *data)
                 switch (*data) {
                 case '\r':
                 case '\n':
+                case '\0':
                         return len;
                 }
         }

--- a/test/AtTest.cpp
+++ b/test/AtTest.cpp
@@ -58,7 +58,7 @@ bool cb(struct at_rsp *rsp, void *up) {
 }
 
 static bool g_uhurc_cb_called;
-bool uhurc_cb(const char* msg) {
+bool uhurc_cb(char* msg) {
         g_uhurc_cb_called = true;
         return false;
 }

--- a/test/AtTest.cpp
+++ b/test/AtTest.cpp
@@ -57,6 +57,12 @@ bool cb(struct at_rsp *rsp, void *up) {
         return false;
 }
 
+static bool g_uhurc_cb_called;
+bool uhurc_cb(const char* msg) {
+        g_uhurc_cb_called = true;
+        return false;
+}
+
 CPP_GUARD_END
 
 void AtTest::setUp()
@@ -66,9 +72,10 @@ void AtTest::setUp()
         g_sb.serial = s;
 
         /* Always init our structs */
-        init_at_info(&g_ati, &g_sb, 1, "\r\n");
+        init_at_info(&g_ati, &g_sb, 1, "\r\n", uhurc_cb);
         g_cb_called = false;
         g_up = NULL;
+        g_uhurc_cb_called = false;
 }
 
 void AtTest::test_init_at_info()
@@ -79,24 +86,30 @@ void AtTest::test_init_at_info()
         g_ati.dev_cfg.quiet_period_ms = 42;
         g_ati.urc_list.count = 57;
 
-        CPPUNIT_ASSERT_EQUAL(true, init_at_info(&g_ati, &g_sb, 1, "\r"));
+        CPPUNIT_ASSERT_EQUAL(true, init_at_info(&g_ati, &g_sb, 1,
+                                                "\r", uhurc_cb));
         CPPUNIT_ASSERT_EQUAL(AT_CMD_STATE_READY, g_ati.cmd_state);
         CPPUNIT_ASSERT_EQUAL(AT_RX_STATE_READY, g_ati.rx_state);
         CPPUNIT_ASSERT_EQUAL(1, g_ati.dev_cfg.quiet_period_ms);
         CPPUNIT_ASSERT_EQUAL((size_t) 0, g_ati.urc_list.count);
         CPPUNIT_ASSERT_EQUAL(&g_sb, g_ati.sb);
+        CPPUNIT_ASSERT_EQUAL(&uhurc_cb, g_ati.unhandled_urc_cb);
 }
 
 void AtTest::test_init_at_info_failures()
 {
         /* No Serial Buffer */
-        CPPUNIT_ASSERT_EQUAL(false, init_at_info(&g_ati, NULL, 0, "\r"));
+        CPPUNIT_ASSERT_EQUAL(false, init_at_info(&g_ati, NULL, 0,
+                                                 "\r", NULL));
         /* No at_info struct */
-        CPPUNIT_ASSERT_EQUAL(false, init_at_info(NULL, &g_sb, 0, "\n"));
+        CPPUNIT_ASSERT_EQUAL(false, init_at_info(NULL, &g_sb, 0,
+                                                 "\n", NULL));
         /* No delim */
-        CPPUNIT_ASSERT_EQUAL(false, init_at_info(&g_ati, &g_sb, 0, NULL));
+        CPPUNIT_ASSERT_EQUAL(false, init_at_info(&g_ati, &g_sb, 0,
+                                                 NULL, NULL));
         /* Delim is too long here */
-        CPPUNIT_ASSERT_EQUAL(false, init_at_info(&g_ati, &g_sb, 0, "AAA"));
+        CPPUNIT_ASSERT_EQUAL(false, init_at_info(&g_ati, &g_sb, 0,
+                                                 "AAA", NULL));
 }
 
 void AtTest::test_at_put_cmd_full()
@@ -185,7 +198,7 @@ void AtTest::test_at_task_cmd_handler_ok()
 }
 
 
-void AtTest::test_at_regisger_urc_full()
+void AtTest::test_at_register_urc_full()
 {
         g_ati.urc_list.count = AT_URC_MAX_URCS;
         CPPUNIT_ASSERT(!at_register_urc(&g_ati, "F", AT_URC_FLAGS_NONE,
@@ -307,7 +320,6 @@ void AtTest::test_at_process_urc_msg_no_status()
         CPPUNIT_ASSERT_EQUAL(AT_RX_STATE_READY, g_ati.rx_state);
 }
 
-
 void AtTest::test_at_process_cmd_msg()
 {
         /* This sets up our command and start it */
@@ -375,6 +387,40 @@ void AtTest::test_is_urc_msg_no_match()
         char msg[] = "+FOO: BAZZ";
         CPPUNIT_ASSERT(!is_urc_msg(&g_ati, msg));
 }
+
+void AtTest::test_urc_unhandled_cb()
+{
+        CPPUNIT_ASSERT(!g_ati.cmd_ip);
+
+        char msg[] = "A,POOR,URC,MSG";
+        process_cmd_or_urc_msg(&g_ati, msg);
+
+        /*
+         * Since no URC match, we should have gone into our unhandled URC
+         * handler.  Ensure that we did.
+         */
+        CPPUNIT_ASSERT(g_uhurc_cb_called);
+}
+
+void AtTest::test_urc_unhandled_cb_cb_undefined()
+{
+        /* Like the test above, except cb is NULL */
+        g_ati.unhandled_urc_cb = NULL;
+
+        CPPUNIT_ASSERT(!g_ati.unhandled_urc_cb);
+        CPPUNIT_ASSERT(!g_ati.cmd_ip);
+
+        char msg[] = "A,POOR,URC,MSG";
+        process_cmd_or_urc_msg(&g_ati, msg);
+
+        /*
+         * Since no URC match, we should have gone into our unhandled URC
+         * handler.  However since one is not defined we should not have
+         * made it in there.
+         */
+        CPPUNIT_ASSERT(!g_uhurc_cb_called);
+}
+
 
 void AtTest::test_is_urc_msg_match()
 {

--- a/test/AtTest.hh
+++ b/test/AtTest.hh
@@ -38,7 +38,7 @@ class AtTest : public CppUnit::TestFixture
         CPPUNIT_TEST( test_at_task_cmd_handler_bad_state );
         CPPUNIT_TEST( test_at_task_cmd_handler_no_cmd );
         CPPUNIT_TEST( test_at_task_cmd_handler_ok );
-        CPPUNIT_TEST( test_at_regisger_urc_full );
+        CPPUNIT_TEST( test_at_register_urc_full );
         CPPUNIT_TEST( test_at_register_urc_too_long );
         CPPUNIT_TEST( test_at_register_urc_ok );
         CPPUNIT_TEST( test_at_qp_handler_no_change );
@@ -53,6 +53,8 @@ class AtTest : public CppUnit::TestFixture
         CPPUNIT_TEST( test_is_urc_msg_none );
         CPPUNIT_TEST( test_is_urc_msg_no_match );
         CPPUNIT_TEST( test_is_urc_msg_match );
+        CPPUNIT_TEST( test_urc_unhandled_cb );
+        CPPUNIT_TEST( test_urc_unhandled_cb_cb_undefined );
         CPPUNIT_TEST( test_is_rsp_status_nope );
         CPPUNIT_TEST( test_is_rsp_status_ok );
         CPPUNIT_TEST( test_complete_cmd );
@@ -79,7 +81,7 @@ public:
         void test_at_task_cmd_handler_bad_state();
         void test_at_task_cmd_handler_no_cmd();
         void test_at_task_cmd_handler_ok();
-        void test_at_regisger_urc_full();
+        void test_at_register_urc_full();
         void test_at_register_urc_too_long();
         void test_at_register_urc_ok();
         void test_at_qp_handler_no_change();
@@ -94,6 +96,8 @@ public:
         void test_is_urc_msg_none();
         void test_is_urc_msg_no_match();
         void test_is_urc_msg_match();
+        void test_urc_unhandled_cb();
+        void test_urc_unhandled_cb_cb_undefined();
         void test_is_rsp_status_nope();
         void test_is_rsp_status_ok();
         void test_complete_cmd();


### PR DESCRIPTION
This change builds off of #554 .  It re-tools the state machine used by our Wifi module to be more sane.  Effectively it puts all the decision making logic in the `check_*` methods. 

This change also fixes some issues in our Serial and serial_buffer code so that its a bit more consistent across the board.  It also addresses some fallout.  I'm sorry that its a bit scatter brained.  Check out the individual commits for a more coherent set of patches.  Each one is pretty well silo'd and tells you what is happening.