### PR TITLE
Fix and Improve ADC setup on RCT

### DIFF
--- a/main.c
+++ b/main.c
@@ -71,7 +71,7 @@ static const struct app_info_block info_block = {
 #define RCP_OUTPUT_PRIORITY	TASK_PRIORITY(2)
 #define RCP_LUA_PRIORITY	TASK_PRIORITY(1)
 
-void setupTask(void *delTask)
+void setupTask(void *param)
 {
         initialize_tracks();
         initialize_logger_config();
@@ -105,8 +105,7 @@ void setupTask(void *delTask)
 #endif
 
         /* Removes this setup task from the scheduler */
-        if (delTask)
-                vTaskDelete(NULL);
+        vTaskDelete(NULL);
 }
 
 int main( void )
@@ -119,25 +118,9 @@ int main( void )
         if (true == ASL_WATCHDOG)
                 watchdog_init(WATCHDOG_TIMEOUT_MS);
 
-        /*
-         * Start the scheduler.
-         *
-         * NOTE : Tasks run in system mode and the scheduler runs in
-         * Supervisor mode. The processor MUST be in supervisor mode
-         * when vTaskStartScheduler is called.  The demo applications
-         * included in the FreeRTOS.org download switch to supervisor
-         * mode prior to main being called.  If you are not using one
-         * of these demo application projects then ensure Supervisor
-         * mode is used here.
-         */
-
-        if (TASK_TASK_INIT) {
-                xTaskCreate(setupTask, (signed portCHAR*) "Hardware Init",
-                            configMINIMAL_STACK_SIZE * 2, (void *) true,
-                            RCP_LUA_PRIORITY, NULL);
-        } else {
-                setupTask((void *) false);
-        }
+        const signed portCHAR task_name[] = "Hardware Init";
+        xTaskCreate(setupTask, task_name, configMINIMAL_STACK_SIZE * 2,
+                    NULL, RCP_LUA_PRIORITY, NULL);
 
         vTaskStartScheduler();
 

--- a/platform/mk2/capabilities.h
+++ b/platform/mk2/capabilities.h
@@ -85,6 +85,4 @@
 #define VERSION_STR MAJOR_REV_STR "." MINOR_REV_STR "." BUGFIX_REV_STR
 #define WELCOME_MSG "Welcome to RaceCapture/Pro MK2 : Firmware Version " VERSION_STR
 
-//initialize main tasks in temporary FreeRTOS task
-#define TASK_TASK_INIT 1
 #endif /* CAPABILITIES_H_ */

--- a/platform/rct/capabilities.h
+++ b/platform/rct/capabilities.h
@@ -55,9 +55,6 @@
 #define VERSION_STR MAJOR_REV_STR "." MINOR_REV_STR "." BUGFIX_REV_STR
 #define WELCOME_MSG "Welcome to RaceCapture : Firmware Version " VERSION_STR
 
-//initialize main tasks in temporary FreeRTOS task
-#define TASK_TASK_INIT 1
-
 /* LUA Configuration */
 
 /*

--- a/platform/rct/hal/ADC_stm32/ADC_device_stm32.c
+++ b/platform/rct/hal/ADC_stm32/ADC_device_stm32.c
@@ -95,7 +95,6 @@ int ADC_device_init(void)
         ADC_SelectCalibrationMode(ADC3, ADC_CalibrationMode_Single);
         ADC_StartCalibration(ADC3);
         while(SET == ADC_GetCalibrationStatus(ADC3));
-        /* calibration_value = ADC_GetCalibrationValue(ADC3); */
 
         ADC_InitTypeDef ADC_InitStructure;
         ADC_StructInit(&ADC_InitStructure);

--- a/platform/rct/hal/ADC_stm32/ADC_device_stm32.c
+++ b/platform/rct/hal/ADC_stm32/ADC_device_stm32.c
@@ -25,6 +25,7 @@
 #include "stm32f30x_dma.h"
 #include "stm32f30x_gpio.h"
 #include "stm32f30x_rcc.h"
+#include "taskUtil.h"
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -34,8 +35,8 @@
  */
 
 #define ADC_SYSTEM_VOLTAGE_RANGE	20.0f
-#define SCALING_BATTERYV	0.00465f
-#define TOTAL_ADC_CHANNELS	1
+#define SCALING_BATTERYV		0.00465f
+#define TOTAL_ADC_CHANNELS		1
 
 volatile unsigned short ADC_Val[TOTAL_ADC_CHANNELS];
 
@@ -81,12 +82,14 @@ int ADC_device_init(void)
 
         /* Calibration procedure */
         ADC_VoltageRegulatorCmd(ADC3, ENABLE);
+
         /*
          * Wait at least 10us before starting calibration or enabling.
-         * This is a total hack since I don't want to put a timer here
-         * and there is no interrupt to tell me this is ready :(.
+         * Since there is no interrupt to tell me this is ready we just
+         * delay one scheduler tick which should be more than 10us.  This
+         * assumes that the scheduler is always active during init.
          */
-        for (size_t i = 0; i < 10000; ++i);
+        delayTicks(1);
 
         /* We compare against Vref only */
         ADC_SelectDifferentialMode(ADC3, ADC_Channel_1, DISABLE);

--- a/platform/rct/hal/ADC_stm32/ADC_device_stm32.c
+++ b/platform/rct/hal/ADC_stm32/ADC_device_stm32.c
@@ -50,15 +50,18 @@ int ADC_device_init(void)
         /* DMA configuration */
         RCC_AHBPeriphClockCmd(RCC_AHBPeriph_DMA2, ENABLE);
 
+        DMA_Cmd(DMA2_Channel5, DISABLE);
+        DMA_DeInit(DMA2_Channel5);
+
         DMA_InitTypeDef DMA_InitStructure;
 	DMA_StructInit(&DMA_InitStructure);
-        DMA_InitStructure.DMA_BufferSize = 1;
+        DMA_InitStructure.DMA_BufferSize = TOTAL_ADC_CHANNELS;
         DMA_InitStructure.DMA_DIR = DMA_DIR_PeripheralSRC;
-        DMA_InitStructure.DMA_MemoryBaseAddr = (uint32_t)&ADC_Val[0];
+        DMA_InitStructure.DMA_MemoryBaseAddr = (uint32_t) &ADC_Val[0];
         DMA_InitStructure.DMA_MemoryDataSize = DMA_MemoryDataSize_HalfWord;
         DMA_InitStructure.DMA_MemoryInc = DMA_MemoryInc_Enable;
         DMA_InitStructure.DMA_Mode = DMA_Mode_Circular;
-        DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)&ADC3->DR;
+        DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t) &ADC3->DR;
         DMA_InitStructure.DMA_PeripheralDataSize = DMA_PeripheralDataSize_HalfWord;
         DMA_InitStructure.DMA_PeripheralInc = DMA_PeripheralInc_Disable;
         DMA_InitStructure.DMA_Priority = DMA_Priority_High;
