### PR TITLE
Improve mk2 sdcard situation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,16 @@ package: clean
 
 PHONY += TAGS
 TAGS:
-	$(Q)find . -type f -regex '.*\.\(c\|cpp\|h\|hh\)$$' | etags -
+	$(Q)find         \
+	include          \
+	platform         \
+	src              \
+	test             \
+	-type f          \
+	-name "*.c"   -o \
+	-name "*.cpp" -o \
+	-name "*.h"   -o \
+	-name "*.hh"     \
+	| etags -
 
 .PHONY: $(PHONY)

--- a/platform/mk2/hal/fat_sd_stm32/fatfs/lo_level_ub/stm32_ub_sdcard.c
+++ b/platform/mk2/hal/fat_sd_stm32/fatfs/lo_level_ub/stm32_ub_sdcard.c
@@ -211,7 +211,8 @@ int MMC_disk_read(BYTE *buff, DWORD sector, BYTE count)
 
     /* Check if the Transfer is finished */
     status =  SD_WaitReadOperation();
-    while(SD_GetStatus() != SD_TRANSFER_OK);
+    while(SD_GetStatus() != SD_TRANSFER_OK)
+            taskYIELD();
 
     if (status == SD_OK) {
         ret_wert=0;
@@ -1628,6 +1629,7 @@ SD_Error SD_SendSDStatus(uint32_t *psdstatus)
             }
             psdstatus += 8;
         }
