### PR TITLE
Move serial_device into the HAL; Improve our serial_device enum

### DIFF
--- a/platform/mk2/config.mk
+++ b/platform/mk2/config.mk
@@ -53,7 +53,6 @@ APP_SRC = 	$(APP_PATH)/main.c \
 			$(RCP_SRC)/jsmn/jsmn.c \
 			$(RCP_SRC)/serial/rx_buff.c \
 			$(RCP_SRC)/serial/serial.c \
-			$(RCP_SRC)/serial/serial_device.c \
 			$(RCP_SRC)/serial/serial_buffer.c \
 			$(RCP_SRC)/usart/usart.c \
 			$(RCP_SRC)/cpu/cpu.c \
@@ -150,7 +149,8 @@ APP_SRC = 	$(APP_PATH)/main.c \
 			$(HAL_SRC)/usb_stm32/usbd_desc.c \
 			$(HAL_SRC)/usb_stm32/usbd_usr.c \
 			$(HAL_SRC)/i2c_stm32/i2c_device_stm32.c \
-			$(HAL_SRC)/imu_stm32/invensense_9150.c
+			$(HAL_SRC)/imu_stm32/invensense_9150.c \
+			$(HAL_SRC)/serial/serial_device.c \
 
 
 #Macro that expands our source files into their fully qualified paths

--- a/platform/mk2/hal/serial/serial_device.c
+++ b/platform/mk2/hal/serial/serial_device.c
@@ -1,0 +1,67 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "USB-CDC_device.h"
+#include "loggerConfig.h"
+#include "serial.h"
+#include "serial_device.h"
+#include "usart.h"
+#include "usart_device.h"
+
+#include <stddef.h>
+#include <stdbool.h>
+
+struct Serial* serial_device_get(const serial_id_t port)
+{
+        struct Serial *s = NULL;
+        switch(port) {
+        case SERIAL_USB:
+#if defined(USB_SERIAL_SUPPORT)
+                s =  USB_CDC_get_serial();
+#endif
+                break;
+        case SERIAL_GPS:
+                s = usart_device_get_serial(UART_GPS);
+                break;
+        case SERIAL_TELEMETRY:
+                s = usart_device_get_serial(UART_TELEMETRY);
+                break;
+        case SERIAL_BLUETOOTH:
+                s = usart_device_get_serial(UART_WIRELESS);
+                break;
+        case SERIAL_WIFI:
+        case SERIAL_AUX:
+                s = usart_device_get_serial(UART_AUX);
+                break;
+        default:
+                s = NULL;
+        };
+
+        if (!s)
+                return NULL;
+
+        /* Hack to get serial logging working temporarily */
+        const bool enable_logs =
+                getWorkingLoggerConfig()->logging_cfg.serial[port];
+        serial_logging(s, enable_logs);
+
+        return s;
+}