@@ -76,46 +79,37 @@ int ADC_device_init(void)
         GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;
         GPIO_Init(GPIOB, &GPIO_InitStructure);
 
-        /* Calibration procedure
-         *  TODO see if this is necessary
-         *
-         ADC_VoltageRegulatorCmd(ADC1, ENABLE);
+        /* Calibration procedure */
+        ADC_VoltageRegulatorCmd(ADC3, ENABLE);
+        /*
+         * Wait at least 10us before starting calibration or enabling.
+         * This is a total hack since I don't want to put a timer here
+         * and there is no interrupt to tell me this is ready :(.
+         */
+        for (size_t i = 0; i < 10000; ++i);
 
-         ADC_SelectCalibrationMode(ADC1, ADC_CalibrationMode_Single);
-         ADC_StartCalibration(ADC1);
+        /* We compare against Vref only */
+        ADC_SelectDifferentialMode(ADC3, ADC_Channel_1, DISABLE);
 
-         while(ADC_GetCalibrationStatus(ADC1) != RESET );
-         calibration_value = ADC_GetCalibrationValue(ADC1);
-        */
+        /* Now calibrate our ADC */
+        ADC_SelectCalibrationMode(ADC3, ADC_CalibrationMode_Single);
+        ADC_StartCalibration(ADC3);
+        while(SET == ADC_GetCalibrationStatus(ADC3));
+        /* calibration_value = ADC_GetCalibrationValue(ADC3); */
 
