### PR TITLE
Make all non-tagged builds DEBUG builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,13 @@ ifneq ($(OFFICIAL_TAG),)
 endif
 export RELEASE_TYPE
 
+#
+# Set the DEBUG flag if we are not build an official release.
+#
+ifneq ($(RELEASE_TYPE),RELEASE_TYPE_OFFICIAL)
+export DEBUG=1
+endif
+
 export VERSION_CFLAGS := \
 -DAPI_REV=$(API) \
 -DMAJOR_REV=$(MAJOR) \

--- a/test/sector_test.cpp
+++ b/test/sector_test.cpp
@@ -156,7 +156,7 @@ void SectorTest::testSectorTimes(){
 	int lineNo = 0;
 	string line;
 
-        const bool debug = getenv("DEBUG") != NULL;
+        const bool debug = getenv("TRACE") != NULL;
         if (debug) printf("\r\n");
 
 	while (std::getline(iss, line)) {


### PR DESCRIPTION
We tag all RC and Release build for RaceCapture.  To ensure that we
find bugs more quickly we should always build with the watchdog
disabled so that bugs that cause crashes are more noticable and thus
get squashed sooner.  This change does that by enabling the DEBUG flag
on all non-tagged builds.  Tested a tagged build to ensure that it had
no DEBUG flag set.