### PR TITLE
Backport the MK2 ORE fix to 2.9.1

### DIFF
--- a/platform/mk2/hal/usart_stm32/usart_device_stm32.c
+++ b/platform/mk2/hal/usart_stm32/usart_device_stm32.c
@@ -687,8 +687,8 @@ static void handle_usart_overrun(USART_TypeDef* USARTx)
          * USART_SR register followed by a read to the USART_DR register)
 	 */
         uint32_t cChar;
-	cChar = USART1->SR;
-	cChar = USART1->DR;
+	cChar = USARTx->SR;
+	cChar = USARTx->DR;
 
 	/* Suppress compiler warning */
 	(void) cChar;


### PR DESCRIPTION
As explained in PR #561 there was a bug with ORE resetting in MK2
where we were only resetting USART1 instead of resetting the handle
that was causing the ORE to occur.  This change fixes that by using
the provided handle to do the steps needed to clear the ORE flag.

Trivial patch.  Addresses issue #562 