### PR TITLE
Add flags support to "getCapabilities" API

### DIFF
--- a/include/system/flags.h
+++ b/include/system/flags.h
@@ -1,0 +1,33 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _FLAGS_H_
+#define _FLAGS_H_
+
+#include "cpp_guard.h"
+
+CPP_GUARD_BEGIN
+
+const char** flags_get_features();
+
+CPP_GUARD_END
+
+#endif /* _FLAGS_H_ */

--- a/platform/mk2/config.mk
+++ b/platform/mk2/config.mk
@@ -122,6 +122,7 @@ APP_SRC = 	$(APP_PATH)/main.c \
 			$(RCP_SRC)/util/str_util.c \
 			$(RCP_SRC)/util/taskUtil.c \
 			$(RCP_SRC)/sdcard/sdcard.c \
+			$(RCP_SRC)/system/flags.c \
 			$(HAL_SRC)/wifi_esp8266/wifi_esp8266_device.c \
 			$(HAL_SRC)/cell_device/cell_pwr_btn.c \
 			$(HAL_SRC)/gps_skytraq/gps_device_skytraq.c \
@@ -202,6 +203,7 @@ APP_INCLUDES += -I. \
 				-I$(INCLUDE_DIR)/command \
 				-I$(INCLUDE_DIR)/virtual_channel \
 				-I$(INCLUDE_DIR)/auto_config \
+				-I$(INCLUDE_DIR)/system \
 				-I$(HAL_SRC)/fat_sd_stm32/fatfs \
 				-I$(HAL_SRC)/fat_sd_stm32/fatfs/lo_level_ub \
 				-I$(HAL_SRC)/usb_stm32 \

