### PR TITLE
Implement socket disconnect, make conn and disconn synchronous

### DIFF
--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -155,10 +155,11 @@ typedef void esp8266_set_ap_info_cb_t(const bool status);
 bool esp8266_set_ap_info(const struct esp8266_ap_info* info,
                          esp8266_set_ap_info_cb_t *cb);
 
+typedef void esp8266_connect_cb_t(const bool status);
 
 bool esp8266_connect(const int chan_id, const enum protocol proto,
                      const char *ip_addr, const int dest_port,
-                     void (*cb) (bool, const int));
+                     esp8266_connect_cb_t* cb);
 
 bool esp8266_send_data(const int chan_id, struct Serial *data,
                        const size_t len, void (*cb)(int));

--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -173,6 +173,10 @@ bool esp8266_connect_udp(const int chan_id, const char* addr,
                          const enum esp8266_udp_mode udp_mode,
                          esp8266_connect_cb_t* cb);
 
+typedef void esp8266_close_cb_t(const bool status);
+
+bool esp8266_close(const int chan_id, esp8266_close_cb_t* cb);
+
 bool esp8266_send_data(const int chan_id, struct Serial *data,
                        const size_t len, void (*cb)(int));
 

--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -155,7 +155,7 @@ typedef void esp8266_set_ap_info_cb_t(const bool status);
 bool esp8266_set_ap_info(const struct esp8266_ap_info* info,
                          esp8266_set_ap_info_cb_t *cb);
 
-typedef void esp8266_connect_cb_t(const bool status);
+typedef void esp8266_connect_cb_t(const bool status, const bool in_use);
 
 bool esp8266_connect_tcp(const int chan_id, const char* addr,
                          const int port, const int keepalive,

--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -157,9 +157,21 @@ bool esp8266_set_ap_info(const struct esp8266_ap_info* info,
 
 typedef void esp8266_connect_cb_t(const bool status);
 
-bool esp8266_connect(const int chan_id, const enum protocol proto,
-                     const char *ip_addr, const int dest_port,
-                     esp8266_connect_cb_t* cb);
+bool esp8266_connect_tcp(const int chan_id, const char* addr,
+                         const int port, const int keepalive,
+                         esp8266_connect_cb_t* cb);
+
+enum esp8266_udp_mode {
+        ESP8266_UDP_MODE_NONE                 = -1,
+        ESP8266_UDP_MODE_PEER_CHANGE_NEVER    = 0,
+        ESP8266_UDP_MODE_PEER_CHANGE_ONCE     = 1,
+        ESP8266_UDP_MODE_PEER_CHANGE_WHENEVER = 2,
+};
+
+bool esp8266_connect_udp(const int chan_id, const char* addr,
+                         const int port, const int src_port,
+                         const enum esp8266_udp_mode udp_mode,
+                         esp8266_connect_cb_t* cb);
 
 bool esp8266_send_data(const int chan_id, struct Serial *data,
                        const size_t len, void (*cb)(int));

--- a/include/drivers/esp8266_drv.h
+++ b/include/drivers/esp8266_drv.h
@@ -43,6 +43,8 @@ struct Serial* esp8266_drv_connect(const enum protocol proto,
                                    const char* dst_ip,
                                    const unsigned int dst_port);
 
+bool esp8266_drv_close(struct Serial* serial);
+
 const struct esp8266_ipv4_info* get_client_ipv4_info();
 
 const struct esp8266_ipv4_info* get_ap_ipv4_info();

--- a/include/net/ipv4.h
+++ b/include/net/ipv4.h
@@ -1,0 +1,33 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _IPV4_H_
+#define _IPV4_H_
+
+#include "cpp_guard.h"
+
+CPP_GUARD_BEGIN
+
+#define IPV4_BROADCAST_ADDRESS_STR	"255.255.255.255"
+
+CPP_GUARD_END
+
+#endif /* _IPV4_H_ */

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -745,12 +745,13 @@ static bool connect_cb(struct at_rsp *rsp, void *up)
         static const char *cmd_name = "connect_cb";
         esp8266_connect_cb_t *cb = up;
         const bool status = at_ok(rsp);
+        const bool in_use = STR_EQ(rsp->msgs[0], "ALREADY CONNECTED");
 
         if (!status)
                 cmd_failure(cmd_name, NULL);
 
         if (cb)
-                cb(status);
+                cb(status, in_use);
 
         return false;
 }

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -819,6 +819,40 @@ bool esp8266_connect_udp(const int chan_id, const char* addr,
                                   connect_cb, cb);
 }
 
