### PR TITLE
Use agressive yet sane GC parameters for LUA on MK2

### DIFF
--- a/platform/mk2/capabilities.h
+++ b/platform/mk2/capabilities.h
@@ -42,8 +42,10 @@
  * A value of 0 means that you want to use the default.  For more info
  * see http://www.lua.org/manual/5.1/manual.html#2.10
  */
-#define LUA_GC_PAUSE_PCT	0
-#define LUA_GC_STEP_MULT_PCT	0
+/* Pause between runs.  < 100 means don't wait */
+#define LUA_GC_PAUSE_PCT	99
+/* Runtime of GC to malloc.  Setting to 10x for agressive behavior. */
+#define LUA_GC_STEP_MULT_PCT	1000
 
 /*
  * Controls whether or not we allow LUA to register the nice to have


### PR DESCRIPTION
Previously we were sending values of 0 to our GC.  I think this may
have been an oversight and hence an indirect cause to GC issues on our
lua environment.  Thus I have tweaked the GC to have no pause time
between GC invocations and set the step multiplier to be a factor of
10 of the memory allocation.  This seems to yield a fairly nice
tradeoff between slightly more memory usage to GC collection periods.
I used "gc_test.lua" script for this.  Stats and script below.

Issue #476

```txt
LUA GC Improvements 2.9.1

= Test 1 =
ONTICK_FREQUENCY  = 1000
OBJECTS_PER_CYCLE = 0
STATS_INTERVAL_MS = 5000
IN_LUA_GC         = false

== Pre Patch ==
LUA is using 23.025391 KB of RAM
LUA ran 4122.0 times during the interval
Expected 5000.0 during the interval
Average run 0.632217 ms
Fastest run 0.0 ms
Slowest run 4.0 ms

== Post Patch ==
LUA is using 24.962891 KB of RAM
LUA ran 4998.0 times during the interval
Expected 5000.0 during the interval
Average run 0.003201 ms
Fastest run 0.0 ms
Slowest run 1.0 ms

= Test 2 =
ONTICK_FREQUENCY  = 1000
OBJECTS_PER_CYCLE = 10
STATS_INTERVAL_MS = 5000
IN_LUA_GC         = false

== Pre Patch ==
LUA is using 24.431641 KB of RAM
LUA ran 662.0 times during the interval
Expected 5000.0 during the interval
Average run 6.956193 ms
Fastest run 6.0 ms
Slowest run 11.0 ms

== Post Patch ==
LUA is using 25.432617 KB of RAM
LUA ran 2423.0 times during the interval
Expected 5000.0 during the interval
Average run 1.96492 ms
Fastest run 1.0 ms
Slowest run 4.0 ms

= Test 3 =
ONTICK_FREQUENCY  = 1000
OBJECTS_PER_CYCLE = 10
STATS_INTERVAL_MS = 5000
IN_LUA_GC         = true

== Pre Patch ==
LUA is using 24.430664 KB of RAM
LUA ran 596.0 times during the interval
Expected 5000.0 during the interval
Average run 7.808725 ms
Fastest run 7.0 ms
Slowest run 12.0 ms

== Post Patch ==
LUA is using 27.150391 KB of RAM
LUA ran 1881.0 times during the interval
Expected 5000.0 during the interval
Average run 2.407762 ms
Fastest run 2.0 ms
Slowest run 5.0 ms

= Test 4 =
ONTICK_FREQUENCY  = 100
OBJECTS_PER_CYCLE = 100
STATS_INTERVAL_MS = 5000
IN_LUA_GC         = false

== Pre Patch ==
LUA is using 38.493164 KB of RAM
LUA ran 65.0 times during the interval
Expected 500.0 during the interval
Average run 76.261538 ms
Fastest run 74.0 ms
Slowest run 80.0 ms

== Post Patch ==
LUA is using 39.494141 KB of RAM
LUA ran 267.0 times during the interval
Expected 500.0 during the interval
Average run 18.599251 ms
Fastest run 17.0 ms
Slowest run 22.0 ms
```

```lua
-- Tests out GC effectiveness by stressing GC and printing out
-- Memory usage information

-- CONSTANTS
ONTICK_FREQUENCY  = 1000
OBJECTS_PER_CYCLE = 0
STATS_INTERVAL_MS = 5000
IN_LUA_GC         = false

setTickRate(ONTICK_FREQUENCY)

--
-- Creates `count` objects that are linked together.  This is designed
-- to stress the GC system a bit since all the objects are linked, but
-- will be orphaned at the end of the call.
function make_objects(count)
	local last = nil
	for i=0,count do
		obj = {}
		obj["time"] = getUptime()
		obj["id"]   = i
		obj["last"] = last
		last = obj
	end
end

--
-- Tracks runtime info like runs, high, low, and avg time
--
_rt_hgh = -1
_rt_low = -1
_rt_tot = 0
_runs = 0

function reset_runtime_stats()
	_rt_hgh = -1
	_rt_low = -1
	_rt_tot = 0
	_runs   = 0
end

function record_runtime(time)
	_runs = _runs + 1
	_rt_tot = _rt_tot + time

	if _rt_hgh == -1 then _rt_hgh = time end
	if _rt_low == -1 then _rt_low = time end

	if time > _rt_hgh then _rt_hgh = time end
	if time < _rt_low then _rt_low = time end
end

function get_runtime_stats()
	return _runs, _rt_tot / _runs, _rt_hgh, _rt_low
end

--
-- Tells us useful stats related to GC testing.
--

function print_stats()
	k, b = collectgarbage("count")
	runs, rt_avg, rt_hgh, rt_low = get_runtime_stats()
	exp_runs = STATS_INTERVAL_MS / 1000 * ONTICK_FREQUENCY

	println("---")
	println("LUA is using " .. k .. " KB of RAM")
	println("LUA ran " .. runs .. " times during the interval")
	println("Expected " .. exp_runs .." during the interval")
	println("Average run " .. rt_avg .. " ms")
	println("Fastest run " .. rt_low .. " ms")
	println("Slowest run " .. rt_hgh .. " ms")

end

last_print = 0
function onTick()
	local start_time = getUptime()
	make_objects(OBJECTS_PER_CYCLE)
	if (last_print + STATS_INTERVAL_MS) < start_time then
		print_stats()
		reset_runtime_stats()
		last_print = start_time
	end

	if IN_LUA_GC then
		collectgarbage()
	end

	record_runtime(getUptime() - start_time)
end
```