### PR TITLE
Move our distance calculation to one that is speed/time based

### DIFF
--- a/include/gps/gps.h
+++ b/include/gps/gps.h
@@ -49,9 +49,11 @@ typedef struct _GpsSample {
 } GpsSample;
 
 typedef struct _GpsSnapshot {
-    GpsSample sample;
-    tiny_millis_t deltaFirstFix;
-    GeoPoint previousPoint;
+        GpsSample sample;
+        tiny_millis_t deltaFirstFix;
+        GeoPoint previousPoint;
+        float previous_speed;
+        tiny_millis_t delta_last_sample; /* Time since last sample */
 } GpsSnapshot;
 
 typedef enum {

--- a/src/gps/gps.c
+++ b/src/gps/gps.c
@@ -190,15 +190,25 @@ static void updateFullDateTime(GpsSample *gpsSample)
 
 void GPS_sample_update(GpsSample *newSample)
 {
-    if (!isGpsSignalUsable(newSample->quality)) return;
+        if (!isGpsSignalUsable(newSample->quality))
+                return;
 
-    const GeoPoint prevPoint = g_gpsSnapshot.sample.point;
+        const GeoPoint prevPoint = g_gpsSnapshot.sample.point;
+        const float prev_speed = g_gpsSnapshot.sample.speed;
+        const tiny_millis_t prev_deltaff = g_gpsSnapshot.deltaFirstFix;
 
-    // Deep copy stuff.
-    g_gpsSnapshot.sample = *newSample;
-    updateFullDateTime(newSample);
-    g_gpsSnapshot.deltaFirstFix = newSample->time - g_timeFirstFix;
-    g_gpsSnapshot.previousPoint = prevPoint;
+        /*
+         * Deep copy stuff and call updateFullDateTime before we update
+         * everything else.
+         */
+        g_gpsSnapshot.sample = *newSample;
+        updateFullDateTime(newSample);
+
+        g_gpsSnapshot.deltaFirstFix = newSample->time - g_timeFirstFix;
+        g_gpsSnapshot.previousPoint = prevPoint;
+        g_gpsSnapshot.previous_speed = prev_speed;
+        g_gpsSnapshot.delta_last_sample =
+                g_gpsSnapshot.deltaFirstFix - prev_deltaff;
 }
 
 int GPS_processUpdate(struct Serial *serial)

--- a/src/lap_stats/lap_stats.c
+++ b/src/lap_stats/lap_stats.c
@@ -142,7 +142,7 @@ static void update_distance(const GpsSnapshot *gps_ss)
          * Delta ms: ms
          * KM/H * delta ms / 3600 = delta distance.
          */
-        g_distance += speed_avg * gps_ss->delta_last_sample / 3600;
+        g_distance += speed_avg * gps_ss->delta_last_sample / 3600000.0;
 }
 
 static void set_distance(const float distance)

--- a/src/lap_stats/lap_stats.c
+++ b/src/lap_stats/lap_stats.c
@@ -19,7 +19,6 @@
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #include "auto_track.h"
 #include "dateTime.h"
 #include "geoCircle.h"
@@ -36,17 +35,14 @@
 #include "predictive_timer_2.h"
 #include "printk.h"
 #include "tracks.h"
-
 #include <stdint.h>
 
 /* Make the radius 2x the size of start/finish radius.*/
 #define GEO_TRIGGER_RADIUS_MULTIPLIER 2
-#define KMS_TO_MILES_CONSTANT (.621371)
-
-// In Millis now.
-#define START_FINISH_TIME_THRESHOLD 10000
-
-#define TIME_NULL -1
+#define KMS_TO_MILES_CONSTANT         (0.621371)
+#define MEASUREMENT_SPEED_MIN_KPH     1
+#define START_FINISH_TIME_THRESHOLD   10000
+#define TIME_NULL                     -1
 
 static const Track *g_active_track;
 static float g_geo_circle_radius;
@@ -134,17 +130,19 @@ static void update_distance(const GpsSnapshot *gps_ss)
         const float speed_avg =
                 (gps_ss->sample.speed + gps_ss->previous_speed) / 2;
 
-        if (speed_avg < 1)
+        /*
+         * Filter out low speed measurements to prevent updates when
+         * a vehicle is stationary or moving at trivial speed.
+         */
+        if (speed_avg < MEASUREMENT_SPEED_MIN_KPH)
                 return;
 
         /*
          * Speed: KM/H
          * Delta ms: ms
-         * KM/H * delta ms / 3600 = distance.  To save a divide
-         * we do KM/H * delta ms * (1 / 3600)
+         * KM/H * delta ms / 3600 = delta distance.
          */
