### PR TITLE
Synchronous WiFi Connect Support

### DIFF
--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -155,10 +155,11 @@ typedef void esp8266_set_ap_info_cb_t(const bool status);
 bool esp8266_set_ap_info(const struct esp8266_ap_info* info,
                          esp8266_set_ap_info_cb_t *cb);
 
+typedef void esp8266_connect_cb_t(const bool status);
 
 bool esp8266_connect(const int chan_id, const enum protocol proto,
                      const char *ip_addr, const int dest_port,
-                     void (*cb) (bool, const int));
+                     esp8266_connect_cb_t* cb);
 
 bool esp8266_send_data(const int chan_id, struct Serial *data,
                        const size_t len, void (*cb)(int));

--- a/src/modem/at.c
+++ b/src/modem/at.c
@@ -39,6 +39,7 @@ static const struct at_rsp_status_msgs {
 } at_status_msgs[] = {
         AT_STATUS_MSG("OK", AT_RSP_STATUS_OK),
         AT_STATUS_MSG("SEND OK", AT_RSP_STATUS_SEND_OK),
+        AT_STATUS_MSG("ALREADY CONNECTED", AT_RSP_STATUS_OK),
         AT_STATUS_MSG("SEND FAIL", AT_RSP_STATUS_SEND_FAIL),
         AT_STATUS_MSG("FAIL", AT_RSP_STATUS_FAILED),
         AT_STATUS_MSG("ERROR", AT_RSP_STATUS_ERROR),


### PR DESCRIPTION
Makes the connect call for the WiFi driver synchronous.  This is because I don't want us to return a Serial device who may or may not have an open connection since Serial has no knowledge of any underlying connection state.  Having the connect method be synchronous makes this easy.  If we want to write an async model later because one is needed then we can with relative ease.