### PR TITLE
Soft AP Beacon Support

### DIFF
--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -110,7 +110,6 @@ struct esp8266_client_info {
         bool has_ap;
         char ssid[ESP8266_SSID_LEN_MAX];
         char mac[ESP8266_MAC_LEN_MAX];
-        char ip[ESP8266_IPV4_LEN_MAX];
 };
 
 void esp8266_log_client_info(const struct esp8266_client_info *info);
@@ -120,8 +119,15 @@ bool esp8266_join_ap(const char* ssid, const char* pass, void (*cb)(bool));
 bool esp8266_get_client_ap(void (*cb)
                            (bool, const struct esp8266_client_info*));
 
-bool esp8266_get_client_ip(void (*cb)
-                           (bool, const char*));
+struct esp8266_ipv4_info {
+        char address[ESP8266_IPV4_LEN_MAX];
+};
+
+typedef void get_ip_info_cb_t(const bool status,
+                              const struct esp8266_ipv4_info* client,
+                              const struct esp8266_ipv4_info* station);
+
+bool esp8266_get_ip_info(get_ip_info_cb_t callback);
 
 enum esp8266_encryption {
         ESP8266_ENCRYPTION_INVALID = -1,

--- a/include/drivers/esp8266_drv.h
+++ b/include/drivers/esp8266_drv.h
@@ -43,7 +43,9 @@ struct Serial* esp8266_drv_connect(const enum protocol proto,
                                    const char* dst_ip,
                                    const unsigned int dst_port);
 
-const struct esp8266_client_info* esp8266_drv_get_client_info();
+const struct esp8266_ipv4_info* get_client_ipv4_info();
+
+const struct esp8266_ipv4_info* get_ap_ipv4_info();
 
 CPP_GUARD_END
 

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -1050,7 +1050,12 @@ struct Serial* esp8266_drv_connect(const enum protocol proto,
         return ch->serial;
 }
 
-const struct esp8266_client_info* esp8266_drv_get_client_info()
+const struct esp8266_ipv4_info* get_client_ipv4_info()
 {
-        return &esp8266_state.client.info;
+        return &esp8266_state.client.ipv4;
+}
+
+const struct esp8266_ipv4_info* get_ap_ipv4_info()
+{
+        return &esp8266_state.ap.ipv4;
 }

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -684,6 +684,7 @@ static void check_wifi_client()
                 }
 
                 /* Then config and reality align.  Done */
+                pr_info(LOG_PFX "Client is inactive.\r\n");
                 return;
         }
 }

--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -193,13 +193,14 @@ static void do_beacon()
         /* Update the time the beacon last went out */
         state.beacon.time_last = getUptime();
 
-        const struct esp8266_client_info* ci = esp8266_drv_get_client_info();
-        if (!ci->has_ap) {
-                /* Then don't bother since we don't have a connection */
+        const struct esp8266_ipv4_info* client_ipv4 = get_client_ipv4_info();
+        const struct esp8266_ipv4_info* softap_ipv4 = get_ap_ipv4_info();
+        if (!*client_ipv4->address && !*softap_ipv4->address) {
+                /* Then don't bother since we don't have any IP addresses */
                 return;
         }
 
-        /* If here then we have at least one connection.  Send the beacon */
+        /* If here then we have at least one IP.  Send the beacon */
         if (NULL == state.beacon.serial) {
                 state.beacon.serial =
                         esp8266_drv_connect(PROTOCOL_UDP, "255.255.255.255",
@@ -213,6 +214,8 @@ static void do_beacon()
         }
 
         const char* ips[] = {
+                client_ipv4->address,
+                softap_ipv4->address,
                 NULL,
         };
         send_beacon(serial, ips);

--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -213,7 +213,6 @@ static void do_beacon()
         }
 
         const char* ips[] = {
-                ci->ip,
                 NULL,
         };
         send_beacon(serial, ips);


### PR DESCRIPTION
This change adds support that allows our soft AP to broadcast its beacon info to both our guests and clients.  Now you can always connect to the unit, regardless of your approach if you can see the beacon.

This change also moves our IP info into its own structure since we needed to do that.