-        ADC_CommonInitTypeDef   ADC_CommonInitStructure;
-
-        ADC_CommonInitStructure.ADC_Mode = ADC_Mode_Independent;
-        ADC_CommonInitStructure.ADC_Clock = ADC_Clock_AsynClkMode;
-        ADC_CommonInitStructure.ADC_DMAAccessMode = ADC_DMAAccessMode_Disabled;
-        ADC_CommonInitStructure.ADC_DMAMode = ADC_DMAMode_Circular;
-        ADC_CommonInitStructure.ADC_TwoSamplingDelay = 0;
-        ADC_CommonInit(ADC3, &ADC_CommonInitStructure);
-
-        ADC_InitTypeDef         ADC_InitStructure;
+        ADC_InitTypeDef ADC_InitStructure;
+        ADC_StructInit(&ADC_InitStructure);
         ADC_InitStructure.ADC_ContinuousConvMode = ADC_ContinuousConvMode_Enable;
-        ADC_InitStructure.ADC_Resolution = ADC_Resolution_12b;
-        ADC_InitStructure.ADC_ExternalTrigConvEvent = ADC_ExternalTrigConvEvent_0;
-        ADC_InitStructure.ADC_ExternalTrigEventEdge = ADC_ExternalTrigEventEdge_None;
-        ADC_InitStructure.ADC_DataAlign = ADC_DataAlign_Right;
-        ADC_InitStructure.ADC_OverrunMode = ADC_OverrunMode_Disable;
-        ADC_InitStructure.ADC_AutoInjMode = ADC_AutoInjec_Disable;
         ADC_InitStructure.ADC_NbrOfRegChannel = 1;
         ADC_Init(ADC3, &ADC_InitStructure);
 
-        /* ADC1 regular channel 6, 7 & 9 configuration.  PB1 */
+        /* Register the channel(s) to read/convert */
         ADC_RegularChannelConfig(ADC3, ADC_Channel_1, 1, ADC_SampleTime_19Cycles5);
 
         /* Enables DMA channel */
-        DMA_Cmd(DMA2_Channel5, ENABLE);
-
-        /* Enable ADC3 DMA */
         ADC_DMACmd(ADC3, ENABLE);
+        ADC_DMAConfig(ADC3, ADC_DMAMode_Circular);
+        DMA_Cmd(DMA2_Channel5, ENABLE);
 
 	/* Enable ADC3 */
 	ADC_Cmd(ADC3, ENABLE);
@@ -123,7 +117,7 @@ int ADC_device_init(void)
         /* wait for ADRDY */
 	while(!ADC_GetFlagStatus(ADC3, ADC_FLAG_RDY));
 
-        /* Start ADC3 Conversion */
+        /* Start ADC3 Conversion. Must be called after ADC enabled */
         ADC_StartConversion(ADC3);
 
         return 1;


### PR DESCRIPTION
ADC wasn't firing more than once after init. We had properly setup
the init structure for the device but had missed setting the
ADCDmaConfig to circular (defaults to one shot).  This is what was
causing the failure.

In the process of doing this I read most of the reference manual on
this device and implemented some other bits we will benefit from
(like calibration).  I also cleaned out a lot of unnecessary fluff
since most of it was default settings.

Issue #520