### PR TITLE
Move the client info timestamp to its correct location

### DIFF
--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -106,7 +106,6 @@ bool esp8266_set_op_mode(const enum esp8266_op_mode mode,
 bool esp8266_get_op_mode(void (*cb)(bool, enum esp8266_op_mode));
 
 struct esp8266_client_info {
-        tiny_millis_t snapshot_time;
         bool has_ap;
         char ssid[ESP8266_SSID_LEN_MAX];
         char mac[ESP8266_MAC_LEN_MAX];

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -547,7 +547,6 @@ static bool get_client_ap_cb(struct at_rsp *rsp, void *up)
         }
 
         struct esp8266_client_info ci;
-        ci.snapshot_time = getUptime();
         char *client_info_rsp = rsp->msgs[rsp->msg_count - 2];
         if (!parse_client_info(client_info_rsp, &ci)) {
                 cmd_failure(cmd_name, "Failed to parse AP info");


### PR DESCRIPTION
Previously this was mushed into the client info structure.
This was bad form on my part.  This patch fixes that by instead
movint it to within the client structure where it belongs.

Issue #598