### PR TITLE
Fix Wifi Client Join

### DIFF
--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -507,12 +507,12 @@ static bool parse_client_info(char *rsp,
         case 1:
                 /* No AP */
                 return true;
-        case 5:
-                break;
-        default:
+        case 0:
+        case 2: /* Then we fail */
                 return false;
         }
 
+        /* If here, we have 3 or more tokens. */
         info->has_ap = true;
         const char *ssid = at_parse_rsp_str(toks[1]);
         const char *mac = at_parse_rsp_str(toks[2]);


### PR DESCRIPTION
We were failing to join clients on older WiFi hardware because the
older baseband software doesn't return as many arguments as newer
does.  This patch works around that issue so we can support both.

Issue #670