-        static const float factor = 1 / 3600;
-        g_distance += speed_avg * gps_ss->delta_last_sample * factor;
+        g_distance += speed_avg * gps_ss->delta_last_sample / 3600;
 }
 
 static void set_distance(const float distance)

--- a/test/lap_stats/LapStatsTest.cpp
+++ b/test/lap_stats/LapStatsTest.cpp
@@ -288,13 +288,14 @@ void LapStatsTest::update_distance_test()
 {
         const float expected =
                 (gps_ss.sample.speed + gps_ss.previous_speed) / 2 *
-                gps_ss.delta_last_sample / 3600;
+                gps_ss.delta_last_sample / 3600000.0;
 
         CPPUNIT_ASSERT_EQUAL((float) 0, getLapDistance());
 
         update_distance(&gps_ss);
 
         CPPUNIT_ASSERT_EQUAL(expected, getLapDistance());
+        CPPUNIT_ASSERT(0 != getLapDistance());
 }
 
 void LapStatsTest::update_distance_low_speed_test()

--- a/test/lap_stats/LapStatsTest.cpp
+++ b/test/lap_stats/LapStatsTest.cpp
@@ -44,10 +44,13 @@ void LapStatsTest::setUp()
         gps_ss.sample.point.latitude = 1.1;
         gps_ss.sample.point.longitude = 2.1;
         gps_ss.sample.time = 1234567;
-        gps_ss.deltaFirstFix = 303;
+        gps_ss.sample.speed = 42;
 
+        gps_ss.deltaFirstFix = 303;
         gps_ss.previousPoint.latitude = 1.0;
         gps_ss.previousPoint.longitude = 2.0;
+        gps_ss.previous_speed = 34;
+        gps_ss.delta_last_sample = 100;
 }
 
 void LapStatsTest::tearDown() {}
@@ -283,8 +286,9 @@ void LapStatsTest::sector_boundary_event_test()
 
 void LapStatsTest::update_distance_test()
 {
-        const float expected = distPythag(&gps_ss.previousPoint,
-                                          &gps_ss.sample.point) / 1000;
+        const float expected =
+                (gps_ss.sample.speed + gps_ss.previous_speed) / 2 *
+                gps_ss.delta_last_sample / 3600;
 
         CPPUNIT_ASSERT_EQUAL((float) 0, getLapDistance());
 
@@ -293,11 +297,13 @@ void LapStatsTest::update_distance_test()
         CPPUNIT_ASSERT_EQUAL(expected, getLapDistance());
 }
 
-void LapStatsTest::update_distance_no_prev_point_test()
+void LapStatsTest::update_distance_low_speed_test()
 {
         CPPUNIT_ASSERT_EQUAL((float) 0, getLapDistance());
 
-        gps_ss.previousPoint = (GeoPoint) { 0 };
+        /* Threshold is 1 KM/H as of this writing */
+        gps_ss.sample.speed = 1.0;
+        gps_ss.previous_speed = 0.8;
         update_distance(&gps_ss);
 
         CPPUNIT_ASSERT_EQUAL((float) 0, getLapDistance());

--- a/test/lap_stats/LapStatsTest.hh
+++ b/test/lap_stats/LapStatsTest.hh
@@ -40,7 +40,7 @@ class LapStatsTest : public CppUnit::TestFixture
         CPPUNIT_TEST( stage_lap_finish_event_test );
         CPPUNIT_TEST( sector_boundary_event_test );
         CPPUNIT_TEST( update_distance_test );
-        CPPUNIT_TEST( update_distance_no_prev_point_test );
+        CPPUNIT_TEST( update_distance_low_speed_test );
         CPPUNIT_TEST( update_sector_geo_circle_test );
         CPPUNIT_TEST( update_elapsed_time_test );
         CPPUNIT_TEST( at_sf_reset_test );
@@ -63,7 +63,7 @@ public:
         void stage_lap_finish_event_test();
         void sector_boundary_event_test();
         void update_distance_test();
-        void update_distance_no_prev_point_test();
+        void update_distance_low_speed_test();
         void update_sector_geo_circle_test();
         void update_elapsed_time_test();
         void at_sf_reset_test();


### PR DESCRIPTION
***1 Upvote*** As we have seen in the field measuring distance by taking the
pythag distance between our current point and the last is not good
in many situations due to GPS inaccuracies.  Speed over time may
be a better approach since we have noticed that speed calculations
tend to be very accurate relative to the sometimes erratic location
calculations.  Hence this change.

Issue #178