+        taskYIELD();
     }
 
     if (SDIO_GetFlagStatus(SDIO_FLAG_DTIMEOUT) != RESET) {
@@ -1766,6 +1768,7 @@ static SD_Error CmdResp1Error(uint8_t cmd)
 
     while (!(status & (SDIO_FLAG_CCRCFAIL | SDIO_FLAG_CMDREND | SDIO_FLAG_CTIMEOUT))) {
         status = SDIO->STA;
+        taskYIELD();
     }
 
     if (status & SDIO_FLAG_CTIMEOUT) {
@@ -1882,6 +1885,7 @@ static SD_Error CmdResp3Error(void)
 
     while (!(status & (SDIO_FLAG_CCRCFAIL | SDIO_FLAG_CMDREND | SDIO_FLAG_CTIMEOUT))) {
         status = SDIO->STA;
+        taskYIELD();
     }
 
     if (status & SDIO_FLAG_CTIMEOUT) {
@@ -1904,6 +1908,7 @@ static SD_Error CmdResp2Error(void)
 
     while (!(status & (SDIO_FLAG_CCRCFAIL | SDIO_FLAG_CTIMEOUT | SDIO_FLAG_CMDREND))) {
         status = SDIO->STA;
+        taskYIELD();
     }
 
     if (status & SDIO_FLAG_CTIMEOUT) {
@@ -1933,6 +1938,7 @@ static SD_Error CmdResp6Error(uint8_t cmd, uint16_t *prca)
 
     while (!(status & (SDIO_FLAG_CCRCFAIL | SDIO_FLAG_CTIMEOUT | SDIO_FLAG_CMDREND))) {
         status = SDIO->STA;
+        taskYIELD();
     }
 
     if (status & SDIO_FLAG_CTIMEOUT) {
@@ -2089,6 +2095,7 @@ static SD_Error IsCardProgramming(uint8_t *pstatus)
     status = SDIO->STA;
     while (!(status & (SDIO_FLAG_CCRCFAIL | SDIO_FLAG_CMDREND | SDIO_FLAG_CTIMEOUT))) {
         status = SDIO->STA;
+        taskYIELD();
     }
 
     if (status & SDIO_FLAG_CTIMEOUT) {
@@ -2265,6 +2272,7 @@ static SD_Error FindSCR(uint16_t rca, uint32_t *pscr)
             *(tempscr + index) = SDIO_ReadData();
             index++;
         }
+        taskYIELD();
     }
 
     if (SDIO_GetFlagStatus(SDIO_FLAG_DTIMEOUT) != RESET) {
@@ -2370,6 +2378,7 @@ SD_Error SD_HighSpeed (void)
                 }
                 tempbuff += 8;
             }
+            taskYIELD();
         }
 
         if (SDIO_GetFlagStatus(SDIO_FLAG_DTIMEOUT) != RESET) {
@@ -2624,6 +2633,3 @@ void SD_SDIO_DMA_IRQHANDLER(void)
     /* Process DMA2 Stream3 or DMA2 Stream6 Interrupt Sources */
     SD_ProcessDMAIRQ();
 }
-
-
-

--- a/platform/mk2/openocd_stlinkv2_gdb.cfg
+++ b/platform/mk2/openocd_stlinkv2_gdb.cfg
@@ -3,4 +3,3 @@ source openocd_stlinkv2.cfg
 $_TARGETNAME configure -rtos auto
 
 init
-reset halt

--- a/src/command/baseCommands.c
+++ b/src/command/baseCommands.c
@@ -100,9 +100,8 @@ void ShowTaskInfo(Serial *serial, unsigned int argc, char **argv)
      */
     char *taskList = (char *) portMalloc(1024);
     if (NULL != taskList) {
-        //TODO BAP - get this working, when we have a USB console
-        //vTaskList(taskList);
-        //serial->put_s(taskList);
+        vTaskList(taskList);
+        serial->put_s(taskList);
         portFree(taskList);
     } else {
         serial->put_s("Out of Memory!");

--- a/src/command/baseCommands.c
+++ b/src/command/baseCommands.c
@@ -100,8 +100,9 @@ void ShowTaskInfo(Serial *serial, unsigned int argc, char **argv)
      */
     char *taskList = (char *) portMalloc(1024);
     if (NULL != taskList) {
-        vTaskList(taskList);
-        serial->put_s(taskList);
+        //TODO BAP - get this working, when we have a USB console
+        //vTaskList(taskList);
+        //serial->put_s(taskList);
         portFree(taskList);
     } else {
         serial->put_s("Out of Memory!");

--- a/src/logger/fileWriter.c
+++ b/src/logger/fileWriter.c
@@ -37,7 +37,7 @@
 #include <stdbool.h>
 
 #define ERROR_SLEEP_DELAY_MS	500
-#define FILE_BUFFER_SIZE	256
+#define FILE_BUFFER_SIZE	512
 #define FILE_WRITER_STACK_SIZE	256
 #define MAX_LOG_FILE_INDEX	99999
 #define WRITE_FAIL	EOF

--- a/src/sdcard/sdcard.c
+++ b/src/sdcard/sdcard.c
@@ -33,124 +33,148 @@
 #include "sdcard_device.h"
 #include "mem_mang.h"
 
-static FATFS *FatFs = NULL;
+static FATFS *fat_fs = NULL;
 
 void InitFSHardware(void)
 {
-    disk_init_hardware();
+        disk_init_hardware();
+
+        if (fat_fs == NULL)
+                fat_fs = pvPortMalloc(sizeof(FATFS));
+
+        if (fat_fs == NULL)
+                pr_error("sdcard: FatFS init fail\r\n");
+}
+
+static bool is_initialized()
+{
+        if (fat_fs)
+                return true;
+
+        pr_error("sdcard: Not initialized");
+        return false;
 }
 
 int InitFS()
 {
-    if (FatFs == NULL)
-        FatFs = pvPortMalloc(sizeof(FATFS));
+        if(!is_initialized())
+                return -1;
 
-    if (FatFs == NULL) {
-        pr_error("sdcard: FatFS init fail\r\n");
-        return -1;
-    }
+        taskENTER_CRITICAL();
+        const int res = disk_initialize(0);
+        taskEXIT_CRITICAL();
 
-    taskENTER_CRITICAL();
-    const int res = disk_initialize(0);
-    taskEXIT_CRITICAL();
+        if (0 != res) {
+                pr_error("sdcard: Disk init fail\r\n");
+                return res;
+        }
 
-    if (0 != res) {
-        pr_error("sdcard: Disk init fail\r\n");
-        return res;
-    }
-
-    return f_mount(FatFs, "0", 1);
+        return f_mount(fat_fs, "0", 1);
 }
 
 int UnmountFS()
 {
-    return f_mount(NULL, "0", 1);
+        if(!is_initialized())
+                return -1;
+
+        return f_mount(NULL, "0", 1);
 }
 
 void TestSDWrite(Serial *serial, int lines, int doFlush, int quiet)
 {
-    int res = 0;
-    FIL *fatFile = NULL;
+        int res = 0;
+        FIL *fatFile = NULL;
 
-    fatFile = pvPortMalloc(sizeof(FIL));
-    if (NULL == fatFile) {
-        if (!quiet) serial->put_s("could not allocate file object\r\n");
-        goto exit;
-    }
+        if(!is_initialized())
+                return;
 
-    if (!quiet) {
-        serial->put_s("Test Write: Lines: ");
-        put_int(serial, lines);
-        put_crlf(serial);
-        serial->put_s("Flushing Enabled: " );
-        put_int(serial, doFlush);
-        put_crlf(serial);
-        serial->put_s("Card Init... ");
-    }
-    res = InitFS();
-    if (res) goto exit;
-
-    if (!quiet) {
-        put_int(serial, res);
-        put_crlf(serial);
-        serial->put_s("Opening File... ");
-    }
-    res = f_open(fatFile,"test1.txt", FA_WRITE | FA_CREATE_ALWAYS);
-    if (!quiet) {
-        put_int(serial, res);
-        put_crlf(serial);
-    }
-    if (res) goto exit;
-
-    if (!quiet) serial->put_s("Writing file..");
-    portTickType startTicks = xTaskGetTickCount();
-    for (int i = 1; i <= lines; i++) {
-        res = f_puts("The quick brown fox jumped over the lazy dog\n",fatFile);
-        if (doFlush) f_sync(fatFile);
-        if (res == EOF) {
-            if (!quiet) serial->put_s("failed writing at line ");
-            put_int(serial, i);
-            serial->put_s("(");
-            put_int(serial, res);
-            serial->put_s(")");
-            put_crlf(serial);
-            goto exit;
+        fatFile = pvPortMalloc(sizeof(FIL));
+        if (NULL == fatFile) {
+                if (!quiet) serial->put_s("could not allocate file object\r\n");
+                goto exit;
         }
-        watchdog_reset();
-    }
-    portTickType endTicks = xTaskGetTickCount();
 
-    if (!quiet) {
-        serial->put_s("Ticks to write: ");
-        put_int(serial, endTicks - startTicks);
-        put_crlf(serial);
-        serial->put_s("Closing... ");
-    }
+        if (!quiet) {
+                serial->put_s("Test Write: Lines: ");
+                put_int(serial, lines);
+                put_crlf(serial);
+                serial->put_s("Flushing Enabled: " );
+                put_int(serial, doFlush);
+                put_crlf(serial);
+                serial->put_s("Card Init... ");
+        }
 
-    res = f_close(fatFile);
-    if (!quiet) {
-        put_int(serial, res);
-        put_crlf(serial);
-    }
-    if (res) goto exit;
+        res = InitFS();
+        if (res) goto exit;
 
-    if (!quiet)		serial->put_s("Unmounting... ");
-    res = UnmountFS();
-    if (!quiet) {
-        put_int(serial, res);
-        put_crlf(serial);
-    }
+        if (!quiet) {
+                put_int(serial, res);
+                put_crlf(serial);
+                serial->put_s("Opening File... ");
+        }
+
+        res = f_open(fatFile,"test1.txt", FA_WRITE | FA_CREATE_ALWAYS);
+        if (!quiet) {
+                put_int(serial, res);
+                put_crlf(serial);
+        }
+
+        if (res)
+                goto exit;
+
+        if (!quiet) serial->put_s("Writing file..");
+        portTickType startTicks = xTaskGetTickCount();
+        for (int i = 1; i <= lines; i++) {
+                res = f_puts("The quick brown fox jumped over the lazy dog\n",fatFile);
+                if (doFlush) f_sync(fatFile);
+                if (res == EOF) {
+                        if (!quiet) serial->put_s("failed writing at line ");
+                        put_int(serial, i);
+                        serial->put_s("(");
+                        put_int(serial, res);
+                        serial->put_s(")");
+                        put_crlf(serial);
+                        goto exit;
+                }
+                watchdog_reset();
+        }
+        portTickType endTicks = xTaskGetTickCount();
+
+        if (!quiet) {
+                serial->put_s("Ticks to write: ");
+                put_int(serial, endTicks - startTicks);
+                put_crlf(serial);
+                serial->put_s("Closing... ");
+        }
+
+        res = f_close(fatFile);
+        if (!quiet) {
+                put_int(serial, res);
+                put_crlf(serial);
+        }
+        if (res) goto exit;
+
+        if (!quiet)
+                serial->put_s("Unmounting... ");
+
+        res = UnmountFS();
+
+        if (!quiet) {
+                put_int(serial, res);
+                put_crlf(serial);
+        }
+
 exit:
-    if (quiet) {
-        put_int(serial, res == 0 ? 1 : 0);
-    } else {
-        if(res == 0) {
-            serial->put_s("SUCCESS");
+        if (quiet) {
+                put_int(serial, res == 0 ? 1 : 0);
         } else {
-            serial->put_s("ERROR");
-            put_int(serial, res);
-            put_crlf(serial);
+                if(res == 0) {
+                        serial->put_s("SUCCESS");
+                } else {
+                        serial->put_s("ERROR");
+                        put_int(serial, res);
+                        put_crlf(serial);
+                }
         }
-    }
-    if (fatFile != NULL) vPortFree(fatFile);
+        if (fatFile != NULL) vPortFree(fatFile);
 }

--- a/src/sdcard/sdcard.c
+++ b/src/sdcard/sdcard.c
@@ -60,15 +60,6 @@ int InitFS()
         if(!is_initialized())
                 return -1;
 
-        taskENTER_CRITICAL();
-        const int res = disk_initialize(0);
-        taskEXIT_CRITICAL();
-
-        if (0 != res) {
-                pr_error("sdcard: Disk init fail\r\n");
-                return res;
-        }
-
         return f_mount(fat_fs, "0", 1);
 }
 


### PR DESCRIPTION
Adds a patch to our sdcard lib to make it not do things twice and improve its sanity.  Also adds some `taskYIELD` methods to the sdcard driver to prevent it from starving the rest of the system from resources.  Also increases the stack size of the fileWriter task so it doesn't go boom boom all over the other tasks.  Also removes any masking of interrupts and adds some general improvements to our sdcard code.  Finally, adds small debugging and Makefile improvements.