### PR TITLE
Improve line dicipline on the rx_buff tool

### DIFF
--- a/src/usb_comm/usb_comm.c
+++ b/src/usb_comm/usb_comm.c
@@ -165,6 +165,7 @@ static void process_rx_msgs()
         {
                 /* A message awaits us */
                 char *data_in = rx_buff_get_msg(rxb);
+                put_crlf(s);
                 pr_trace_str_msg(LOG_PFX "Received CMD: ", data_in);
                 process_read_msg(s, data_in, strlen(data_in));
                 break;


### PR DESCRIPTION
Fixes small gotchas that were introduced when I moved our USB line
dicipline code over to rx_buff. Now we don't delete more characters
than we have typed, properly reply to backspace commands (including
the rubout character) and always include a \r\n after all commands.