### PR TITLE
Fix minor irq handler bug in RCT USB stack

### DIFF
--- a/platform/rct/hal/usb_stm32/USB-CDC_device_stm32.c
+++ b/platform/rct/hal/usb_stm32/USB-CDC_device_stm32.c
@@ -121,19 +121,19 @@ static void usb_handle_transfer(void)
         portBASE_TYPE hpta = false;
         xQueueHandle queue = serial_get_tx_queue(usb_state.serial);
         uint8_t *buff = usb_state.USB_Tx_Buffer;
-        size_t len;
+        size_t len = 0;
 
-        for (len = 0; len < VIRTUAL_COM_PORT_DATA_SIZE; ++len)
+        for (; len < VIRTUAL_COM_PORT_DATA_SIZE; ++len)
                 if (!xQueueReceiveFromISR(queue, buff + len, &hpta))
                         break;
 
         /* Check if we actually have something to send */
-	if (0 == len)
-		return;
-
-	UserToPMABufferCopy(usb_state.USB_Tx_Buffer, ENDP1_TXADDR, len);
-	SetEPTxCount(ENDP1, len);
-	SetEPTxValid(ENDP1);
+	if (len) {
+                UserToPMABufferCopy(usb_state.USB_Tx_Buffer,
+                                    ENDP1_TXADDR, len);
+                SetEPTxCount(ENDP1, len);
+                SetEPTxValid(ENDP1);
+        }
 
         portEND_SWITCHING_ISR(hpta);
 }


### PR DESCRIPTION
There was a case where we may not properly wake up the FreeRTOS
scheduler in our send logic in USB.  This patch resolves that little bug.