### PR TITLE
Don't error on missing `onTick` method in Lua

### DIFF
--- a/src/lua/luaTask.c
+++ b/src/lua/luaTask.c
@@ -166,9 +166,10 @@ static int lua_invocation(struct lua_run_state *rs)
         /* Now run the callback */
         lua_getglobal(rs->lua_state, function);
         if (lua_isnil(rs->lua_state, -1)) {
-                pr_error_str_msg(_LOG_PFX "Function not found: ", function);
+                /* No longer a failure per Issue #707 */
+                pr_debug_str_msg(_LOG_PFX "Function not found: ", function);
                 lua_pop(rs->lua_state, 1);
-                status = LUA_ERR_CALLBACK_NOT_FOUND;
+                status = 0;
                 goto done;
         }
 


### PR DESCRIPTION
This change alters our Lua subsystem to no longer error on a
missing `onTick` method.  This will allow users to create scripts
that run one time during first load of the script and will also
set us up to be able to fire callbacks in future versions should
we choose to do so.

Issue #707