### PR TITLE
Rude AT Command Support

### DIFF
--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -177,8 +177,10 @@ typedef void esp8266_close_cb_t(const bool status);
 
 bool esp8266_close(const int chan_id, esp8266_close_cb_t* cb);
 
+typedef void esp8266_send_data_cb(const bool status, const size_t len);
+
 bool esp8266_send_data(const int chan_id, struct Serial *data,
-                       const size_t len, void (*cb)(int));
+                       const size_t len, esp8266_send_data_cb* cb);
 
 bool esp8266_send_serial(const int chan_id, struct Serial *serial,
                          const size_t len, void (*cb)(bool));

--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -177,7 +177,8 @@ typedef void esp8266_close_cb_t(const bool status);
 
 bool esp8266_close(const int chan_id, esp8266_close_cb_t* cb);
 
-typedef void esp8266_send_data_cb(const bool status, const size_t len);
+typedef void esp8266_send_data_cb(const bool status, const size_t len,
+                                  const bool valid_link);
 
 bool esp8266_send_data(const int chan_id, struct Serial *data,
                        const size_t len, esp8266_send_data_cb* cb);

--- a/include/modem/at.h
+++ b/include/modem/at.h
@@ -101,9 +101,15 @@ struct at_timing {
         tiny_millis_t quiet_start_ms;
 };
 
+enum at_dev_cfg_flag {
+        /* Used for AT devices that will send URCS mid command response */
+        AT_DEV_CFG_FLAG_RUDE = 1 << 0,
+};
+
 struct at_dev_cfg {
         char delim[AT_DEV_CVG_DELIM_MAX_LEN];
         tiny_millis_t quiet_period_ms;
+        enum at_dev_cfg_flag flags;
 };
 
 enum at_urc_flags {

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -876,6 +876,7 @@ static bool send_data_cb(struct at_rsp *rsp, void *up)
 {
         struct tx_info *ti = up;
         bool status = false;
+        bool valid_link = true;
 
         switch(rsp->status) {
         case AT_RSP_STATUS_OK:
@@ -908,6 +909,7 @@ static bool send_data_cb(struct at_rsp *rsp, void *up)
                 goto fini;
         default:
                 /* Then bad things happened */
+                valid_link = !STR_EQ(rsp->msgs[0], "link is not valid");
                 cmd_failure("send_data_cb", "Bad response value");
                 status = false;
                 goto fini;
@@ -915,7 +917,7 @@ static bool send_data_cb(struct at_rsp *rsp, void *up)
 
 fini:
         if (ti->cb)
-                ti->cb(status, ti->sent);
+                ti->cb(status, ti->sent, valid_link);
 
         portFree(ti);
         return false;

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -342,19 +342,19 @@ static void drop_data(struct channel *ch)
 /**
  * Callback that is invoked when the send_data method completes.
  */
-static void _send_data_cb(int bytes_sent)
+static void _send_data_cb(const bool status, const size_t sent)
 {
         cmd_completed();
         cmd_set_check(CHECK_DATA);
 
         struct channel* tx_chan = esp8266_state.comm.tx_chan;
         esp8266_state.comm.tx_chan = NULL;
+        tx_chan->tx_chars_buffered -= sent;
 
-        if (bytes_sent < 0) {
+        if (!status) {
                 pr_warning(LOG_PFX "Failed to send data\r\n");
         } else {
-                pr_debug_int_msg(LOG_PFX "# of bytes sent: ", bytes_sent);
-                tx_chan->tx_chars_buffered -= bytes_sent;
+                pr_info_int_msg(LOG_PFX "# of bytes sent: ", sent);
         }
 }
 

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -342,7 +342,8 @@ static void drop_data(struct channel *ch)
 /**
  * Callback that is invoked when the send_data method completes.
  */
-static void _send_data_cb(const bool status, const size_t sent)
+static void _send_data_cb(const bool status, const size_t sent,
+                          const bool valid_link)
 {
         cmd_completed();
         cmd_set_check(CHECK_DATA);
@@ -353,8 +354,14 @@ static void _send_data_cb(const bool status, const size_t sent)
 
         if (!status) {
                 pr_warning(LOG_PFX "Failed to send data\r\n");
+                if (!valid_link) {
+                        /* Link has closed */
+                        pr_info(LOG_PFX "Link invalid. Closing\r\n");
+                        tx_chan->connected = false;
+                }
+
         } else {
-                pr_info_int_msg(LOG_PFX "# of bytes sent: ", sent);
+                pr_trace_int_msg(LOG_PFX "# of bytes sent: ", sent);
         }
 }
 

--- a/src/modem/at.c
+++ b/src/modem/at.c
@@ -253,7 +253,20 @@ static void at_task_run_bytes_read(struct at_info *ati, char *msg)
          * Our rx state will dictate how we process this message beacuse that
          * allows us to know previous messages and what message type to expect.
          */
-        switch (ati->rx_state) {
+        //enum at_rx_state state = ati->rx_state;
+        enum at_rx_state state = AT_RX_STATE_READY;
+
+        /*
+         * If the device is a rude device, then we need to treat every message
+         * as a new message. Sane AT devices will buffer all URCs until after a
+         * command is complete.  Some however do not and thus we must acomodate
+         * them here.  This has potential drawbacks if a URC and a command
+         * response conflict, but that is the price of a rude device.
+         */
+        //if (ati->dev_cfg.flags & AT_DEV_CFG_FLAG_RUDE)
+        //        state = AT_RX_STATE_READY;
+
+        switch (state) {
         case AT_RX_STATE_CMD:
                 /* We are in the middle of receiving a command message. */
                 return process_cmd_msg(ati, msg);

--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -186,6 +186,7 @@ static void send_beacon(struct Serial* serial, const char* ips[])
 
         json_objEnd(serial, false);
         json_objEnd(serial, false);
+        put_crlf(serial);
 }
 
 static void do_beacon()


### PR DESCRIPTION
This change is built on top of PR #664, so please review that first prior to reviewing this.

This change adds the ability to support "Rude AT commands".  Rude at commands are AT commands that show up during the middle of another command instead of being queued.  They are considered rude because they interrupt the other command (and can even ruin it).  But sometimes you have to work with the cards you're dealt and this is one of those times.

In brief testing it seems to help the WiFi driver cope with a flood of messages, but there is still the chance that if you flood it with messages it simply will not be able to handle them or may even freeze.  I'm doing my best to prevent that as is reasonable.