### PR TITLE
Full Assert Support

### DIFF
--- a/make/asl_cflags.mk
+++ b/make/asl_cflags.mk
@@ -28,16 +28,13 @@ ASL_CFLAGS += -Os -std=gnu99
 # to the official build as possible without being labeled as official.
 # That means no checks that would occur when DEBUG is active.
 #
-# STIEG: BUG: -DUSE_FULL_ASSERT - Not working on MK2.
-#
 ifeq ($(RELEASE_TYPE),RELEASE_TYPE_DEVEL)
-ASL_CFLAGS += -DASL_DEBUG -D_DEBUG
-endif
-
+ASL_CFLAGS += -DASL_DEBUG -D_DEBUG -DUSE_FULL_ASSERT
 ASL_WATCHDOG := false
-ifeq ($(RELEASE_TYPE),RELEASE_TYPE_OFFICIAL)
+else
 ASL_WATCHDOG := true
 endif
+
 ASL_CFLAGS += -DASL_WATCHDOG=$(ASL_WATCHDOG)
 
 ASL_WARNING_FLAGS := \

--- a/platform/mk2/hal/CAN_stm32/CAN_device_stm32.c
+++ b/platform/mk2/hal/CAN_stm32/CAN_device_stm32.c
@@ -273,7 +273,8 @@ int CAN_device_tx_msg(uint8_t channel, CAN_msg * msg, unsigned int timeoutMs)
         /* Using ticks avoids a race-condition */
         size_t ticks = getCurrentTicks();
         const size_t trigger = ticks + msToTicks(timeoutMs);
