### PR TITLE
Audit and sanitize all IRQ Premptive Priority Values

### DIFF
--- a/platform/mk2/hal/i2c_stm32/i2c_device_stm32.c
+++ b/platform/mk2/hal/i2c_stm32/i2c_device_stm32.c
@@ -333,7 +333,7 @@ static void i2c_nvic_setup(struct i2c_priv *p)
 
     /* Enable the I2Cx Interrupt */
     NVIC_InitStructure.NVIC_IRQChannel = p->ev_irqn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
+    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 5;
     NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
     NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
     NVIC_Init(&NVIC_InitStructure);

--- a/platform/mk2/hal/timer_stm32/timer_device_stm32.c
+++ b/platform/mk2/hal/timer_stm32/timer_device_stm32.c
@@ -39,7 +39,7 @@
 #define PRESCALER_SLOW		1680
 #define TIMER_CLK_FREQ_FAST_HZ	168000000 /* Logical Timer 1 */
 #define TIMER_CLK_FREQ_SLOW_HZ	84000000  /* Logical Timer 0 & 2 */
-#define TIMER_IRQ_PRIORITY 	4
+#define TIMER_IRQ_PRIORITY 	5
 #define TIMER_IRQ_SUB_PRIORITY 	0
 #define TIMER_PERIOD		0xFFFF
 

--- a/platform/mk2/hal/usb_stm32/usb_bsp.c
+++ b/platform/mk2/hal/usb_stm32/usb_bsp.c
@@ -99,7 +99,7 @@ void USB_OTG_BSP_Init(USB_OTG_CORE_HANDLE *pdev)
     RCC_OTGFSCLKConfig(RCC_OTGFSCLKSource_PLLVCO_Div3);
     RCC_AHBPeriphClockCmd(RCC_AHBPeriph_OTG_FS, ENABLE) ;
 
-#else // USE_STM322xG_EVAL  
+#else // USE_STM322xG_EVAL
     GPIO_InitTypeDef GPIO_InitStructure;
 #ifdef USE_USB_OTG_FS
     RCC_AHB1PeriphClockCmd( RCC_AHB1Periph_GPIOA , ENABLE);
@@ -119,7 +119,7 @@ void USB_OTG_BSP_Init(USB_OTG_CORE_HANDLE *pdev)
 
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE);
     RCC_AHB2PeriphClockCmd(RCC_AHB2Periph_OTG_FS, ENABLE) ;
-#else // USE_USB_OTG_HS 
+#else // USE_USB_OTG_HS
 
 #ifdef USE_ULPI_PHY // ULPI
     RCC_AHB1PeriphClockCmd( RCC_AHB1Periph_GPIOA | RCC_AHB1Periph_GPIOB |
@@ -237,21 +237,21 @@ void USB_OTG_BSP_EnableInterrupt(USB_OTG_CORE_HANDLE *pdev)
     NVIC_InitStructure.NVIC_IRQChannel = OTG_FS_IRQn;
 #endif
     NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 5;
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 3;
+    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
     NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
     NVIC_Init(&NVIC_InitStructure);
 #ifdef USB_OTG_HS_DEDICATED_EP1_ENABLED
     //NVIC_PriorityGroupConfig(NVIC_PriorityGroup_4);
     NVIC_InitStructure.NVIC_IRQChannel = OTG_HS_EP1_OUT_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 2;
+    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 5;
+    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
     NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
     NVIC_Init(&NVIC_InitStructure);
 
     //NVIC_PriorityGroupConfig(NVIC_PriorityGroup_4);
     NVIC_InitStructure.NVIC_IRQChannel = OTG_HS_EP1_IN_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 1;
+    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 5;
+    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
     NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
     NVIC_Init(&NVIC_InitStructure);
 #endif


### PR DESCRIPTION
Because of how FreeRTOS works there is a certain maximum IRQ value that
non-FreeRTOS interrutps may use.  Using anything higher can compromise
the stability of the system.

This change evaluates all of the IRQ settings across MK2 and RCT and
adjusts the IRQ settings appropriately so that all non-FreeRTOS priority
are lower priority (lower value) than all FreeRTOS IRQ. In other words,
this change ensures that IRQ values >= 5 are set on all non-FreeRTOS
subsystems that generate IRQs.

There is one exception here: The SDCard subsystem.  In tryint to adjust
those IRQ levels the system was no longer responsive.  That work is
tracked by issue #647

Issue: #541