### PR TITLE
Update and finalize the WiFi configuration setters and getters

### DIFF
--- a/include/logger/loggerApi.h
+++ b/include/logger/loggerApi.h
@@ -51,8 +51,7 @@ CPP_GUARD_BEGIN
         API_METHOD("getTrackCfg", api_getTrackConfig)                   \
         API_METHOD("getTrackDb", api_getTrackDb)                        \
         API_METHOD("getVer", api_getVersion)                            \
-        API_METHOD("get_wifi_ap_cfg", api_get_wifi_ap_cfg)              \
-        API_METHOD("get_wifi_client_cfg", api_get_wifi_client_cfg)      \
+        API_METHOD("getWifiCfg", api_get_wifi_cfg)                      \
         API_METHOD("hb", api_heart_beat)                                \
         API_METHOD("log", api_log)                                      \
         API_METHOD("s", api_sampleData)                                 \
@@ -64,8 +63,7 @@ CPP_GUARD_BEGIN
         API_METHOD("setLogfileLevel", api_setLogfileLevel)              \
         API_METHOD("setObd2Cfg", api_setObd2Config)                     \
         API_METHOD("setTrackCfg", api_setTrackConfig)                   \
-        API_METHOD("set_wifi_ap_cfg", api_set_wifi_ap_cfg)              \
-        API_METHOD("set_wifi_client_cfg", api_set_wifi_client_cfg)      \
+        API_METHOD("setWifiCfg", api_set_wifi_cfg)                      \
         API_METHOD("sysReset", api_systemReset)                         \
 
 
@@ -173,10 +171,8 @@ void api_send_sample_record(struct Serial *serial, struct sample *sample,
 void unescapeTextField(char *data);
 
 /* Wifi methods */
-int api_get_wifi_client_cfg(struct Serial *s, const jsmntok_t *json);
-int api_set_wifi_client_cfg(struct Serial *s, const jsmntok_t *json);
-int api_get_wifi_ap_cfg(struct Serial *serial, const jsmntok_t *json);
-int api_set_wifi_ap_cfg(struct Serial *s, const jsmntok_t *json);
+int api_get_wifi_cfg(struct Serial *s, const jsmntok_t *json);
+int api_set_wifi_cfg(struct Serial *s, const jsmntok_t *json);
 
 CPP_GUARD_END
 

--- a/include/tasks/wifi.h
+++ b/include/tasks/wifi.h
@@ -47,6 +47,7 @@ struct wifi_ap_cfg {
 };
 
 struct wifi_cfg {
+        bool active;
         struct wifi_client_cfg client;
         struct wifi_ap_cfg ap;
 };

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -1743,7 +1743,7 @@ int api_set_wifi_cfg(struct Serial *serial, const jsmntok_t *json)
         struct wifi_ap_cfg *ap_cfg = &cfg->ap;
 
         const jsmntok_t* client_json_root = jsmn_find_node(json, "client");
-        const jsmntok_t* ap_json_root = jsmn_find_node(json, "ap");;
+        const jsmntok_t* ap_json_root = jsmn_find_node(json, "ap");
 
         if (ap_json_root)
                 if (!set_wifi_ap_cfg(ap_json_root, ap_cfg))
@@ -1795,7 +1795,7 @@ int api_get_wifi_cfg(struct Serial *serial, const jsmntok_t *json)
         const struct wifi_ap_cfg *ap_cfg = &cfg->ap;
 
         json_objStart(serial);
-        json_objStartString(serial, "getWifiCfg");
+        json_objStartString(serial, "wifiCfg");
 
         json_bool(serial, "active", cfg->active, true);
         get_wifi_client_cfg(serial, client_cfg, true);

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -1690,56 +1690,31 @@ int api_runScript(struct Serial *serial, const jsmntok_t *json)
 }
 #endif /* LUA_SUPPORT */
 