-        uint8_t status;
+
+        uint8_t status = CAN_TxStatus_Failed;
         while(ticks <= trigger) {
                 status = CAN_TransmitStatus(chan, mailbox);
                 if (CAN_TxStatus_Pending != status)

--- a/platform/mk2/hal/cpu_stm32/cpu_device_stm32.c
+++ b/platform/mk2/hal/cpu_stm32/cpu_device_stm32.c
@@ -1,5 +1,6 @@
 #include "cpu_device.h"
 #include "portmacro.h"
+#include "printk.h"
 #include <stm32f4xx_misc.h>
 #include <stm32f4xx_rcc.h>
 #include <core_cm4.h>
@@ -12,7 +13,13 @@
 #define SERIAL_ID_BITS		96
 #define SERIAL_ID_BUFFER_LEN	(((SERIAL_ID_BITS / 8) * 2) + 1)
 
-extern uint32_t _flash_start;
+/*
+ * Set by f407_mem.ld linker script.  Somehow this is getting
+ * altered to a value of 0x20020000.  Don't know why yet.
+ * But we handle this below by masking off the top 12 bits.
+ */
+extern const uint32_t _flash_start;
+
 static char cpu_id[SERIAL_ID_BUFFER_LEN];
 
 static void init_cpu_id()
@@ -32,10 +39,10 @@ static void init_cpu_id()
 
 int cpu_device_init(void)
 {
-    NVIC_SetVectorTable(NVIC_VectTab_FLASH, _flash_start);
-    NVIC_PriorityGroupConfig(NVIC_PriorityGroup_4);
-    init_cpu_id();
-    return 1;
+        NVIC_SetVectorTable(NVIC_VectTab_FLASH, _flash_start & 0x000FFFFF);
+        NVIC_PriorityGroupConfig(NVIC_PriorityGroup_4);
+        init_cpu_id();
+        return 1;
 }
 
 void cpu_device_reset(int bootloader)

--- a/platform/mk2/hal/usart_stm32/usart_device_stm32.c
+++ b/platform/mk2/hal/usart_stm32/usart_device_stm32.c
@@ -463,9 +463,11 @@ static void usart_generic_irq_handler(volatile struct usart_info *ui)
                                                    &xTaskWoken)) {
                         /*
                          * A character was retrieved from the queue so
-                         * can be sent to the USART.
+                         * can be sent to the USART. Casting to uint8_t
+                         * here to avoid issues when SendData casts the
+                         * value to a uint16_t (sign extension).
                          */
-                        USART_SendData(usart, cChar);
+                        USART_SendData(usart, (uint8_t) cChar);
                 } else {
                         /*
                          * Queue empty, nothing to send so turn off the
@@ -491,9 +493,10 @@ static void usart_generic_irq_handler(volatile struct usart_info *ui)
                 /*
                  * The interrupt was caused by a character being received.
                  * Grab the character from the rx and place it in the queue
-                 * or received characters.
+                 * or received characters. Casting to uint8_t first here
+                 * to avoid any casting issues from uint16_t
                  */
-                cChar = USART_ReceiveData(usart);
+                cChar = (uint8_t) USART_ReceiveData(usart);
                 xQueueHandle rx_queue = serial_get_rx_queue(ui->serial);
                 if (!xQueueSendFromISR(rx_queue, &cChar, &xTaskWoken))
                         ui->char_dropped = true;

--- a/platform/mk2/hal/usart_stm32/usart_device_stm32.c
+++ b/platform/mk2/hal/usart_stm32/usart_device_stm32.c
@@ -214,7 +214,11 @@ static void enable_dma_tx(const uint32_t dma_periph,
 
         DMA_InitStructure.DMA_Channel = dma->channel;
         DMA_InitStructure.DMA_Memory0BaseAddr = (uint32_t) dma->buff;
-        DMA_InitStructure.DMA_BufferSize = 0;
+        /*
+         * Setting BufferSize here to 0 is invalid. Its initial value
+         * doesn't matter anyways so set 1 here.
+         */
+        DMA_InitStructure.DMA_BufferSize = 1;
         DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t) &ui->usart->DR;
         DMA_InitStructure.DMA_DIR = DMA_DIR_MemoryToPeripheral;
         DMA_InitStructure.DMA_PeripheralInc = DMA_PeripheralInc_Disable;

--- a/platform/mk2/libs/STM32F4xx_DSP_StdPeriph_Lib_V1.0.1/Libraries/STM32F4xx_StdPeriph_Driver/inc/stm32f4xx_dma.h
+++ b/platform/mk2/libs/STM32F4xx_DSP_StdPeriph_Lib_V1.0.1/Libraries/STM32F4xx_StdPeriph_Driver/inc/stm32f4xx_dma.h
@@ -356,8 +356,8 @@ typedef struct {
 /** @defgroup DMA_flags_definition
   * @{
   */
-#define DMA_FLAG_FEIF0                    ((uint32_t)0x10800001)
-#define DMA_FLAG_DMEIF0                   ((uint32_t)0x10800004)
+#define DMA_FLAG_FEIF0                    ((uint32_t)0x10000001)
+#define DMA_FLAG_DMEIF0                   ((uint32_t)0x10000004)
 #define DMA_FLAG_TEIF0                    ((uint32_t)0x10000008)
 #define DMA_FLAG_HTIF0                    ((uint32_t)0x10000010)
 #define DMA_FLAG_TCIF0                    ((uint32_t)0x10000020)

--- a/platform/rct/hal/usart_stm32/usart_device_stm32.c
+++ b/platform/rct/hal/usart_stm32/usart_device_stm32.c
@@ -412,7 +412,7 @@ static void usart_generic_irq_handler(volatile struct usart_info *ui)
                          * A character was retrieved from the queue so
                          * can be sent to the USART.
                          */
-                        USART_SendData(usart, cChar);
+                        USART_SendData(usart, (uint8_t) cChar);
                 } else {
                         /*
                          * Queue empty, nothing to send so turn off the
@@ -429,7 +429,7 @@ static void usart_generic_irq_handler(volatile struct usart_info *ui)
                  * Grab the character from the rx and place it in the queue
                  * or received characters.
                  */
-                cChar = USART_ReceiveData(usart);
+                cChar = (uint8_t) USART_ReceiveData(usart);
                 xQueueHandle rx_queue = serial_get_rx_queue(ui->serial);
                 if (!xQueueSendFromISR(rx_queue, &cChar, &xTaskWokenByPost))
                         ui->char_dropped = true;


### PR DESCRIPTION
This change enables us to use the `assert_param` methods in firmware, allowing us to have assert checks in debug (non-tagged) versions of the firmware.  This better allows us to validate the inputs we pass into hardware and to catch potentially tricky bugs during development.

It did expose several bugs in MK2, half of which were semi-legit to full legit (casting issues with USART).  Those are all fixed as part of this release.