### PR TITLE
IMU information in getStatus API

### DIFF
--- a/include/imu/imu_device.h
+++ b/include/imu/imu_device.h
@@ -29,6 +29,14 @@ CPP_GUARD_BEGIN
 
 void imu_device_init();
 
+enum imu_init_status {
+        IMU_INIT_STATUS_FAILED  = -1,
+        IMU_INIT_STATUS_UNINIT  =  0,
+        IMU_INIT_STATUS_SUCCESS =  1,
+};
+
+enum imu_init_status imu_device_init_status();
+
 int imu_device_read(enum imu_channel channel);
 
 float imu_device_counts_per_unit(enum imu_channel channel);

--- a/platform/mk2/hal/imu_stm32/imu_device_stm32.c
+++ b/platform/mk2/hal/imu_stm32/imu_device_stm32.c
@@ -21,6 +21,7 @@
 static struct is9150_all_sensor_data sensor_data[2];
 static struct is9150_all_sensor_data *read_buf = &sensor_data[0];
 static struct is9150_all_sensor_data *fill_buf = &sensor_data[1];
+static enum imu_init_status init_status;
 
 static void imu_update_buf_ptrs(void)
 {
@@ -47,6 +48,7 @@ static void imu_update_task(void *params)
 
     /* Clear the sensor data structures */
     memset(sensor_data, 0x00, sizeof(struct is9150_all_sensor_data) * 2);
+    init_status = 0 == res ? IMU_INIT_STATUS_SUCCESS : IMU_INIT_STATUS_FAILED;
 
     while(1) {
         res = is9150_read_all_sensors(fill_buf);
@@ -62,6 +64,11 @@ void imu_device_init()
         static const signed portCHAR task_name[] = "IMU Reader Task";
         xTaskCreate(imu_update_task, task_name, configMINIMAL_STACK_SIZE,
                     NULL, IMU_TASK_PRIORITY, NULL);
+}
+
+enum imu_init_status imu_device_init_status()
+{
+        return init_status;
 }
 
 int imu_device_read(enum imu_channel channel)

--- a/platform/rct/hal/imu_stm32/imu_device_stm32.c
+++ b/platform/rct/hal/imu_stm32/imu_device_stm32.c
@@ -42,6 +42,8 @@
 static struct is9150_all_sensor_data sensor_data[2];
 static struct is9150_all_sensor_data *read_buf = &sensor_data[0];
 static struct is9150_all_sensor_data *fill_buf = &sensor_data[1];
+static enum imu_init_status init_status;
+
 static void imu_update_buf_ptrs(void)
 {
     static struct is9150_all_sensor_data *tmp;
@@ -67,6 +69,7 @@ static void imu_update_task(void *params)
 
     /* Clear the sensor data structures */
     memset(sensor_data, 0x00, sizeof(struct is9150_all_sensor_data) * 2);
+    init_status = 0 == res ? IMU_INIT_STATUS_SUCCESS : IMU_INIT_STATUS_FAILED;
 
     while(1) {
         res = is9150_read_all_sensors(fill_buf);
@@ -82,6 +85,11 @@ void imu_device_init()
         static const signed portCHAR task_name[] = "IMU Reader Task";
         xTaskCreate(imu_update_task, task_name, configMINIMAL_STACK_SIZE,
                     NULL, IMU_TASK_PRIORITY, NULL);
+}
+
+enum imu_init_status imu_device_init_status()
+{
+        return init_status;
 }
 
 int imu_device_read(enum imu_channel channel)

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -268,7 +268,7 @@ int api_getCapabilities(struct Serial *serial, const jsmntok_t *json)
         return API_SUCCESS_NO_RETURN;
 }
 
-static void imu_status(struct Serial *serial, const bool more)
+static void get_imu_status(struct Serial *serial, const bool more)
 {
         const bool imu_init =
                 imu_device_init_status() == IMU_INIT_STATUS_SUCCESS;
@@ -339,7 +339,7 @@ int api_getStatus(struct Serial *serial, const jsmntok_t *json)
         json_int(serial, "armed", lc_is_armed(), 0);
         json_objEnd(serial, true);
 
-        imu_status(serial, false);
+        get_imu_status(serial, false);
 
         json_objEnd(serial, 0);
         json_objEnd(serial, 0);

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -35,6 +35,7 @@
 #include "geopoint.h"
 #include "gps.h"
 #include "imu.h"
+#include "imu_device.h"
 #include "lap_stats.h"
 #include "launch_control.h"
 #include "logger.h"
@@ -267,6 +268,16 @@ int api_getCapabilities(struct Serial *serial, const jsmntok_t *json)
         return API_SUCCESS_NO_RETURN;
 }
 
+static void imu_status(struct Serial *serial, const bool more)
+{
+        const bool imu_init =
+                imu_device_init_status() == IMU_INIT_STATUS_SUCCESS;
+
+        json_objStartString(serial, "imu");
+        json_bool(serial, "init", imu_init, false);
+        json_objEnd(serial, more);
+}
+
 int api_getStatus(struct Serial *serial, const jsmntok_t *json)
 {
         json_objStart(serial);
@@ -326,7 +337,9 @@ int api_getStatus(struct Serial *serial, const jsmntok_t *json)
         json_int(serial, "trackId", lapstats_get_selected_track_id(), 1);
         json_int(serial, "inLap", (int)lapstats_lap_in_progress(), 1);
         json_int(serial, "armed", lc_is_armed(), 0);
-        json_objEnd(serial, 0);
+        json_objEnd(serial, true);
+
+        imu_status(serial, false);
 
         json_objEnd(serial, 0);
         json_objEnd(serial, 0);

--- a/test/logger_mock/imu_device_mock.c
+++ b/test/logger_mock/imu_device_mock.c
@@ -45,3 +45,8 @@ float imu_device_counts_per_unit(unsigned int channel)
 {
     return (channel == IMU_CHANNEL_YAW ? YAW_DEVICE_COUNTS_PER_DEGREE_PER_SEC : ACCEL_DEVICE_COUNTS_PER_G);
 }
+
+enum imu_init_status imu_device_init_status()
+{
+        return IMU_INIT_STATUS_SUCCESS;
+}


### PR DESCRIPTION
Returns some very basic information about our IMU in the status API.
Currently only returns whether or not it is initialized.  This can
be expanded later as needed.

Issue #675