### PR TITLE
Get SDCard Logging Functional Again

### DIFF
--- a/include/util/macros.h
+++ b/include/util/macros.h
@@ -38,6 +38,16 @@ CPP_GUARD_BEGIN
  */
 #define STR_EQ(s1, s2)	(0 == strcmp((s1), (s2)))
 
+/**
+ * Chooses the maximum of two values.
+ */
+#define MAX(a,b) (((a)>(b))?(a):(b))
+
+/**
+ * Chooses the minimum of two values.
+ */
+#define MIN(a,b) (((a)<(b))?(a):(b))
+
 CPP_GUARD_END
 
 #endif /* _MACROS_H_ */

--- a/platform/mk2/Makefile
+++ b/platform/mk2/Makefile
@@ -79,7 +79,7 @@ FREERTOS_LD_FLAGS := -Wl,--undefined=uxTopUsedPriority
 LDFLAGS ?= --specs=nano.specs $(LIBS) -mcpu=$(CPU_TYPE) \
 	-L. -Lcpu/common -L$(LUA_LIB_DIR) -L$(CPU_BASE) -T$(CPU_LINK_MEM) \
 	-Tlink_sections.ld -nostartfiles -Wl,--gc-sections -mthumb \
-	-msoft-float $(FREERTOS_LD_FLAGS) -Wl,-static
+	-msoft-float $(FREERTOS_LD_FLAGS) -Wl,-static -Wl,-Map=main.map
 
 # Be silent per default, but 'make V=1' will show all compiler calls.
 ifneq ($(V),1)

