### PR TITLE
Fix RCT Mass Erase Issue, Improve Version Logging

### DIFF
--- a/include/logger/versionInfo.h
+++ b/include/logger/versionInfo.h
@@ -41,9 +41,9 @@ typedef struct _VersionInfo {
         uint32_t bugfix;
 } VersionInfo;
 
-#define DEFAULT_VERSION_INFO {MAJOR_REV, MINOR_REV, BUGFIX_REV}
-
-bool versionChanged(const volatile VersionInfo *versionInfo);
+bool version_check_changed(const VersionInfo *versionInfo,
+                           const char* log_pfx);
+const VersionInfo* get_current_version_info();
 const char* version_git_description();
 enum release_type version_get_release_type();
 const char* version_release_type_api_key(const enum release_type rt);

--- a/include/tracks/tracks.h
+++ b/include/tracks/tracks.h
@@ -49,13 +49,6 @@ enum track_add_mode {
 
 #define DEFAULT_TRACK_TARGET_RADIUS	0.0001
 
-#define DEFAULT_TRACKS \
-{ \
-    DEFAULT_VERSION_INFO, \
-    0, \
-    {} \
-}
-
 enum TrackType {
     TRACK_TYPE_CIRCUIT = 0,
     TRACK_TYPE_STAGE = 1,

--- a/platform/rct/capabilities.h
+++ b/platform/rct/capabilities.h
@@ -45,8 +45,8 @@
 //logger message buffering
 #define LOGGER_MESSAGE_BUFFER_SIZE  5
 
-//logging
-#define LOG_BUFFER_SIZE	2048
+/* Logging Buffer Size (in 1K Blocks) */
+#define LOG_BUFFER_SIZE	(1024 * 3)
 
 //system info
 #define DEVICE_NAME    "RCT"

--- a/platform/rct/openocd_flash.cfg
+++ b/platform/rct/openocd_flash.cfg
@@ -4,8 +4,13 @@ init
 reset halt
 
 flash probe 0
-stm32f1x mass_erase 0
-#flash write_image .build/main.hex
+
+#
+# Doing a mass erase will destroy all the configuration
+# information.  Don't do it unless you really need it.
+#
+#stm32f1x mass_erase 0
+
 program .build/main.hex verify
 
 reset run

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -690,14 +690,14 @@ int flashLoggerConfig(void)
 
 static bool checkFlashDefaultConfig(void)
 {
-    bool changed = versionChanged(&g_savedLoggerConfig.RcpVersionInfo);
-    if (changed) {
+        const VersionInfo sv = g_savedLoggerConfig.RcpVersionInfo;
+        bool changed = version_check_changed(&sv, "Config DB");
+        if (!changed)
+                return false;
+
         pr_info("major/minor version changed\r\n");
         flash_default_logger_config();
         return true;
-    } else {
-        return false;
-    }
 }
 
 static void loadWorkingLoggerConfig(void)

--- a/src/logger/versionInfo.c
+++ b/src/logger/versionInfo.c
@@ -19,15 +19,50 @@
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "printk.h"
 #include "versionInfo.h"
-
 #include <stddef.h>
 
-bool versionChanged(const volatile VersionInfo *versionInfo)
+static void print_version(const VersionInfo *vi)
 {
-        bool major_version_changed = versionInfo->major != MAJOR_REV;
-        bool minor_version_changed = versionInfo->minor != MINOR_REV;
-        bool changed = (major_version_changed || minor_version_changed);
+        pr_info_int(vi->major);
+        pr_info_char('.');
+        pr_info_int(vi->minor);
+        pr_info_char('.');
+        pr_info_int(vi->bugfix);
+}
+
+const VersionInfo* get_current_version_info() {
+        static const VersionInfo vi = {
+                .major = MAJOR_REV,
+                .minor = MINOR_REV,
+                .bugfix = BUGFIX_REV,
+        };
+
+        return &vi;
+}
+
+bool version_check_changed(const VersionInfo *pv,
+                           const char* log_pfx)
+{
+        const VersionInfo* cv = get_current_version_info();
+        const bool changed = cv->major != pv->major ||
+                cv->minor != pv->minor;
+
+        if (changed) {
+                if (log_pfx) {
+                        pr_info(log_pfx);
+                        pr_info(" version changed: ");
+                } else {
+                        pr_info("Version changed: ");
+                }
+
+                print_version(pv);
+                pr_info(" -> ");
+                print_version(cv);
+                pr_info("\r\n");
+        }
+
         return changed;
 }
 

--- a/src/tracks/tracks.c
+++ b/src/tracks/tracks.c
@@ -34,19 +34,24 @@ static const volatile Tracks g_tracks __attribute__((section(".tracks\n\t#")));
 static Tracks g_tracks = DEFAULT_TRACKS;
 #endif
 
-static const Tracks g_defaultTracks = DEFAULT_TRACKS;
-
 void initialize_tracks()
 {
-    if (versionChanged(&g_tracks.versionInfo)) {
-        flash_default_tracks();
-    }
+        const VersionInfo vi = g_tracks.versionInfo;
+        if (version_check_changed(&vi, "Tracks DB"))
+                flash_default_tracks();
 }
 
 int flash_default_tracks(void)
 {
-    pr_info("flashing default tracks...");
-    return flash_tracks(&g_defaultTracks, sizeof (g_defaultTracks));
+        Tracks* def_tracks = calloc(1, sizeof(Tracks));
+        const VersionInfo* cv = get_current_version_info();
+        memcpy(&def_tracks->versionInfo, cv, sizeof(VersionInfo));
+
+        pr_info("flashing default tracks...");
+        const int status = flash_tracks(def_tracks, sizeof(Tracks));
+
+        free(def_tracks);
+        return status;
 }
 
 int flash_tracks(const Tracks *source, size_t rawSize)


### PR DESCRIPTION
This change does 3 things:

* Improves version check so we can better see what is happening when a version check fails
* Reduces firmware image footprint by removing an object that we don't need frequently.  I instead dynamically allocate it, set appropriate values, then free it.
* Remove the `mass_erase` method from our OpenOCD script.  Because with it we will nuke all our configs.  And that makes me a sad panda.