### PR TITLE
Add support for the ESP8266 SoftAP

### DIFF
--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -101,9 +101,11 @@ bool esp8266_get_client_ip(void (*cb)
 
 enum esp8266_encryption {
         ESP8266_ENCRYPTION_NONE = 0,
+        ESP8266_ENCRYPTION_WEP = 1, /* Support deprecated */
         ESP8266_ENCRYPTION_WPA_PSK = 2,
         ESP8266_ENCRYPTION_WPA2_PSK = 3,
         ESP8266_ENCRYPTION_WPA_WPA2_PSK = 4,
+        __ESP8266_ENCRYPTION_MAX, /* Always the last value */
 };
 
 struct esp8266_ap_info {

--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -31,6 +31,11 @@
 
 CPP_GUARD_BEGIN
 
+#define ESP8266_SSID_LEN_MAX	24
+#define ESP8266_MAC_LEN_MAX	18
+#define ESP8266_IPV4_LEN_MAX	16
+#define ESP8266_PASSWD_LEN_MAX	24
+
 void esp8266_do_loop(const size_t timeout);
 
 /**
@@ -79,9 +84,9 @@ bool esp8266_get_op_mode(void (*cb)(bool, enum esp8266_op_mode));
 struct esp8266_client_info {
         tiny_millis_t snapshot_time;
         bool has_ap;
-        char ssid[24];
-        char mac[18];
-        char ip[16];
+        char ssid[ESP8266_SSID_LEN_MAX];
+        char mac[ESP8266_MAC_LEN_MAX];
+        char ip[ESP8266_IPV4_LEN_MAX];
 };
 
 void esp8266_log_client_info(const struct esp8266_client_info *info);
@@ -93,6 +98,31 @@ bool esp8266_get_client_ap(void (*cb)
 
 bool esp8266_get_client_ip(void (*cb)
                            (bool, const char*));
+
+enum esp8266_encryption {
+        ESP8266_ENCRYPTION_NONE = 0,
+        ESP8266_ENCRYPTION_WPA_PSK = 2,
+        ESP8266_ENCRYPTION_WPA2_PSK = 3,
+        ESP8266_ENCRYPTION_WPA_WPA2_PSK = 4,
+};
+
+struct esp8266_ap_info {
+        char ssid[ESP8266_SSID_LEN_MAX];
+        char password[ESP8266_PASSWD_LEN_MAX];
+        size_t channel;
+        enum esp8266_encryption encryption;
+};
+
+typedef void esp8266_get_ap_info_cb_t(const bool status,
+                                      const struct esp8266_ap_info* info);
+
+bool esp8266_get_ap_info(esp8266_get_ap_info_cb_t *cb);
+
+typedef void esp8266_set_ap_info_cb_t(const bool status);
+
+bool esp8266_set_ap_info(const struct esp8266_ap_info* info,
+                         esp8266_set_ap_info_cb_t *cb);
+
 
 bool esp8266_connect(const int chan_id, const enum protocol proto,
                      const char *ip_addr, const int dest_port,

--- a/include/drivers/esp8266_drv.h
+++ b/include/drivers/esp8266_drv.h
@@ -34,6 +34,8 @@ typedef void new_conn_func_t(struct Serial *s);
 
 bool esp8266_drv_update_client_cfg(const struct wifi_client_cfg *cc);
 
+bool esp8266_drv_update_ap_cfg(const struct wifi_ap_cfg *wac);
+
 bool esp8266_drv_init(struct Serial *s, const int priority,
                       new_conn_func_t new_conn_cb);
 

--- a/include/logger/loggerApi.h
+++ b/include/logger/loggerApi.h
@@ -51,6 +51,7 @@ CPP_GUARD_BEGIN
         API_METHOD("getTrackCfg", api_getTrackConfig)                   \
         API_METHOD("getTrackDb", api_getTrackDb)                        \
         API_METHOD("getVer", api_getVersion)                            \
+        API_METHOD("get_wifi_ap_cfg", api_get_wifi_ap_cfg)              \
         API_METHOD("get_wifi_client_cfg", api_get_wifi_client_cfg)      \
         API_METHOD("hb", api_heart_beat)                                \
         API_METHOD("log", api_log)                                      \
@@ -63,6 +64,7 @@ CPP_GUARD_BEGIN
         API_METHOD("setLogfileLevel", api_setLogfileLevel)              \
         API_METHOD("setObd2Cfg", api_setObd2Config)                     \
         API_METHOD("setTrackCfg", api_setTrackConfig)                   \
+        API_METHOD("set_wifi_ap_cfg", api_set_wifi_ap_cfg)              \
         API_METHOD("set_wifi_client_cfg", api_set_wifi_client_cfg)      \
         API_METHOD("sysReset", api_systemReset)                         \
 
@@ -173,6 +175,8 @@ void unescapeTextField(char *data);
 /* Wifi methods */
 int api_get_wifi_client_cfg(struct Serial *s, const jsmntok_t *json);
 int api_set_wifi_client_cfg(struct Serial *s, const jsmntok_t *json);
+int api_get_wifi_ap_cfg(struct Serial *serial, const jsmntok_t *json);
+int api_set_wifi_ap_cfg(struct Serial *s, const jsmntok_t *json);
 
 CPP_GUARD_END
 

--- a/include/tasks/wifi.h
+++ b/include/tasks/wifi.h
@@ -60,6 +60,12 @@ bool wifi_update_client_config(struct wifi_client_cfg *wcc);
 
 bool wifi_update_ap_config(struct wifi_ap_cfg *wac);
 
+bool wifi_validate_ap_config(const struct wifi_ap_cfg *wac);
+
+const char* wifi_api_get_encryption_str_val(const enum esp8266_encryption enc);
+
+enum esp8266_encryption wifi_api_get_encryption_enum_val(const char* str);
+
 CPP_GUARD_END
 
 #endif /* _WIFI_H_ */

--- a/include/tasks/wifi.h
+++ b/include/tasks/wifi.h
@@ -23,6 +23,7 @@
 #define _WIFI_H_
 
 #include "cpp_guard.h"
+#include "esp8266.h"
 #include <stdbool.h>
 
 CPP_GUARD_BEGIN
@@ -36,8 +37,18 @@ struct wifi_client_cfg {
         char passwd[WIFI_PASSWD_MAX_LEN];
 };
 
+struct wifi_ap_cfg {
+        bool active;
+        char ssid[WIFI_SSID_MAX_LEN];
+        char password[WIFI_PASSWD_MAX_LEN];
+        size_t channel;
+        /* Ok for now.  If needed could make independent */
+        enum esp8266_encryption encryption;
+};
+
 struct wifi_cfg {
         struct wifi_client_cfg client;
+        struct wifi_ap_cfg ap;
 };
 
 bool wifi_init_task(const int wifi_task_priority,
@@ -46,6 +57,8 @@ bool wifi_init_task(const int wifi_task_priority,
 void wifi_reset_config(struct wifi_cfg *cfg);
 
 bool wifi_update_client_config(struct wifi_client_cfg *wcc);
+
+bool wifi_update_ap_config(struct wifi_ap_cfg *wac);
 
 CPP_GUARD_END
 

--- a/include/tasks/wifi.h
+++ b/include/tasks/wifi.h
@@ -41,7 +41,7 @@ struct wifi_ap_cfg {
         bool active;
         char ssid[WIFI_SSID_MAX_LEN];
         char password[WIFI_PASSWD_MAX_LEN];
-        size_t channel;
+        uint8_t channel;
         /* Ok for now.  If needed could make independent */
         enum esp8266_encryption encryption;
 };

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -642,6 +642,99 @@ bool esp8266_get_client_ip(void (*cb)(bool, const char*))
 }
 
 /**
+ * The callback invoked by our AT state machine upon the completion
+ * of the command
+ */
+static bool get_ap_info_cb(struct at_rsp *rsp, void *up)
+{
+        static const char *cmd_name = "get_ap_info_cb";
+        esp8266_get_ap_info_cb_t *cb = up;
+        struct esp8266_ap_info ap_info;
+        memset(&ap_info, 0, sizeof(struct esp8266_ap_info));
+
+        bool status = at_ok(rsp);
+        if (!status) {
+                cmd_failure(cmd_name, NULL);
+                goto do_cb;
+        }
+
+        /*
+         * AT+CWSAP_DEF=<ssid>,<pwd>,<chl>,<ecn>
+         * ssid -> string
+         * pwd  -> string
+         * chl  -> number
+         * ecn  -> number
+         */
+        char *toks[6];
+        const int tok_cnt = at_parse_rsp_line(rsp->msgs[0], toks,
+                                              ARRAY_LEN(toks));
+
+        if (tok_cnt != 5) {
+                cmd_failure(cmd_name, "Unexpected # of tokens in response");
+                status = false;
+                goto do_cb;
+        }
+
+        strncpy(ap_info.ssid, at_parse_rsp_str(toks[1]),
+                ARRAY_LEN(ap_info.ssid));
+        strncpy(ap_info.password, at_parse_rsp_str(toks[2]),
+                ARRAY_LEN(ap_info.password));
+        ap_info.channel = atoi(toks[3]);
+        ap_info.encryption = (enum esp8266_encryption) atoi(toks[4]);
+
+do_cb:
+        if (cb)
+                cb(status, &ap_info);
+
+        return false;
+}
+
+bool esp8266_get_ap_info(esp8266_get_ap_info_cb_t *cb)
+{
+        if (!check_initialized("get_ap_info"))
+                return false;
+
+        const char cmd[] = "AT+CWSAP_DEF?";
+        return NULL != at_put_cmd(state.ati, cmd, _TIMEOUT_MEDIUM_MS,
+                                  get_ap_info_cb, cb);
+}
+
+/**
+ * Callback that gets invoked when the set_ap_info command completes.
+ */
+static bool set_ap_info_cb(struct at_rsp *rsp, void *up)
+{
+        static const char *cmd_name = "set_ap_info_cb";
+        esp8266_set_ap_info_cb_t *cb = up;
+
+        bool status = at_ok(rsp);
+        if (!status) {
+                cmd_failure(cmd_name, NULL);
+        }
+
+        if (cb)
+                cb(status);
+
+        return false;
+}
+
+bool esp8266_set_ap_info(const struct esp8266_ap_info* info,
+                         esp8266_set_ap_info_cb_t *cb)
+{
+        if (!check_initialized("set_ap_info") || NULL == info)
+                return false;
+
+        char cmd[64];
+        snprintf(cmd, ARRAY_LEN(cmd), "AT+CWSAP_DEF=\"%s\",\"%s\",%d,%d",
+                 info->ssid, info->password, info->channel,
+                 info->encryption);
+
+        return NULL != at_put_cmd(state.ati, cmd, _TIMEOUT_LONG_MS,
+                                  set_ap_info_cb, cb);
+
+}
+
+/**
  *
  * @param cb The callback to be invoked when the method completes.
  */

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -725,7 +725,7 @@ bool esp8266_set_ap_info(const struct esp8266_ap_info* info,
                 return false;
 
         char cmd[64];
-        snprintf(cmd, ARRAY_LEN(cmd), "AT+CWSAP_DEF=\"%s\",\"%s\",%d,%d",
+        snprintf(cmd, ARRAY_LEN(cmd), "AT+CWSAP_DEF=\"%s\",\"%s\",%zu,%d",
                  info->ssid, info->password, info->channel,
                  info->encryption);
 

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -725,8 +725,8 @@ bool esp8266_set_ap_info(const struct esp8266_ap_info* info,
                 return false;
 
         char cmd[64];
-        snprintf(cmd, ARRAY_LEN(cmd), "AT+CWSAP_DEF=\"%s\",\"%s\",%zu,%d",
-                 info->ssid, info->password, info->channel,
+        snprintf(cmd, ARRAY_LEN(cmd), "AT+CWSAP_DEF=\"%s\",\"%s\",%d,%d",
+                 info->ssid, info->password, (int) info->channel,
                  info->encryption);
 
         return NULL != at_put_cmd(state.ati, cmd, _TIMEOUT_LONG_MS,

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -709,7 +709,7 @@ static void get_ap_info_cb(const bool status,
         pr_info_str_msg("\t SSID      : ", info->ssid);
         pr_info_str_msg("\t Password  : ", info->password);
         pr_info_int_msg("\t Channel   : ", info->channel);
-        pr_info_int_msg("\t Encrpytion: ", info->encryption);
+        pr_info_int_msg("\t Encryption: ", info->encryption);
 }
 
 /**
@@ -981,19 +981,13 @@ bool esp8266_drv_init(struct Serial *s, const int priority,
         const struct wifi_client_cfg *cfg =
                 &lc->ConnectivityConfigs.wifi.client;
         if (!esp8266_drv_update_client_cfg(cfg)) {
-                pr_error(LOG_PFX "Failed to set WiFi cfg\r\n");
+                pr_error(LOG_PFX "Failed to set WiFi client cfg\r\n");
                 return false;
         }
 
-        /* Temporary until we add the config section */
-        static struct wifi_ap_cfg wifi_ap_config = {
-                .active = true,
-                .ssid = "RaceCapture WiFi",
-                .password = "driveitlikeyoustoleit",
-                .channel = 11,
-                .encryption = ESP8266_ENCRYPTION_WPA2_PSK,
-        };
-        esp8266_drv_update_ap_cfg(&wifi_ap_config);
+        const struct wifi_ap_cfg* wac =
+                &lc->ConnectivityConfigs.wifi.ap;
+        esp8266_drv_update_ap_cfg(wac);
 
         esp8266_state.comm.new_conn_cb = new_conn_cb;
 

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -728,7 +728,7 @@ static bool get_ap_info()
 }
 
 /**
- * Callback that is invoked when the set_ap command complets.
+ * Callback that is invoked when the set_ap command completes.
  */
 static void set_ap_cb(const bool status)
 {

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -40,6 +40,7 @@
 #define AT_TASK_TIMEOUT_MS	3
 #define CHECK_DONE_SLEEP_MS	3600000
 #define CLIENT_BACKOFF_MS	30000
+#define AP_BACKOFF_MS		60000
 #define INIT_FAIL_SLEEP_MS	10000
 #define LOG_PFX			"[ESP8266 Driver] "
 #define MAX_CHANNELS		5
@@ -62,6 +63,13 @@ struct client {
         const struct wifi_client_cfg *config;
         struct esp8266_client_info info;
         tiny_millis_t next_join_attempt;
+};
+
+struct ap {
+        const struct wifi_ap_cfg *config;
+        struct esp8266_ap_info info;
+        tiny_millis_t info_timestamp;
+        tiny_millis_t next_set_attempt;
 };
 
 struct server {
@@ -98,6 +106,7 @@ struct comm {
 enum check {
         CHECK_INIT,
         CHECK_WIFI_CLIENT,
+        CHECK_WIFI_AP,
         CHECK_SERVER,
         CHECK_DATA,
         __NUM_CHECKS, /* Always the last */
@@ -111,6 +120,7 @@ struct cmd {
 static struct {
         struct device device;
         struct client client;
+        struct ap ap;
         struct server server;
         struct comm comm;
         struct cmd cmd;
@@ -428,6 +438,7 @@ static void init_wifi_cb(enum dev_init_state dev_state)
         /* Now that init state has changed, check them */
         cmd_set_check(CHECK_INIT);
         cmd_set_check(CHECK_WIFI_CLIENT);
+        cmd_set_check(CHECK_WIFI_AP);
         cmd_set_check(CHECK_SERVER);
         cmd_set_check(CHECK_DATA);
 }
@@ -672,6 +683,168 @@ static void check_wifi_client()
 }
 
 
+/* *** Methods that handle the Wifi AP and its actions *** */
+
+/**
+ * Callback that gets invoked when the get_ap_info command completes.
+ */
+static void get_ap_info_cb(const bool status,
+                           const struct esp8266_ap_info* info)
+{
+        cmd_completed();
+        cmd_set_check(CHECK_WIFI_AP);
+        esp8266_state.ap.info_timestamp = getUptime();
+
+        const size_t ap_info_size = sizeof(esp8266_state.ap.info);
+        if (!status) {
+                pr_warning(LOG_PFX "Failed to read AP info\r\n");
+                memset(&esp8266_state.ap.info, 0, ap_info_size);
+                return;
+        }
+
+        memcpy(&esp8266_state.ap.info, info, ap_info_size);
+
+        /* Print out our AP Info here */
+        pr_info(LOG_PFX "AP info:\r\n");
+        pr_info_str_msg("\t SSID      : ", info->ssid);
+        pr_info_str_msg("\t Password  : ", info->password);
+        pr_info_int_msg("\t Channel   : ", info->channel);
+        pr_info_int_msg("\t Encrpytion: ", info->encryption);
+}
+
+/**
+ * Command that will retrieve the Soft AP configuration settings
+ * from the WiFi device.
+ */
+static bool get_ap_info()
+{
+        pr_info(LOG_PFX "Retrieving Wifi AP Info\r\n");
+
+        const bool queued = esp8266_get_ap_info(get_ap_info_cb);
+        if (queued)
+                cmd_started();
+
+        return queued;
+}
+
+/**
+ * Callback that is invoked when the set_ap command complets.
+ */
+static void set_ap_cb(const bool status)
+{
+        cmd_completed();
+        cmd_set_check(CHECK_WIFI_AP);
+
+        /* Update our backoff timer to prevent busy loops */
+        esp8266_state.ap.next_set_attempt =
+                date_time_uptime_now_plus(AP_BACKOFF_MS);
+
+        /* Clear out the info since it has changed */
+        const size_t ap_info_size = sizeof(esp8266_state.ap.info);
+        memset(&esp8266_state.ap.info, 0, ap_info_size);
+        esp8266_state.ap.info_timestamp = 0;
+
+        if (!status)
+                pr_warning(LOG_PFX "Failed to read AP info\r\n");
+}
+
+/**
+ * Command that will set the configuration of the soft AP of the
+ * esp8266 device.
+ */
+static bool set_ap(struct esp8266_ap_info* ap_info)
+{
+        pr_info(LOG_PFX "Updating Wifi AP Config:");
+        const bool queued = esp8266_set_ap_info(ap_info, set_ap_cb);
+        if (queued)
+                cmd_started();
+
+        return queued;
+}
+
+/**
+ * Helper method to check_wifi_ap.  This method will attempt to adjust the
+ * wifi ap settings if it deems that enough time has passed.  Otherwise it
+ * will cause a back-off to occur.  This is necessary so that a bad config
+ * doesn't cause a busy wait in the system.
+ */
+static void ap_check_try_set()
+{
+        if (!date_time_is_past(esp8266_state.ap.next_set_attempt)){
+                /* Then we need to backoff */
+                const tiny_millis_t sleep_len =
+                        esp8266_state.ap.next_set_attempt - getUptime();
+                cmd_sleep(CHECK_WIFI_AP, sleep_len);
+                return;
+        }
+
+        /* Setup our configuration structure to pass in */
+        const struct wifi_ap_cfg* cfg = esp8266_state.ap.config;
+        struct esp8266_ap_info ap_info;
+        strncpy(ap_info.ssid, cfg->ssid, ARRAY_LEN(ap_info.ssid));
+        strncpy(ap_info.password, cfg->password, ARRAY_LEN(ap_info.password));
+        ap_info.channel = cfg->channel;
+        ap_info.encryption = cfg->encryption;
+
+        if (!set_ap(&ap_info))
+                pr_warning(LOG_PFX "Failed to issue set_ap command\r\n");
+}
+
+/**
+ * This is the block of logic that manages our WiFi client state.
+ * Its responsible for keeping the client status as close to the
+ * configuration as is reasonably possible.
+ */
+static void check_wifi_ap()
+{
+        cmd_check_complete(CHECK_WIFI_AP);
+        pr_info(LOG_PFX "Checking WiFi AP\r\n");
+
+        /* First check that we are initialized */
+        if (!device_initialized()) {
+                cmd_sleep(CHECK_WIFI_AP, AP_BACKOFF_MS);
+                return;
+        }
+
+        /*
+         * First check if we have reasonably fresh AP info. Have to
+         * have it before we can make any decisions.
+         */
+        if (0 == esp8266_state.ap.info_timestamp) {
+                get_ap_info();
+                return;
+        }
+
+        /* If here, we have fresh AP info.  Use it to make decisions. */
+        const struct wifi_ap_cfg* cfg = esp8266_state.ap.config;
+        if (!cfg->active) {
+                /*
+                 * AP should be inactive. This should be controlled by a
+                 * different state machine because managing the esp8266
+                 * device mode effects both the wifi client and the soft
+                 * AP.  Hence this is a NO OP.
+                 */
+                pr_info(LOG_PFX "AP is inactive.\r\n");
+                return;
+        }
+
+        /* Config says AP should be active. Make it so. */
+        const struct esp8266_ap_info* info = &esp8266_state.ap.info;
+        if (!STR_EQ(cfg->ssid, info->ssid) ||
+            !STR_EQ(cfg->password, info->password) ||
+            cfg->channel != info->channel ||
+            cfg->encryption != info->encryption) {
+                /* Then we need to re-setup our AP */
+                ap_check_try_set();
+                return;
+        }
+
+        /* If here, we are setup properly and are done */
+        pr_info(LOG_PFX "AP configured properly\r\n");
+        return;
+}
+
+
 /* *** Methods that handle the Server and its actions *** */
 
 static void server_cmd_cb(bool status)
@@ -735,6 +908,9 @@ static void task_loop()
         case CHECK_WIFI_CLIENT:
                 check_wifi_client();
                 break;
+        case CHECK_WIFI_AP:
+                check_wifi_ap();
+                break;
         case CHECK_SERVER:
                 check_server();
                 break;
@@ -768,6 +944,22 @@ bool esp8266_drv_update_client_cfg(const struct wifi_client_cfg *cc)
         return true;
 }
 
+bool esp8266_drv_update_ap_cfg(const struct wifi_ap_cfg *wac)
+{
+        if (NULL == wac)
+                return false;
+
+        esp8266_state.ap.config = wac;
+
+        /* Zero this value out so we will forego any backoff attempts */
+        esp8266_state.ap.next_set_attempt = 0;
+
+        /* AP state changed. */
+        cmd_set_check(CHECK_WIFI_AP);
+
+        return true;
+}
+
 bool esp8266_drv_init(struct Serial *s, const int priority,
                       new_conn_func_t new_conn_cb)
 {
@@ -792,6 +984,16 @@ bool esp8266_drv_init(struct Serial *s, const int priority,
                 pr_error(LOG_PFX "Failed to set WiFi cfg\r\n");
                 return false;
         }
+
+        /* Temporary until we add the config section */
+        static struct wifi_ap_cfg wifi_ap_config = {
+                .active = true,
+                .ssid = "RaceCapture WiFi",
+                .password = "driveitlikeyoustoleit",
+                .channel = 11,
+                .encryption = ESP8266_ENCRYPTION_WPA2_PSK,
+        };
+        esp8266_drv_update_ap_cfg(&wifi_ap_config);
 
         esp8266_state.comm.new_conn_cb = new_conn_cb;
 

--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -271,15 +271,6 @@ bool wifi_init_task(const int wifi_task_priority,
         return true;
 }
 
-void wifi_reset_config(struct wifi_cfg *cfg)
-{
-        /* For now simply zero this out */
-        memset(cfg, 0, sizeof(struct wifi_cfg));
-
-        /* Inform the Wifi device that settings may have changed */
-        wifi_update_client_config(&cfg->client);
-}
-
 /**
  * Wrapper for the driver to update the client wifi config
  * settings.  This is here because it makes sense for these
@@ -289,4 +280,23 @@ void wifi_reset_config(struct wifi_cfg *cfg)
 bool wifi_update_client_config(struct wifi_client_cfg *wcc)
 {
         return esp8266_drv_update_client_cfg(wcc);
+}
+
+/**
+ * Wrapper for the driver to update the ap wifi config
+ * settings.
+ */
+bool wifi_update_ap_config(struct wifi_ap_cfg *wac)
+{
+        return esp8266_drv_update_ap_cfg(wac);
+}
+
+void wifi_reset_config(struct wifi_cfg *cfg)
+{
+        /* For now simply zero this out */
+        memset(cfg, 0, sizeof(struct wifi_cfg));
+
+        /* Inform the Wifi device that settings may have changed */
+        wifi_update_client_config(&cfg->client);
+        wifi_update_ap_config(&cfg->ap);
 }

--- a/test/json_api_files/get_wifi_ap_cfg.json
+++ b/test/json_api_files/get_wifi_ap_cfg.json
@@ -1,0 +1,1 @@
+{"get_wifi_ap_cfg":null}

--- a/test/json_api_files/set_wifi_ap_cfg.json
+++ b/test/json_api_files/set_wifi_ap_cfg.json
@@ -1,0 +1,1 @@
+{"set_wifi_ap_cfg":{"active":true,"ssid":"RaceIt","passwd":"dontcrashit","channel":1,"encryption":"none"}}

--- a/test/json_api_files/set_wifi_ap_cfg_bad_channel.json
+++ b/test/json_api_files/set_wifi_ap_cfg_bad_channel.json
@@ -1,0 +1,1 @@
+{"set_wifi_ap_cfg":{"active":true,"ssid":"RaceIt","passwd":"dontcrashit","channel":0,"encryption":"none"}}

--- a/test/json_api_files/set_wifi_ap_cfg_bad_encryption.json
+++ b/test/json_api_files/set_wifi_ap_cfg_bad_encryption.json
@@ -1,0 +1,1 @@
+{"set_wifi_ap_cfg":{"active":true,"ssid":"RaceIt","passwd":"dontcrashit","channel":1,"encryption":"wap"}}

--- a/test/loggerApi_test.h
+++ b/test/loggerApi_test.h
@@ -81,6 +81,11 @@ class LoggerApiTest : public CppUnit::TestFixture
     CPPUNIT_TEST( testGetCapabilities);
     CPPUNIT_TEST( testSetWifiClientCfg );
     CPPUNIT_TEST( testGetWifiClientCfg );
+    CPPUNIT_TEST( testSetWifiApCfg );
+    CPPUNIT_TEST( testSetWifiApCfgBadChannel );
+    CPPUNIT_TEST( testSetWifiApCfgBadEncryption );
+    CPPUNIT_TEST( testSetAndGetWifiApCfg );
+    CPPUNIT_TEST( testGetDefaultWifiApCfg );
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -138,6 +143,11 @@ public:
     void testGetCapabilities();
     void testSetWifiClientCfg();
     void testGetWifiClientCfg();
+    void testSetWifiApCfg();
+    void testSetWifiApCfgBadChannel();
+    void testSetWifiApCfgBadEncryption();
+    void testSetAndGetWifiApCfg();
+    void testGetDefaultWifiApCfg();
 
 private:
     void testSetScriptFile(string filename);


### PR DESCRIPTION
Includes the patches needed to enable support for the softAP functionality on the esp8266.  This will allow us to control the main aspects of the AP (name, password, channel, encryption) as well as allows us to configure it through our APIs.  Also added unit tests for the API calls as well as for the default reset behavior.  Fixes #592 