### PR TITLE
Fix Bitwise Logic Bug, Remove Unused Variable

### DIFF
--- a/platform/mk2/hal/usart_stm32/usart_device_stm32.c
+++ b/platform/mk2/hal/usart_stm32/usart_device_stm32.c
@@ -330,9 +330,10 @@ static void enableRxTxIrq(USART_TypeDef * USARTx, uint8_t usartIrq,
     NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
     NVIC_Init(&NVIC_InitStructure);
 
-    if (irqType | UART_RX_IRQ)
+    if (irqType & UART_RX_IRQ)
         USART_ITConfig(USARTx, USART_IT_RXNE, ENABLE);
-    if (irqType | UART_TX_IRQ)
+
+    if (irqType & UART_TX_IRQ)
         USART_ITConfig(USARTx, USART_IT_TXE, ENABLE);
 }
 

--- a/platform/rct/hal/usart_stm32/usart_device_stm32.c
+++ b/platform/rct/hal/usart_stm32/usart_device_stm32.c
@@ -304,9 +304,10 @@ static void enableRxTxIrq(USART_TypeDef * USARTx, uint8_t usartIrq,
     NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
     NVIC_Init(&NVIC_InitStructure);
 
-    if (irqType | UART_RX_IRQ)
+    if (irqType & UART_RX_IRQ)
         USART_ITConfig(USARTx, USART_IT_RXNE, ENABLE);
-    if (irqType | UART_TX_IRQ)
+
+    if (irqType & UART_TX_IRQ)
         USART_ITConfig(USARTx, USART_IT_TXE, ENABLE);
 }
 

--- a/src/devices/cellular.c
+++ b/src/devices/cellular.c
@@ -54,7 +54,6 @@ static const struct at_config *at_cfg;
 
 static struct cellular_info cell_info;
 static struct telemetry_info telemetry_info;
-static const enum log_level serial_dbg_lvl = TRACE;
 
 static const struct at_config* get_safe_at_config()
 {


### PR DESCRIPTION
Fixes a logic bug in our USART.  Also removes an unused variable that causes GCC 6 to barf.