+/**
+ * Method that is invoked upon the completion of the close method.
+ */
+static bool close_cb(struct at_rsp *rsp, void *up)
+{
+        static const char *cmd_name = "close_cb";
+        esp8266_close_cb_t* cb = up;
+        bool status = at_ok(rsp);
+
+        if (!status)
+                cmd_failure(cmd_name, NULL);
+
+        if (cb)
+                cb(status);
+
+        return false;
+}
+
+/**
+ * Closes a connection
+ * @param chan_id The channel ID to use.  0 - 4
+ * @return true if the request was queued, false otherwise.
+ */
+bool esp8266_close(const int chan_id, esp8266_close_cb_t* cb)
+{
+        if (!check_initialized("close"))
+                return false;
+
+        char cmd[16];
+        snprintf(cmd, ARRAY_LEN(cmd), "AT+CIPCLOSE=%d", chan_id);
+        return NULL != at_put_cmd(state.ati, cmd, _TIMEOUT_LONG_MS,
+                                  close_cb, cb);
+}
+
 struct tx_info {
         struct Serial *serial;
         size_t len;

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -1142,10 +1142,16 @@ bool esp8266_drv_init(struct Serial *s, const int priority,
 /**
  * Callback method invoked when a callback completes.
  */
-static void connect_cb(const bool status)
+static void connect_cb(const bool status, const bool already_connected)
 {
         struct comm *comm = &esp8266_state.comm;
         comm->connect_status = status;
+
+        if (!status && already_connected) {
+                /* Attempt to close the connection to rectify state */
+                /* TODO: Do call here */
+                pr_info(LOG_PFX "Closing unexpectedly open connection\r\n");
+        }
 
         cmd_set_check(CHECK_DATA);
 

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -91,12 +91,17 @@ struct channel {
         bool created_externally;
 };
 
+struct channel_sync_op {
+        xSemaphoreHandle op_semaphore;
+        xSemaphoreHandle cb_semaphore;
+        size_t chan_id;
+};
+
 struct comm {
         new_conn_func_t *new_conn_cb;
         struct channel channels[MAX_CHANNELS];
-        xSemaphoreHandle connect_semaphore;
-        xSemaphoreHandle connect_cb_semaphore;
-        bool connect_status;
+        struct channel_sync_op connect_op;
+        struct channel_sync_op close_op;
 };
 
 /**
@@ -259,6 +264,18 @@ static int get_next_free_channel_num()
 
         return -1;
 }
+
+static int find_channel_with_serial(struct Serial *serial)
+{
+        for (size_t i = 0; is_valid_socket_channel_id(i); ++i) {
+                struct channel *ch = esp8266_state.comm.channels + i;
+                if (serial == ch->serial)
+                        return i;
+        }
+
+        return -1;
+}
+
 
 /**
  * Callback that gets invoked by the device code whenever new data
@@ -1086,6 +1103,23 @@ bool esp8266_drv_update_ap_cfg(const struct wifi_ap_cfg *wac)
         return true;
 }
 
+static bool init_channel_sync_op(struct channel_sync_op* op)
+{
+        if (op->op_semaphore || op->cb_semaphore) {
+                pr_error(LOG_PFX "Sync op already initialized\r\n");
+                return false;
+        }
+
+        op->op_semaphore = xSemaphoreCreateBinary();
+        op->cb_semaphore = xSemaphoreCreateBinary();
+
+        if (!op->op_semaphore || !op->cb_semaphore)
+                return false;
+
+        xSemaphoreGive(op->op_semaphore);
+        return true;
+}
+
 bool esp8266_drv_init(struct Serial *s, const int priority,
                       new_conn_func_t new_conn_cb)
 {
@@ -1109,10 +1143,13 @@ bool esp8266_drv_init(struct Serial *s, const int priority,
                       SERIAL_STOP_BITS, SERIAL_BAUD);
 
         /* Create and setup semaphores for connections */
-        esp8266_state.comm.connect_semaphore = xSemaphoreCreateBinary();
-        xSemaphoreGive(esp8266_state.comm.connect_semaphore);
-        esp8266_state.comm.connect_cb_semaphore = xSemaphoreCreateBinary();
-
+        const bool init_sync_ops =
+                init_channel_sync_op(&esp8266_state.comm.connect_op) &&
+                init_channel_sync_op(&esp8266_state.comm.close_op);
+        if (!init_sync_ops) {
+                pr_error(LOG_PFX "Failed to initialize sync op structs\r\n");
+                return false;
+        }
 
         /* Initialize our WiFi configs here */
         LoggerConfig *lc = getWorkingLoggerConfig();
@@ -1144,36 +1181,45 @@ bool esp8266_drv_init(struct Serial *s, const int priority,
  */
 static void connect_cb(const bool status, const bool already_connected)
 {
-        struct comm *comm = &esp8266_state.comm;
-        comm->connect_status = status;
+        struct channel_sync_op *cso = &esp8266_state.comm.connect_op;
+        struct channel *ch = esp8266_state.comm.channels + cso->chan_id;
+
+        ch->connected = status;
 
         if (!status && already_connected) {
                 /* Attempt to close the connection to rectify state */
-                /* TODO: Do call here */
                 pr_info(LOG_PFX "Closing unexpectedly open connection\r\n");
+                esp8266_close(cso->chan_id, NULL);
         }
 
         cmd_set_check(CHECK_DATA);
 
-        xSemaphoreGive(comm->connect_cb_semaphore);
+        xSemaphoreGive(cso->cb_semaphore);
 }
 
+/**
+ * Synchronous command used to open a new connection to a given destinataion
+ * @param proto The protocol to use.
+ * @param addr The destination address (either IP or DNS name).
+ * @param port The destination port to connect to.
+ * @return A valid Serial object if a connection was made, NULL otherwise.
+ */
 struct Serial* esp8266_drv_connect(const enum protocol proto,
-                                   const char* dst_ip,
-                                   const unsigned int dst_port)
+                                   const char* addr,
+                                   const unsigned int port)
 {
         /* This is synchronous code for now */
-        struct comm *comm = &esp8266_state.comm;
-        xSemaphoreTake(comm->connect_semaphore, portMAX_DELAY);
+        struct channel_sync_op *cso = &esp8266_state.comm.connect_op;
+        xSemaphoreTake(cso->op_semaphore, portMAX_DELAY);
 
         struct Serial* serial = NULL;
-        const int chan_id = get_next_free_channel_num();
-        if (chan_id < 0) {
+        cso->chan_id = get_next_free_channel_num();
+        if (cso->chan_id < 0) {
                 pr_warning(LOG_PFX "Failed to acquire a free channel\r\n");
                 goto done;
         }
 
-        struct channel *ch = get_channel_for_use(chan_id);
+        struct channel *ch = get_channel_for_use(cso->chan_id);
         if (NULL == ch) {
                 pr_warning(LOG_PFX "Can't allocate resources for channel\r\n");
                 goto done;
@@ -1182,20 +1228,20 @@ struct Serial* esp8266_drv_connect(const enum protocol proto,
         bool connect_result = false;
         switch(proto) {
         case PROTOCOL_TCP:
-                connect_result = esp8266_connect_tcp(chan_id, dst_ip, dst_port,
-                                                     -1, connect_cb);
+                connect_result = esp8266_connect_tcp(cso->chan_id, addr,
+                                                     port, -1, connect_cb);
                 break;
         case PROTOCOL_UDP:
                 ;
                 int src_port = 0;
                 enum esp8266_udp_mode udp_mode = ESP8266_UDP_MODE_NONE;
-                if (0 == strcmp(dst_ip, IPV4_BROADCAST_ADDRESS_STR)) {
-                        src_port = dst_port;
+                if (0 == strcmp(addr, IPV4_BROADCAST_ADDRESS_STR)) {
+                        src_port = port;
                         udp_mode = ESP8266_UDP_MODE_PEER_CHANGE_WHENEVER;
                 }
-                connect_result = esp8266_connect_udp(chan_id, dst_ip, dst_port,
-                                                     src_port, udp_mode,
-                                                     connect_cb);
+                connect_result = esp8266_connect_udp(cso->chan_id, addr,
+                                                     port, src_port,
+                                                     udp_mode, connect_cb);
                 break;
         }
         if (!connect_result) {
@@ -1204,26 +1250,89 @@ struct Serial* esp8266_drv_connect(const enum protocol proto,
         }
 
         /* Now wait for our callback to come */
-        if (!xSemaphoreTake(comm->connect_cb_semaphore, portMAX_DELAY)) {
+        if (!xSemaphoreTake(cso->cb_semaphore, portMAX_DELAY)) {
                 pr_warning(LOG_PFX "Timed out waiting for connect "
                            "response\r\n");
                 goto done;
         }
 
-        ch->connected = comm->connect_status;
         if (!ch->connected) {
-                pr_info_str_msg(LOG_PFX "Failed to connect: ", dst_ip);
-
+                pr_info_str_msg(LOG_PFX "Failed to connect: ", addr);
                 goto done;
         }
 
         ch->in_use = true;
         serial = ch->serial;
-        pr_info_int_msg(LOG_PFX "Connected on comm channel ", chan_id);
+        pr_info_int_msg(LOG_PFX "Connected on comm channel ", cso->chan_id);
 
 done:
-        xSemaphoreGive(comm->connect_semaphore);
+        xSemaphoreGive(cso->op_semaphore);
         return serial;
+}
+
+/**
+ * Callback invoked when the close command completes.
+ */
+static void close_cb(const bool status)
+{
+        struct channel_sync_op *cso = &esp8266_state.comm.close_op;
+        struct channel *ch = esp8266_state.comm.channels + cso->chan_id;
+
+        if (status)
+                ch->connected = false;
+
+        cmd_set_check(CHECK_DATA);
+
+        xSemaphoreGive(cso->cb_semaphore);
+}
+
+/**
+ * Closes an open connection given the Serial object returned by
+ * esp8266_drv_connect
+ * @param serial Serial object returned by esp8266_drv_connect
+ * @return True if the operation was successful, false otherwise.
+ */
+bool esp8266_drv_close(struct Serial* serial)
+{
+        /* This is synchronous code for now */
+        struct channel_sync_op *cso = &esp8266_state.comm.close_op;
+        xSemaphoreTake(cso->op_semaphore, portMAX_DELAY);
+        bool status = false;
+
+        cso->chan_id = find_channel_with_serial(serial);
+        if (0 > cso->chan_id) {
+                pr_warning(LOG_PFX "Unable to find channel with associated "
+                           "Serial device.\r\n");
+                goto done;
+        }
+
+        struct channel *ch = esp8266_state.comm.channels + cso->chan_id;
+        if (!ch->connected)
+                pr_warning(LOG_PFX "Channel supposedly not connected.\r\n");
+
+        if (!esp8266_close(cso->chan_id, close_cb)) {
+                pr_warning(LOG_PFX "Failed to issue close command\r\n");
+                goto done;
+        }
+
+        /* Now wait for our callback to come */
+        if (!xSemaphoreTake(cso->cb_semaphore, portMAX_DELAY)) {
+                pr_warning(LOG_PFX "Timed out waiting for close "
+                           "response\r\n");
+                goto done;
+        }
+
+        if (ch->connected) {
+                pr_info_int_msg(LOG_PFX "Failed to close channel ", cso->chan_id);
+                goto done;
+        }
+
+        ch->in_use = false;
+        ch->created_externally = false;
+
+done:
+        xSemaphoreGive(cso->op_semaphore);
+        return status;
 }
 
 const struct esp8266_ipv4_info* get_client_ipv4_info()

--- a/src/modem/at.c
+++ b/src/modem/at.c
@@ -39,6 +39,7 @@ static const struct at_rsp_status_msgs {
 } at_status_msgs[] = {
         AT_STATUS_MSG("OK", AT_RSP_STATUS_OK),
         AT_STATUS_MSG("SEND OK", AT_RSP_STATUS_SEND_OK),
+        AT_STATUS_MSG("ALREADY CONNECTED", AT_RSP_STATUS_OK),
         AT_STATUS_MSG("SEND FAIL", AT_RSP_STATUS_SEND_FAIL),
         AT_STATUS_MSG("FAIL", AT_RSP_STATUS_FAILED),
         AT_STATUS_MSG("ERROR", AT_RSP_STATUS_ERROR),

--- a/src/modem/at.c
+++ b/src/modem/at.c
@@ -39,7 +39,6 @@ static const struct at_rsp_status_msgs {
 } at_status_msgs[] = {
         AT_STATUS_MSG("OK", AT_RSP_STATUS_OK),
         AT_STATUS_MSG("SEND OK", AT_RSP_STATUS_SEND_OK),
-        AT_STATUS_MSG("ALREADY CONNECTED", AT_RSP_STATUS_OK),
         AT_STATUS_MSG("SEND FAIL", AT_RSP_STATUS_SEND_FAIL),
         AT_STATUS_MSG("FAIL", AT_RSP_STATUS_FAILED),
         AT_STATUS_MSG("ERROR", AT_RSP_STATUS_ERROR),

--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -219,6 +219,9 @@ static void do_beacon()
                 NULL,
         };
         send_beacon(serial, ips);
+
+        /* Now flush all incomming data.  We don't care about it. */
+        serial_purge_rx_queue(serial);
 }
 
 static tiny_millis_t get_task_sleep_time()


### PR DESCRIPTION
This change completes the majority of the wifi socket support by making the connect and disconnect calls synchronous.  It achieves this by using a couple of synchronization primitives and adjusting the callbacks accordingly.  This is inline with POSIX calls, so their behavior is roughly the same.

This change also adds the ability to correct for any issues where we may not be synchronized with the device.  This happens after a soft reset of the device.