--- a/platform/mk2/hal/cpu_stm32/cpu_device_stm32.c
+++ b/platform/mk2/hal/cpu_stm32/cpu_device_stm32.c
@@ -51,7 +51,7 @@ static void init_cpu_id()
 {
         const uint8_t* ids = (const uint8_t*) CPU_ID_REGISTER_START;
 
-        for (int i = 0; i < CPU_ID_BYTE_COUNT; ++i) {
+        for (size_t i = 0; i < CPU_ID_BYTE_COUNT; ++i) {
                 cpu_id[2 * i] = to_hex(ids[i] >> 4);
                 cpu_id[2 * i + 1] = to_hex(ids[i] & 0xF);
         }

--- a/platform/mk2/hal/cpu_stm32/cpu_device_stm32.c
+++ b/platform/mk2/hal/cpu_stm32/cpu_device_stm32.c
@@ -1,17 +1,36 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "cpu_device.h"
 #include "portmacro.h"
 #include "printk.h"
-#include <stm32f4xx_misc.h>
-#include <stm32f4xx_rcc.h>
+#include <app_info.h>
 #include <core_cm4.h>
 #include <stdint.h>
-#include <app_info.h>
+#include <stm32f4xx_misc.h>
+#include <stm32f4xx_rcc.h>
 
 #define CPU_ID_REGISTER_START 	0x1FFF7A10
-#define CPU_ID_REGISTER_END   	0x1FFF7A1C
-#define ASCII(x)		(((x)&0xF) < 10) ? (((x)&0xF)+'0') : (((x)&0xF)-10+'A')
-#define SERIAL_ID_BITS		96
-#define SERIAL_ID_BUFFER_LEN	(((SERIAL_ID_BITS / 8) * 2) + 1)
+#define CPU_ID_BYTE_COUNT	12
+#define SERIAL_ID_BUFFER_LEN	(CPU_ID_BYTE_COUNT * 2 + 1)
 
 /*
  * Set by f407_mem.ld linker script.  Somehow this is getting
@@ -22,19 +41,20 @@ extern const uint32_t _flash_start;
 
 static char cpu_id[SERIAL_ID_BUFFER_LEN];
 
+static char to_hex(uint8_t val)
+{
+        val &= 0x0F;
+        return val >= 10 ? val - 10  + 'A' : val + '0';
+}
+
 static void init_cpu_id()
 {
-    uint32_t *p = (uint32_t *) CPU_ID_REGISTER_START;
-    int i = 0, j = 0;
+        const uint8_t* ids = (const uint8_t*) CPU_ID_REGISTER_START;
 
-    while (p <= (uint32_t *) CPU_ID_REGISTER_END) {
-        for (i = 0; i < 8; i++)
-            cpu_id[7 - i + j] = ASCII(*p >> (i * 4));
-        p++;
-        j += 8;
-    }
-
-    cpu_id[SERIAL_ID_BUFFER_LEN - 1] = 0;
+        for (int i = 0; i < CPU_ID_BYTE_COUNT; ++i) {
+                cpu_id[2 * i] = to_hex(ids[i] >> 4);
+                cpu_id[2 * i + 1] = to_hex(ids[i] & 0xF);
+        }
 }
 
 int cpu_device_init(void)

--- a/platform/mk2/hal/fat_sd_stm32/fatfs/lo_level_ub/stm32_ub_sdcard.c
+++ b/platform/mk2/hal/fat_sd_stm32/fatfs/lo_level_ub/stm32_ub_sdcard.c
@@ -299,18 +299,19 @@ int MMC_disk_ioctl(BYTE cmd, void *buff)
 //--------------------------------------------------------------
 static void NVIC_Configuration(void)
 {
-    NVIC_InitTypeDef NVIC_InitStructure;
+        NVIC_InitTypeDef NVIC_InitStructure;
 
-    NVIC_PriorityGroupConfig(NVIC_PriorityGroup_4);
+        NVIC_PriorityGroupConfig(NVIC_PriorityGroup_4);
 
-    NVIC_InitStructure.NVIC_IRQChannel = SDIO_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0;
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
-    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-    NVIC_Init(&NVIC_InitStructure);
-    NVIC_InitStructure.NVIC_IRQChannel = SD_SDIO_DMA_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
-    NVIC_Init(&NVIC_InitStructure);
+        NVIC_InitStructure.NVIC_IRQChannel = SDIO_IRQn;
+        NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 5;
+        NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
+        NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
+        NVIC_Init(&NVIC_InitStructure);
+
+        NVIC_InitStructure.NVIC_IRQChannel = SD_SDIO_DMA_IRQn;
+        NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 6;
+        NVIC_Init(&NVIC_InitStructure);
 }
 
 

--- a/platform/rct/hal/cpu_stm32/cpu_device_stm32.c
+++ b/platform/rct/hal/cpu_stm32/cpu_device_stm32.c
@@ -43,7 +43,7 @@ static void init_cpu_id()
 {
         const uint8_t* ids = (const uint8_t *) CPU_ID_REGISTER_START;
 
-        for (int i = 0; i < CPU_ID_BYTE_COUNT; ++i) {
+        for (size_t i = 0; i < CPU_ID_BYTE_COUNT; ++i) {
                 cpu_id[2 * i] = to_hex(ids[i] >> 4);
                 cpu_id[2 * i + 1] = to_hex(ids[i] & 0xF);
         }

--- a/platform/rct/hal/cpu_stm32/cpu_device_stm32.c
+++ b/platform/rct/hal/cpu_stm32/cpu_device_stm32.c
@@ -1,33 +1,52 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "cpu_device.h"
 #include "portmacro.h"
+#include <app_info.h>
+#include <stdint.h>
 #include <stm32f30x_misc.h>
 #include <stm32f30x_rcc.h>
-#include <core_cm4.h>
-#include <stdint.h>
-#include <app_info.h>
 
-#define CPU_ID_REGISTER_START 	0x1FFFF7E8
-#define CPU_ID_REGISTER_END   	0x1FFFF7F4 /*TODO BAP verify serial number */
-#define ASCII(x)		(((x)&0xF) < 10) ? (((x)&0xF)+'0') : (((x)&0xF)-10+'A')
-#define SERIAL_ID_BITS		96
-#define SERIAL_ID_BUFFER_LEN	(((SERIAL_ID_BITS / 8) * 2) + 1)
+#define CPU_ID_REGISTER_START 	0x1FFFF7AC
+#define CPU_ID_BYTE_COUNT	12
+#define SERIAL_ID_BUFFER_LEN	(CPU_ID_BYTE_COUNT * 2 + 1)
 
 extern uint32_t _flash_start;
 static char cpu_id[SERIAL_ID_BUFFER_LEN];
 
+static char to_hex(uint8_t val)
+{
+        val &= 0x0F;
+        return val >= 10 ? val - 10  + 'A' : val + '0';
+}
+
 static void init_cpu_id()
 {
-    uint32_t *p = (uint32_t *) CPU_ID_REGISTER_START;
-    int i = 0, j = 0;
+        const uint8_t* ids = (const uint8_t *) CPU_ID_REGISTER_START;
 
-    while (p <= (uint32_t *) CPU_ID_REGISTER_END) {
-        for (i = 0; i < 8; i++)
-            cpu_id[7 - i + j] = ASCII(*p >> (i * 4));
-        p++;
-        j += 8;
-    }
-
-    cpu_id[SERIAL_ID_BUFFER_LEN - 1] = 0;
+        for (int i = 0; i < CPU_ID_BYTE_COUNT; ++i) {
+                cpu_id[2 * i] = to_hex(ids[i] >> 4);
+                cpu_id[2 * i + 1] = to_hex(ids[i] & 0xF);
+        }
 }
 
 int cpu_device_init(void)

--- a/src/logger/fileWriter.c
+++ b/src/logger/fileWriter.c
@@ -19,11 +19,12 @@
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "led.h"
+
 #include "fileWriter.h"
+#include "led.h"
 #include "loggerHardware.h"
+#include "macros.h"
 #include "mem_mang.h"
-#include <string.h>
 #include "modp_numtoa.h"
 #include "printk.h"
 #include "ring_buffer.h"
@@ -32,8 +33,8 @@
 #include "task.h"
 #include "taskUtil.h"
 #include "test.h"
-
 #include <stdbool.h>
+#include <string.h>
 #include <string.h>
 
 #define ERROR_SLEEP_DELAY_MS	500
@@ -85,10 +86,11 @@ static FRESULT append_file_buffer(const char *str)
         FRESULT res = FR_OK;
         size_t len = strlen(str);
         while(len) {
-                size_t space = ring_buffer_bytes_used(file_buff);
-                ring_buffer_put(file_buff, str, space);
-                str += space;
-                len -= space;
+                const size_t write_len =
+                        MIN(ring_buffer_bytes_free(file_buff), len);
+                ring_buffer_put(file_buff, str, write_len);
+                str += write_len;
+                len -= write_len;
 
                 /* If not at end of string, more to write.  Flush */
                 if (len > 0)


### PR DESCRIPTION
SD Card functionality broke on MK2 in 2.10.0 sometime back.  This PR fixes it by resolving the following issues:

* Corrects a buffer overflow we were having when calculating the CPU serial number.  Now we no longer write outside the bounds of our array.
* Corrects some bad logic in the fileWriter.c where we could get stuck in an infinite loop.
* Fixes the IRQ levels to not have higher priority than the FreeRTOS subsystem.

Resolves issue #714 and #647 