--- a/platform/mk2/hal/usart_stm32/usart_device_stm32.c
+++ b/platform/mk2/hal/usart_stm32/usart_device_stm32.c
@@ -319,7 +319,7 @@ int usart_device_init()
                 init_usart_serial(UART_TELEMETRY, UART4,
                                   SERIAL_TELEMETRY, "Cell") &&
                 init_usart_serial(UART_WIRELESS, USART1,
-                                  SERIAL_WIRELESS, "BT") &&
+                                  SERIAL_BLUETOOTH, "BT") &&
                 init_usart_serial(UART_AUX, USART3, SERIAL_AUX, "Aux");
 
         if (!mem_alloc_success) {

--- a/platform/rct/Makefile
+++ b/platform/rct/Makefile
@@ -145,6 +145,9 @@ src-y += $(wildcard $(RC_SRC_DIR)/usart/*.c)
 src-y += $(wildcard hal/usart_stm32/*.c)
 inc-y += $(RC_INCLUDE_DIR)/usart
 
+# Serial Device
+src-y += $(wildcard hal/serial/*.c)
+
 # Watchdog
 src-y += $(wildcard $(RC_SRC_DIR)/watchdog/*.c)
 src-y += $(wildcard hal/watchdog_stm32/*.c)

--- a/platform/rct/hal/serial/serial_device.c
+++ b/platform/rct/hal/serial/serial_device.c
@@ -41,14 +41,9 @@ struct Serial* serial_device_get(const serial_id_t port)
         case SERIAL_GPS:
                 s = usart_device_get_serial(UART_GPS);
                 break;
-        case SERIAL_TELEMETRY:
-                s = usart_device_get_serial(UART_TELEMETRY);
-                break;
-        case SERIAL_WIRELESS:
+        case SERIAL_BLUETOOTH:
+        case SERIAL_WIFI:
                 s = usart_device_get_serial(UART_WIRELESS);
-                break;
-        case SERIAL_AUX:
-                s = usart_device_get_serial(UART_AUX);
                 break;
         default:
                 s = NULL;

--- a/platform/rct/hal/usart_stm32/usart_device_stm32.c
+++ b/platform/rct/hal/usart_stm32/usart_device_stm32.c
@@ -304,7 +304,7 @@ int usart_device_init()
                 init_usart_serial(UART_GPS, USART2,
                                   SERIAL_GPS, "GPS") &&
                 init_usart_serial(UART_WIRELESS, USART1,
-                                  SERIAL_WIRELESS, "WiFi");
+                                  SERIAL_WIFI, "WiFi");
 
 
         if (!mem_alloc_success) {

--- a/src/logger/connectivityTask.c
+++ b/src/logger/connectivityTask.c
@@ -171,7 +171,7 @@ static void createWirelessConnectionTask(int16_t priority,
         params->check_connection_status = &bt_check_connection_status;
         params->disconnect = &bt_disconnect;
         params->init_connection = &bt_init_connection;
-        params->serial = SERIAL_WIRELESS;
+        params->serial = SERIAL_BLUETOOTH;
         params->sampleQueue = sampleQueue;
         params->always_streaming = true;
         params->max_sample_rate = SAMPLE_50Hz;

--- a/src/lua/luaLoggerBinding.c
+++ b/src/lua/luaLoggerBinding.c
@@ -280,8 +280,7 @@ static struct Serial* lua_get_serial(lua_State *L, const serial_id_t pid)
 /**
  * Initializes the specified serial port
  * Lua Params:
- * port - the serial port to initialize (SERIAL_USB, SERIAL_GPS,
- * SERIAL_TELEMETRY, SERIAL_WIRELESS, SERIAL_AUX) (defaults to SERIAL_AUX)
+ * port - the serial port to initialize (defaults to SERIAL_AUX)
  * baud - Baud Rate (defaults to 115200)
  * bits - Number of bit in the message (8 or 7) (defaults to 8)
  * parity - (1 = Even Parity, 2 = Odd Parity, 0 = No Parity)
@@ -327,7 +326,6 @@ static int lua_init_serial(lua_State *L)
  * Read a character from the specified serial port
  * Lua Params:
  * port - the serial port to initialize
- *        (SERIAL_USB, SERIAL_GPS, SERIAL_TELEMETRY, SERIAL_WIRELESS, SERIAL_AUX)
  * timeout - the read timeout, in ms.
  *
  * Lua Returns:
@@ -365,7 +363,6 @@ static int lua_serial_read_char(lua_State *L)
  * Read a single newline terminated line from the specified serial port
  * Lua Params:
  * port - the serial port to initialize
- *        (SERIAL_USB, SERIAL_GPS, SERIAL_TELEMETRY, SERIAL_WIRELESS, SERIAL_AUX)
  * timeout - the read timeout, in ms.
  *
  * Lua Returns:
@@ -405,7 +402,6 @@ static int lua_serial_read_line(lua_State *L)
  *
  * Lua Params:
  * port - the serial port to write
- *        (SERIAL_USB, SERIAL_GPS, SERIAL_TELEMETRY, SERIAL_WIRELESS, SERIAL_AUX)
  * line - the string to write. A newline will automatically be added at the end.
  *
  * Lua Returns:
@@ -433,7 +429,6 @@ static int lua_serial_write_line(lua_State *L)
  *
  * Lua Params:
  * port - the serial port to write
- *        (SERIAL_USB, SERIAL_GPS, SERIAL_TELEMETRY, SERIAL_WIRELESS, SERIAL_AUX)
  * char - the character to write.
  *
  * Lua Returns:

--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -184,7 +184,7 @@ bool wifi_init_task(const int wifi_task_priority,
                     const int wifi_drv_priority)
 {
         /* Get our serial port setup */
-        struct Serial *s = serial_device_get(SERIAL_AUX);
+        struct Serial *s = serial_device_get(SERIAL_WIFI);
         if (!s)
                 return false;
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -161,6 +161,7 @@ $(MOCK_DIR)/luaTask_mock.c \
 $(MOCK_DIR)/memory_device_mock.c \
 $(MOCK_DIR)/messaging.c \
 $(MOCK_DIR)/sdcard_mock.c \
+$(MOCK_DIR)/serial_device.c \
 $(MOCK_DIR)/timer_device_mock.c \
 $(MOCK_DIR)/watchdog_device_mock.c \
 $(RCP_SRC)/ADC/ADC.c \
@@ -204,7 +205,6 @@ $(RCP_SRC)/predictive_timer/predictive_timer_2.c \
 $(RCP_SRC)/serial/rx_buff.c \
 $(RCP_SRC)/serial/serial_buffer.c \
 $(RCP_SRC)/serial/serial.c \
-$(RCP_SRC)/serial/serial_device.c \
 $(RCP_SRC)/timer/timer.c \
 $(RCP_SRC)/timer/timer_config.c \
 $(RCP_SRC)/tracks/tracks.c \

--- a/test/logger_mock/serial_device.c
+++ b/test/logger_mock/serial_device.c
@@ -19,29 +19,10 @@
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _SERIAL_DEVICE_H_
-#define _SERIAL_DEVICE_H_
+#include "mock_serial.h"
+#include "serial_device.h"
 
-#include "cpp_guard.h"
-#include "serial.h"
-
-#include <stdbool.h>
-
-CPP_GUARD_BEGIN
-
-/* STIEG: Update Enum type to be proper later */
-typedef enum {
-        SERIAL_USB = 0,
-        SERIAL_GPS,
-        SERIAL_TELEMETRY,
-        SERIAL_BLUETOOTH,
-        SERIAL_WIFI,
-        SERIAL_AUX,
-        __SERIAL_COUNT, /* ALWAYS AT THE END */
-} serial_id_t;
-
-struct Serial* serial_device_get(const serial_id_t port);
-
-CPP_GUARD_END
-
-#endif /* _SERIAL_DEVICE_H_ */
+struct Serial* serial_device_get(const serial_id_t port)
+{
+        return getMockSerial();
+}


### PR DESCRIPTION
Two changes here.  First we move serial_device into the HAL from the
common src region.  This is because the serial mappings differ between
devices.  Fancy that.

This change also improves upon our serial device naming convention.
We add a SERIAL_WIFI to represent the wifi device and renames the
SERIAL_WIRELESS to SERIAL_BLUETOOTH since that is more accurate.