### PR TITLE
Reduce the GPS DMA Rx buffer to 32 bytes from 132

### DIFF
--- a/platform/mk2/hal/usart_stm32/usart_device_stm32.c
+++ b/platform/mk2/hal/usart_stm32/usart_device_stm32.c
@@ -33,7 +33,7 @@
 #include "usart_device.h"
 
 #define UART_QUEUE_LENGTH 	1024
-#define GPS_BUFFER_SIZE		132
+#define GPS_BUFFER_SIZE		32
 
 #define UART_WIRELESS_IRQ_PRIORITY 	7
 #define UART_AUX_IRQ_PRIORITY 		8


### PR DESCRIPTION
This means that it will only take 16 characters to trigger a transfer
of data from the buffer instead of 66.  This is a solid improvement since
it will help us deal with low traffic situations (like when we detect a
timeout).

Issue #668