### PR TITLE
Up BT baud to 230400, remove unnecessary baud from config

### DIFF
--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -396,12 +396,10 @@ typedef struct _TrackConfig {
 
 #define BT_DEVICE_NAME_LENGTH 21
 #define BT_PASSCODE_LENGTH 5
-#define DEFAULT_BT_BAUD 115200
 #define DEFAULT_BT_ENABLED 1
 
 typedef struct _BluetoothConfig {
         unsigned char btEnabled;
-        unsigned int baudRate;
         char new_name [BT_DEVICE_NAME_LENGTH];
         char new_pin [BT_PASSCODE_LENGTH];
 } BluetoothConfig;

--- a/src/devices/bluetooth.c
+++ b/src/devices/bluetooth.c
@@ -51,6 +51,7 @@
 #define BT_MAX_NAME_LEN	(BT_DEVICE_NAME_LENGTH - 1)
 #define BT_MAX_PIN_LEN	(BT_PASSCODE_LENGTH - 1)
 #define BT_PING_TRIES	3
+#define TARGET_BAUD	230400
 
 static bluetooth_status_t g_bluetooth_status = BT_STATUS_NOT_INIT;
 
@@ -153,11 +154,11 @@ static bool bt_set_pin(DeviceConfig *config, const char *new_pin)
                                          BT_COMMAND_WAIT);
 }
 
-static int bt_find_working_baud(DeviceConfig *config, BluetoothConfig *btc)
+static int bt_find_working_baud(DeviceConfig *config,
+                                BluetoothConfig *btc,
+                                const int targetBaud)
 {
         pr_info("BT: Detecting baud rate...\r\n");
-
-        const int targetBaud = btc->baudRate;
         const int rates[] = BT_BAUD_RATES;
         int rate = 0;
 
@@ -213,7 +214,7 @@ int bt_init_connection(DeviceConfig *config)
 {
         BluetoothConfig *btConfig =
                 &(getWorkingLoggerConfig()->ConnectivityConfigs.bluetoothConfig);
-        unsigned int targetBaud = btConfig->baudRate;
+        const int targetBaud = TARGET_BAUD;
         const char *new_name = btConfig->new_name;
         const char *new_pin = btConfig->new_pin;
 
@@ -225,7 +226,7 @@ int bt_init_connection(DeviceConfig *config)
          * factory level (9600).  This ensures things go slow enough for the
          * HC-06 processor + code to handle it.
          */
-        int baud = bt_find_working_baud(config, btConfig);
+        int baud = bt_find_working_baud(config, btConfig, targetBaud);
         switch (baud) {
         case 0:
                 pr_info("BT: Failed to communicate with device.\r\n");

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -240,10 +240,8 @@ static void resetTrackConfig(TrackConfig *cfg)
 
 static void resetBluetoothConfig(BluetoothConfig *cfg)
 {
-        *cfg = (BluetoothConfig) {
-                .btEnabled = DEFAULT_BT_ENABLED,
-                .baudRate = DEFAULT_BT_BAUD,
-        };
+        memset(cfg, 0, sizeof(BluetoothConfig));
+        cfg->btEnabled = DEFAULT_BT_ENABLED;
 }
 
 static void resetCellularConfig(CellularConfig *cfg)


### PR DESCRIPTION
This change ups the default BT baud rate to 230400, effectively
doubling the rate at which we can send data over BT.  Combined with
the DMA improvements the result is a snappier BT experience.

This change also removes the baudRate value from the bluetooth
config since that was not being used in any significant way.

Issue #530