### PR TITLE
RCT WiFi LED support

### DIFF
--- a/include/LED/led.h
+++ b/include/LED/led.h
@@ -43,6 +43,7 @@ enum led {
         LED_LOGGER    =  1,
         LED_GPS       =  2,
         LED_TELEMETRY =  3,
+        LED_WIFI      =  4,
 };
 
 bool led_init(void);

--- a/platform/rct/hal/LED_stm32/led_device_stm32.c
+++ b/platform/rct/hal/LED_stm32/led_device_stm32.c
@@ -43,9 +43,9 @@ static struct led_data {
         uint16_t mask;
         bool level;
 } leds[] = {
-        {LED_ERROR,     GPIO_Pin_0, 0},
-        {LED_GPS,       GPIO_Pin_1, 0},
-        {LED_TELEMETRY, GPIO_Pin_2, 0},
+        {LED_ERROR, GPIO_Pin_0, 0},
+        {LED_GPS,   GPIO_Pin_1, 0},
+        {LED_WIFI,  GPIO_Pin_2, 0},
 };
 
 static bool led_set_level(struct led_data *ld, const bool on)


### PR DESCRIPTION
Adds support so that our LED on the RCT unit will blink whenever Tx or Rx traffic is detected.  This is only for socket traffic, not AT traffic.

Issue #621 