### PR TITLE
Remove retrieval of BT name and password

### DIFF
--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -858,18 +858,6 @@ int api_getCellConfig(struct Serial *serial, const jsmntok_t *json)
     return API_SUCCESS_NO_RETURN;
 }
 
-int api_getBluetoothConfig(struct Serial *serial, const jsmntok_t *json)
-{
-    BluetoothConfig *cfg = &(getWorkingLoggerConfig()->ConnectivityConfigs.bluetoothConfig);
-    json_objStart(serial);
-    json_objStartString(serial, "btCfg");
-    json_string(serial, "name", cfg->new_name, 1);
-    json_string(serial, "pass", cfg->new_pin, 0);
-    json_objEnd(serial, 0);
-    json_objEnd(serial, 0);
-    return API_SUCCESS_NO_RETURN;
-}
-
 int api_getLogfile(struct Serial *serial, const jsmntok_t *json)
 {
     json_objStart(serial);
@@ -946,8 +934,9 @@ int api_getConnectivityConfig(struct Serial *serial, const jsmntok_t *json)
 
     json_objStartString(serial, "btCfg");
     json_int(serial, "btEn", cfg->bluetoothConfig.btEnabled, 1);
-    json_string(serial, "name", cfg->bluetoothConfig.new_name, 1);
-    json_string(serial, "pass", cfg->bluetoothConfig.new_pin, 0);
+    /* Remove Name and Pass in next major API version change.  Issue #720 */
+    json_string(serial, "name", "", 1);
+    json_string(serial, "pass", "", 0);
     json_objEnd(serial, 1);
 
     json_objStartString(serial, "cellCfg");

--- a/test/loggerApi_test.cpp
+++ b/test/loggerApi_test.cpp
@@ -502,8 +502,8 @@ void LoggerApiTest::testGetConnectivityCfg(){
 	Object &connJson = json["connCfg"];
 
 	CPPUNIT_ASSERT_EQUAL((int)(connCfg->bluetoothConfig.btEnabled), (int)(Number)connJson["btCfg"]["btEn"]);
-	CPPUNIT_ASSERT_EQUAL(string(connCfg->bluetoothConfig.new_name), string((String)connJson["btCfg"]["name"]));
-	CPPUNIT_ASSERT_EQUAL(string(connCfg->bluetoothConfig.new_pin), string((String)connJson["btCfg"]["pass"]));
+	CPPUNIT_ASSERT_EQUAL(string(""), string((String)connJson["btCfg"]["name"]));
+	CPPUNIT_ASSERT_EQUAL(string(""), string((String)connJson["btCfg"]["pass"]));
 
 	CPPUNIT_ASSERT_EQUAL((int)(connCfg->cellularConfig.cellEnabled), (int)(Number)connJson["cellCfg"]["cellEn"]);
 	CPPUNIT_ASSERT_EQUAL(string(connCfg->cellularConfig.apnHost), string((String)connJson["cellCfg"]["apnHost"]));


### PR DESCRIPTION
Since we can only set these parameters anyways it makes no sense to
return them in the getter commands for BT informaiton.  Thus we no
longer return them.  Instead we return empty strings since deleting
these would break our API stabiliity standards.  Filed issue #720 to
track removal of those parameters entirely.

Issue #715