### PR TITLE
Add support for flexible boolean in Lua

### DIFF
--- a/include/lua/luaBaseBinding.h
+++ b/include/lua/luaBaseBinding.h
@@ -34,7 +34,8 @@ void lua_validate_arg_number(lua_State *l, const int idx);
 void lua_validate_arg_string(lua_State *l, const int idx);
 void lua_validate_arg_table(lua_State *l, const int idx);
 void lua_validate_arg_number_or_string(lua_State *l, const int idx);
-
+void lua_validate_arg_boolean_flex(lua_State *l, const int idx);
+bool lua_toboolean_flex(lua_State *l, const int idx);
 void registerBaseLuaFunctions(lua_State *L);
 
 CPP_GUARD_END

--- a/src/lua/luaBaseBinding.c
+++ b/src/lua/luaBaseBinding.c
@@ -145,6 +145,38 @@ void lua_validate_arg_table(lua_State *l, const int idx)
         luaL_error(l, buff);
 }
 
+/**
+ * Validates that the argument at idx is of boolean type or int type.  The
+ * intention here is that the value will be converted using lua_toboolean_flex.
+ * This method is a form of a stop gap until we can implement strong typing
+ * in our bindings to/from lua since we have used 0 and 1 in places where
+ * we should have been using false/true respectively.
+ */
+void lua_validate_arg_boolean_flex(lua_State *l, const int idx)
+{
+        if (lua_isboolean(l, idx) || lua_isnumber(l, idx))
+                return;
+
+        char buff[48];
+        sprintf(buff, "Expected boolean/int argument at position %d", idx);
+        luaL_error(l, buff);
+}
+
+/**
+ * Similar to the lua_toboolean method except this method will treat a value
+ * of 0 as false instead of true.  This is for legacy purposese since we have
+ * used 1 and 0 in place of true and false in our API respectively.
+ * @return false if false, nil, 0 or string that represent 0; true otherwise.
+ */
+bool lua_toboolean_flex(lua_State *l, const int idx)
+{
+	if (lua_isnumber(l, idx))
+		return 0 != lua_tonumber(l, idx);
+
+	return lua_toboolean(l, idx);
+}
+
+
 static int lua_sleep(lua_State *L)
 {
         lua_validate_args_count(L, 1, 1);

--- a/src/lua/luaLoggerBinding.c
+++ b/src/lua/luaLoggerBinding.c
@@ -466,10 +466,10 @@ static int lua_set_gpio(lua_State *L)
 {
         lua_validate_args_count(L, 2, 2);
         lua_validate_arg_number(L, 1);
-        lua_validate_arg_boolean(L, 2);
+        lua_validate_arg_boolean_flex(L, 2);
 
         const unsigned int channel = (unsigned int) lua_tointeger(L, 1);
-        const unsigned int state = (unsigned int) lua_toboolean(L, 2);
+        const unsigned int state = lua_toboolean_flex(L, 2);
         GPIO_set(channel, state);
         return 0;
 }
@@ -767,12 +767,13 @@ static int lua_set_led(lua_State *ls)
 {
         lua_validate_args_count(ls, 2, 2);
         lua_validate_arg_number_or_string(ls, 1);
+	lua_validate_arg_boolean_flex(ls, 2);
 
         /*
          * Numbers can be passed in as 123 or "123" in lua.  So handle
          * that case first
          */
-        const bool on = lua_toboolean(ls, 2);
+        volatile const bool on = lua_toboolean_flex(ls, 2);
         bool res;
         if (lua_isnumber(ls, 1)) {
                 res = led_set_index(lua_tointeger(ls, 1), on);


### PR DESCRIPTION
In some of our Lua API calls we are using 0 and 1 values where we
should really be using false and true values.  These include

* setGpio
* setLed

This patch adds some new methods to allow users to either specify a
boolean parameter or use the legacy behavior and specify a digit to be
interpreted as a boolean.  0 is false and everything else is true.

Issue #628