-int api_set_wifi_client_cfg(struct Serial *s, const jsmntok_t *json)
+static void set_wifi_client_cfg(const jsmntok_t *json,
+                                struct wifi_client_cfg* cfg)
 {
-        LoggerConfig *lc = getWorkingLoggerConfig();
-        struct wifi_client_cfg *cfg = &lc->ConnectivityConfigs.wifi.client;
-
         setBoolValueIfExists(json, "active", &cfg->active);
         setStringValueIfExists(json, "ssid", cfg->ssid,
                                ARRAY_LEN(cfg->ssid));
-        setStringValueIfExists(json, "passwd", cfg->passwd,
+        setStringValueIfExists(json, "password", cfg->passwd,
                                ARRAY_LEN(cfg->passwd));
 
         /* Inform the Wifi device that settings may have changed */
         wifi_update_client_config(cfg);
-
-        return API_SUCCESS;
 }
 
-int api_get_wifi_client_cfg(struct Serial *serial, const jsmntok_t *json)
+static bool set_wifi_ap_cfg(const jsmntok_t *json,
+                            struct wifi_ap_cfg* cfg)
 {
-        LoggerConfig *lc = getWorkingLoggerConfig();
-        struct wifi_client_cfg *cfg = &lc->ConnectivityConfigs.wifi.client;
-
-        json_objStart(serial);
-        json_objStartString(serial, "wifi_client_cfg");
-
-        json_bool(serial, "active", cfg->active, 1);
-        json_string(serial, "ssid", cfg->ssid,1);
-        json_string(serial, "passwd", cfg->passwd,0);
-
-        json_objEnd(serial, 0);
-        json_objEnd(serial, 0);
-
-        return API_SUCCESS_NO_RETURN;
-}
-
-int api_set_wifi_ap_cfg(struct Serial *s, const jsmntok_t *json)
-{
-        LoggerConfig *lc = getWorkingLoggerConfig();
-        struct wifi_ap_cfg *cfg = &lc->ConnectivityConfigs.wifi.ap;
-
         struct wifi_ap_cfg tmp_cfg;
         memcpy(&tmp_cfg, cfg, sizeof(struct wifi_ap_cfg));
 
         setBoolValueIfExists(json, "active", &tmp_cfg.active);
         setStringValueIfExists(json, "ssid", tmp_cfg.ssid,
                                ARRAY_LEN(tmp_cfg.ssid));
-        setStringValueIfExists(json, "passwd", tmp_cfg.password,
+        setStringValueIfExists(json, "password", tmp_cfg.password,
                                ARRAY_LEN(tmp_cfg.password));
         setIntValueIfExists(json, "channel", (int*) &tmp_cfg.channel);
-
 
         char enc_str[12];
         setStringValueIfExists(json, "encryption", enc_str,
@@ -1748,7 +1723,7 @@ int api_set_wifi_ap_cfg(struct Serial *s, const jsmntok_t *json)
 
         if (!wifi_validate_ap_config(&tmp_cfg)) {
                 pr_info("Invalid Wifi AP config given\r\n");
-                return API_ERROR_PARAMETER;
+                return false;
         }
 
         /* Copy the validated config to our real config */
@@ -1757,26 +1732,77 @@ int api_set_wifi_ap_cfg(struct Serial *s, const jsmntok_t *json)
         /* Inform the Wifi device that settings may have changed */
         wifi_update_ap_config(cfg);
 
+        return true;
+}
+
+int api_set_wifi_cfg(struct Serial *serial, const jsmntok_t *json)
+{
+        LoggerConfig *lc = getWorkingLoggerConfig();
+        struct wifi_cfg *cfg = &lc->ConnectivityConfigs.wifi;
+        struct wifi_client_cfg *client_cfg = &cfg->client;
+        struct wifi_ap_cfg *ap_cfg = &cfg->ap;
+
+        const jsmntok_t* client_json_root = jsmn_find_node(json, "client");
+        const jsmntok_t* ap_json_root = jsmn_find_node(json, "ap");;
+
+        if (ap_json_root)
+                if (!set_wifi_ap_cfg(ap_json_root, ap_cfg))
+                        return API_ERROR_PARAMETER;
+
+        if (client_json_root)
+                set_wifi_client_cfg(client_json_root, client_cfg);
+
+        setBoolValueIfExists(json, "active", &cfg->active);
+
         return API_SUCCESS;
 }
 
-int api_get_wifi_ap_cfg(struct Serial *serial, const jsmntok_t *json)
-{
-        LoggerConfig *lc = getWorkingLoggerConfig();
-        const struct wifi_ap_cfg *cfg = &lc->ConnectivityConfigs.wifi.ap;
+static void get_wifi_client_cfg(struct Serial *serial,
+                                const struct wifi_client_cfg* cfg,
+                                const bool more)
 
-        json_objStart(serial);
-        json_objStartString(serial, "wifi_ap_cfg");
+{
+        json_objStartString(serial, "client");
+
+        json_bool(serial, "active", cfg->active, true);
+        json_string(serial, "ssid", cfg->ssid, true);
+        json_string(serial, "password", cfg->passwd, false);
+
+        json_objEnd(serial, more);
+}
+
+static void get_wifi_ap_cfg(struct Serial *serial,
+                            const struct wifi_ap_cfg* cfg,
+                            const bool more)
+{
+        json_objStartString(serial, "ap");
 
         json_bool(serial, "active", cfg->active, 1);
-        json_string(serial, "ssid", cfg->ssid,1);
-        json_string(serial, "passwd", cfg->password,1);
-        json_int(serial, "channel", cfg->channel,1);
+        json_string(serial, "ssid", cfg->ssid, 1);
+        json_string(serial, "password", cfg->password, 1);
+        json_int(serial, "channel", cfg->channel, 1);
         json_string(serial, "encryption",
                     wifi_api_get_encryption_str_val(cfg->encryption), 0);
 
-        json_objEnd(serial, 0);
-        json_objEnd(serial, 0);
+        json_objEnd(serial, more);
+}
+
+int api_get_wifi_cfg(struct Serial *serial, const jsmntok_t *json)
+{
+        const LoggerConfig *lc = getWorkingLoggerConfig();
+        const struct wifi_cfg *cfg = &lc->ConnectivityConfigs.wifi;
+        const struct wifi_client_cfg *client_cfg = &cfg->client;
+        const struct wifi_ap_cfg *ap_cfg = &cfg->ap;
+
+        json_objStart(serial);
+        json_objStartString(serial, "getWifiCfg");
+
+        json_bool(serial, "active", cfg->active, true);
+        get_wifi_client_cfg(serial, client_cfg, true);
+        get_wifi_ap_cfg(serial, ap_cfg, false);
+
+        json_objEnd(serial, false);
+        json_objEnd(serial, false);
 
         return API_SUCCESS_NO_RETURN;
 }

--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -303,6 +303,9 @@ void wifi_reset_config(struct wifi_cfg *cfg)
         /* For now simply zero this out */
         memset(cfg, 0, sizeof(struct wifi_cfg));
 
+        /* Enable WiFi by Default */
+        cfg->active = true;
+
         /*
          * Set some sane values for the AP configuration.  We turn on our
          * AP by default because it gives us a way to communicate with the

--- a/test/json_api_files/get_wifi_ap_cfg.json
+++ b/test/json_api_files/get_wifi_ap_cfg.json
@@ -1,1 +1,0 @@
-{"get_wifi_ap_cfg":null}

--- a/test/json_api_files/get_wifi_cfg.json
+++ b/test/json_api_files/get_wifi_cfg.json
@@ -1,0 +1,1 @@
+{"getWifiCfg":null}

--- a/test/json_api_files/get_wifi_client_cfg.json
+++ b/test/json_api_files/get_wifi_client_cfg.json
@@ -1,1 +1,0 @@
-{"get_wifi_client_cfg":null}

--- a/test/json_api_files/set_wifi_ap_cfg.json
+++ b/test/json_api_files/set_wifi_ap_cfg.json
@@ -1,1 +1,0 @@
-{"set_wifi_ap_cfg":{"active":true,"ssid":"RaceIt","passwd":"dontcrashit","channel":1,"encryption":"none"}}

--- a/test/json_api_files/set_wifi_ap_cfg_bad_channel.json
+++ b/test/json_api_files/set_wifi_ap_cfg_bad_channel.json
@@ -1,1 +1,0 @@
-{"set_wifi_ap_cfg":{"active":true,"ssid":"RaceIt","passwd":"dontcrashit","channel":0,"encryption":"none"}}

--- a/test/json_api_files/set_wifi_ap_cfg_bad_encryption.json
+++ b/test/json_api_files/set_wifi_ap_cfg_bad_encryption.json
@@ -1,1 +1,0 @@
-{"set_wifi_ap_cfg":{"active":true,"ssid":"RaceIt","passwd":"dontcrashit","channel":1,"encryption":"wap"}}

--- a/test/json_api_files/set_wifi_cfg.json
+++ b/test/json_api_files/set_wifi_cfg.json
@@ -1,0 +1,1 @@
+{"setWifiCfg":{"active": true,"client":{"active": true,"ssid":"foobar","password":"bazbiz"}, "ap":{"active":true,"ssid":"RaceIt","password":"dontcrashit","channel":1,"encryption":"wpa2"}}}

--- a/test/json_api_files/set_wifi_cfg_ap_bad_channel.json
+++ b/test/json_api_files/set_wifi_cfg_ap_bad_channel.json
@@ -1,0 +1,1 @@
+{"setWifiCfg":{"ap":{"active":true,"ssid":"RaceIt","passwd":"dontcrashit","channel":0,"encryption":"none"}}}

--- a/test/json_api_files/set_wifi_cfg_ap_bad_encryption.json
+++ b/test/json_api_files/set_wifi_cfg_ap_bad_encryption.json
@@ -1,0 +1,1 @@
+{"setWifiCfg":{"ap":{"active":true,"ssid":"RaceIt","passwd":"dontcrashit","channel":1,"encryption":"wap"}}}

--- a/test/json_api_files/set_wifi_client_cfg.json
+++ b/test/json_api_files/set_wifi_client_cfg.json
@@ -1,1 +1,0 @@
-{"set_wifi_client_cfg":{"active": true,"ssid":"foobar","passwd":"bazbiz"}}

--- a/test/loggerApi_test.cpp
+++ b/test/loggerApi_test.cpp
@@ -1398,7 +1398,7 @@ void LoggerApiTest::testGetWifiCfgDefault() {
         Object json;
         stringToJson(response, json);
 
-        Object gwc = json["getWifiCfg"];
+        Object gwc = json["wifiCfg"];
         CPPUNIT_ASSERT_EQUAL(true, (bool)(Boolean)gwc["active"]);
 
         Object wcc = gwc["client"];
@@ -1422,7 +1422,7 @@ void LoggerApiTest::testSetGetWifiCfg() {
         Object json;
         stringToJson(response, json);
 
-        Object gwc = json["getWifiCfg"];
+        Object gwc = json["wifiCfg"];
         CPPUNIT_ASSERT_EQUAL(true, (bool)(Boolean)gwc["active"]);
 
         Object wcc = gwc["client"];

--- a/test/loggerApi_test.h
+++ b/test/loggerApi_test.h
@@ -79,12 +79,11 @@ class LoggerApiTest : public CppUnit::TestFixture
     CPPUNIT_TEST( testGetVersion);
     CPPUNIT_TEST( testGetStatus);
     CPPUNIT_TEST( testGetCapabilities);
-    CPPUNIT_TEST( testSetWifiClientCfg );
-    CPPUNIT_TEST( testGetWifiClientCfg );
-    CPPUNIT_TEST( testSetWifiApCfg );
-    CPPUNIT_TEST( testSetWifiApCfgBadChannel );
-    CPPUNIT_TEST( testSetWifiApCfgBadEncryption );
-    CPPUNIT_TEST( testSetAndGetWifiApCfg );
+    CPPUNIT_TEST( testSetWifiCfg );
+    CPPUNIT_TEST( testSetWifiCfgApBadChannel );
+    CPPUNIT_TEST( testSetWifiCfgApBadEncryption );
+    CPPUNIT_TEST( testGetWifiCfgDefault );
+    CPPUNIT_TEST( testSetGetWifiCfg );
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -140,12 +139,11 @@ public:
     void testGetVersion();
     void testGetStatus();
     void testGetCapabilities();
-    void testSetWifiClientCfg();
-    void testGetWifiClientCfg();
-    void testSetWifiApCfg();
-    void testSetWifiApCfgBadChannel();
-    void testSetWifiApCfgBadEncryption();
-    void testSetAndGetWifiApCfg();
+    void testSetWifiCfg();
+    void testSetWifiCfgApBadChannel();
+    void testSetWifiCfgApBadEncryption();
+    void testGetWifiCfgDefault();
+    void testSetGetWifiCfg();
 
 private:
     void testSetScriptFile(string filename);


### PR DESCRIPTION
This code updates the JSON setter and getter methods used to manipulate
the configuration on RCP.  It changes it to the final structure as
outlined in issue #638, adds a new "active" flag that controls the
entire WiFi subsystem, and further cleans up how all of this is done.

Issue: #638