--- a/platform/rct/Makefile
+++ b/platform/rct/Makefile
@@ -67,6 +67,10 @@ inc-y += $(RC_INCLUDE_DIR)/util
 src-y += $(wildcard $(RC_SRC_DIR)/serial/*.c)
 inc-y += $(RC_INCLUDE_DIR)/serial
 
+# system
+src-y += $(wildcard $(RC_SRC_DIR)/system/*.c)
+inc-y += $(RC_INCLUDE_DIR)/system
+
 src-y += $(wildcard $(RC_SRC_DIR)/usart/*.c)
 inc-y += $(RC_INCLUDE_DIR)/usart
 

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -31,6 +31,7 @@
 #include "constants.h"
 #include "cpu.h"
 #include "dateTime.h"
+#include "flags.h"
 #include "geopoint.h"
 #include "gps.h"
 #include "imu.h"
@@ -208,6 +209,16 @@ int api_getCapabilities(struct Serial *serial, const jsmntok_t *json)
 {
         json_objStart(serial);
         json_objStartString(serial,"capabilities");
+
+        /* Send all of our feature flags over the wire */
+        json_arrayStart(serial, "flags");
+        const char** flags = flags_get_features();
+        while (*flags) {
+                const char** next = flags + 1;
+                json_arrayElementString(serial, *flags, !!*next);
+                flags = next;
+        }
+        json_arrayEnd(serial, 1);
 
         json_objStartString(serial,"channels");
         json_int(serial, "analog", ANALOG_CHANNELS, 1);

--- a/src/system/flags.c
+++ b/src/system/flags.c
@@ -39,9 +39,9 @@
  * - gps Global Positioning Satellite support
  * - imu Inertia Measurement Unit support
  * - lua Lua scripting support
- * - pwmin Pulse width modulation measurement input support
- * - pwmout Pulsw width modulation generation output support
+ * - pwm Pulsw width modulation generation output support
  * - telemstream Supports telemetry streaming API
+ * - timer Timed pulse frequency measurement support
  * - tracks Track DB support
  * - usb USB connectivity support
  * - wifi WiFi support
@@ -71,13 +71,13 @@ static const char* feature_flags[] = {
 #if CAN_CHANNELS > 0
         FEATURE_FLAG("obd2")
 #endif
-#if TIMER_CHANNELS > 0
-        FEATURE_FLAG("pwmin")
-#endif
 #if PWM_CHANNELS > 0
-        FEATURE_FLAG("pwmout")
+        FEATURE_FLAG("pwm")
 #endif
         FEATURE_FLAG("telemstream")
+#if TIMER_CHANNELS > 0
+        FEATURE_FLAG("timer")
+#endif
 #if MAX_TRACKS > 0
         FEATURE_FLAG("tracks")
 #endif

--- a/src/system/flags.c
+++ b/src/system/flags.c
@@ -1,0 +1,93 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "capabilities.h"
+#include "flags.h"
+
+#define FEATURE_FLAG(flag)	flag,
+
+/**
+ * Denotes features supported on the given unit.  These features flags
+ * help the app determine what windows it should display in the config.
+ * Flags are always returned in alphabetical order and the list is always
+ * NULL terminated.
+ * Meanings:
+ * - activetrack Support setting the active track in non-volatile fashion
+ * - adc Analog to digital converter support
+ * - bt Bluetooth support
+ * - can CAN bus support
+ * - cell Cellular support
+ * - gpio General purose input/output support
+ * - gps Global Positioning Satellite support
+ * - imu Inertia Measurement Unit support
+ * - lua Lua scripting support
+ * - pwmin Pulse width modulation measurement input support
+ * - pwmout Pulsw width modulation generation output support
+ * - telemstream Supports telemetry streaming API
+ * - tracks Track DB support
+ * - usb USB connectivity support
+ * - wifi WiFi support
+ */
+static const char* feature_flags[] = {
+        FEATURE_FLAG("activetrack")
+#if ANALOG_CHANNELS > 0
+        FEATURE_FLAG("adc")
+#endif
+#if BLUETOOTH_SUPPORT > 0
+        FEATURE_FLAG("bt")
+#endif
+#if CAN_CHANNELS > 0
+        FEATURE_FLAG("can")
+#endif
+#if CELLULAR_SUPPORT
+        FEATURE_FLAG("cell")
+#endif
+#if GPIO_CHANNELS > 0
+        FEATURE_FLAG("gpio")
+#endif
+        FEATURE_FLAG("gps")
+        FEATURE_FLAG("imu")
+#if LUA_SUPPORT > 0
+        FEATURE_FLAG("lua")
+#endif
+#if PWM_CHANNELS > 0
+        FEATURE_FLAG("pwmin")
+#endif
+#if TIMER_CHANNELS > 0
+        FEATURE_FLAG("pwmout")
+#endif
+        FEATURE_FLAG("telemstream")
+#if MAX_TRACKS > 0
+        FEATURE_FLAG("tracks")
+#endif
+#if USB_SERIAL_SUPPORT > 0
+        FEATURE_FLAG("usb")
+#endif
+#if WIFI_SUPPORT > 0
+        FEATURE_FLAG("wifi")
+#endif
+        NULL, /* Always NULL terminated! */
+};
+
+const char** flags_get_features()
+{
+        return feature_flags;
+}

--- a/src/system/flags.c
+++ b/src/system/flags.c
@@ -68,10 +68,13 @@ static const char* feature_flags[] = {
 #if LUA_SUPPORT > 0
         FEATURE_FLAG("lua")
 #endif
-#if PWM_CHANNELS > 0
-        FEATURE_FLAG("pwmin")
+#if CAN_CHANNELS > 0
+        FEATURE_FLAG("obd2")
 #endif
 #if TIMER_CHANNELS > 0
+        FEATURE_FLAG("pwmin")
+#endif
+#if PWM_CHANNELS > 0
         FEATURE_FLAG("pwmout")
 #endif
         FEATURE_FLAG("telemstream")

--- a/test/Makefile
+++ b/test/Makefile
@@ -76,6 +76,7 @@ INCLUDES = \
 -I$(RCP_INC)/watchdog \
 -I$(RCP_INC)/memory \
 -I$(RCP_INC)/sdcard \
+-I$(RCP_INC)/system \
 -I$(RCP_INC)/lap_stats \
 -I$(MOCK_DIR) \
 -I$(GPS_DIR) \
@@ -212,6 +213,7 @@ $(RCP_SRC)/predictive_timer/predictive_timer_2.c \
 $(RCP_SRC)/serial/rx_buff.c \
 $(RCP_SRC)/serial/serial_buffer.c \
 $(RCP_SRC)/serial/serial.c \
+$(RCP_SRC)/system/flags.c \
 $(RCP_SRC)/timer/timer.c \
 $(RCP_SRC)/timer/timer_config.c \
 $(RCP_SRC)/tracks/tracks.c \


### PR DESCRIPTION
Flags tell the caller what features will be supported on the unit.
This allows us to selectively enable/disable windows in the app so
that the user only sees what they need to see.  This also allows us
to have the app be flexible as we add new features going forward while
retaining backwards compatibility as much as possible.

Issue #709