### PR TITLE
Float value for pulses per revolution

### DIFF
--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -536,7 +536,6 @@ unsigned short filterPwmDutyCycle(int dutyCycle);
 unsigned short filterPwmPeriod(int period);
 uint16_t filterPwmClockFrequency(uint16_t frequency);
 
-unsigned char filterPulsePerRevolution(unsigned char pulsePerRev);
 unsigned short filterTimerDivider(unsigned short divider);
 char filterTimerMode(int config);
 

--- a/include/timer/timer_config.h
+++ b/include/timer/timer_config.h
@@ -47,8 +47,8 @@ enum timer_edge {
 typedef struct _TimerConfig {
         ChannelConfig cfg;
         float filterAlpha;
+	float pulsePerRevolution;
         unsigned char mode;
-        unsigned char pulsePerRevolution;
         unsigned short timerSpeed;
         int filter_period_us;
         enum timer_edge edge;

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -1188,7 +1188,7 @@ static void sendTimerConfig(struct Serial *serial, size_t startIndex, size_t end
         json_uint(serial, "st", 0, 1);
         json_uint(serial, "mode", cfg->mode, 1);
         json_float(serial, "alpha", cfg->filterAlpha, FILTER_ALPHA_PRECISION, 1);
-        json_float(serial, "ppr", cfg->pulsePerRevolution, 2, 1);
+        json_float(serial, "ppr", cfg->pulsePerRevolution, 6, 1);
         json_uint(serial, "speed", cfg->timerSpeed, 1);
         json_int(serial, "filter_period", cfg->filter_period_us, 1);
         json_string(serial, "edge", get_timer_edge_api_key(cfg->edge), 0);

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -1165,8 +1165,7 @@ static const jsmntok_t * setTimerExtendedField(const jsmntok_t *valueTok,
     if (STR_EQ("alpha", name))
         timerCfg->filterAlpha = atof(value);
     if (STR_EQ("ppr", name))
-        timerCfg->pulsePerRevolution =
-                filterPulsePerRevolution(atoi(value));
+        timerCfg->pulsePerRevolution = atof(value);
     if (STR_EQ("speed", name))
         timerCfg->timerSpeed = filterTimerDivider(atoi(value));
     if (STR_EQ("filter_period", name))
@@ -1189,7 +1188,7 @@ static void sendTimerConfig(struct Serial *serial, size_t startIndex, size_t end
         json_uint(serial, "st", 0, 1);
         json_uint(serial, "mode", cfg->mode, 1);
         json_float(serial, "alpha", cfg->filterAlpha, FILTER_ALPHA_PRECISION, 1);
-        json_uint(serial, "ppr", cfg->pulsePerRevolution, 1);
+        json_float(serial, "ppr", cfg->pulsePerRevolution, 2, 1);
         json_uint(serial, "speed", cfg->timerSpeed, 1);
         json_int(serial, "filter_period", cfg->filter_period_us, 1);
         json_string(serial, "edge", get_timer_edge_api_key(cfg->edge), 0);

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -359,11 +359,6 @@ unsigned char filterSdLoggingMode(unsigned char mode)
 
 
 #if TIMER_CHANNELS > 0
-unsigned char filterPulsePerRevolution(unsigned char pulsePerRev)
-{
-    return pulsePerRev == 0 ? 1 : pulsePerRev;
-}
-
 unsigned short filterTimerDivider(unsigned short speed)
 {
     switch(speed) {

--- a/src/timer/timer.c
+++ b/src/timer/timer.c
@@ -44,8 +44,11 @@ static Filter g_timer_filter[CONFIG_TIMER_CHANNELS];
 static uint32_t calc_quiet_period(const TimerConfig *tc,
                                   const float period)
 {
+        const float ppr = tc->pulsePerRevolution;
+	if (!ppr)
+		return 0;
+
         const float max_rpm = tc->cfg.max;
-        const float ppr = (float) tc->pulsePerRevolution;
         const float max_hz = max_rpm * ppr * MAX_RPM_MULT / period;
 
         const uint32_t res = max_hz ? US_IN_A_SEC / max_hz : 0;
@@ -124,7 +127,10 @@ float timer_get_sample(const int cid)
                 return -1;
 
         TimerConfig *c = getWorkingLoggerConfig()->TimerConfigs + cid;
-        unsigned char ppr = c->pulsePerRevolution;
+        const float ppr = c->pulsePerRevolution;
+	if (0 == ppr)
+		return 0;
+
         switch (c->mode) {
         case MODE_LOGGING_TIMER_RPM:
                 return timer_get_rpm(cid) / ppr;

--- a/test/loggerApi_test.cpp
+++ b/test/loggerApi_test.cpp
@@ -641,7 +641,7 @@ void LoggerApiTest::testGetTimerConfigFile(string filename, int index){
 
 	timerCfg->mode = 2;
 	timerCfg->filterAlpha = 0.5F;
-	timerCfg->pulsePerRevolution = 3;
+	timerCfg->pulsePerRevolution = 3.1;
 	timerCfg->timerSpeed = 2;
 
 	const char *response = processApiGeneric(filename);
@@ -658,7 +658,8 @@ void LoggerApiTest::testGetTimerConfigFile(string filename, int index){
 	CPPUNIT_ASSERT_EQUAL(0, (int)(Number)timerJson["st"]); /* DEPRECATED */
 	CPPUNIT_ASSERT_EQUAL(2, (int)(Number)timerJson["mode"]);
 	CPPUNIT_ASSERT_EQUAL(0.5F, (float)(Number)timerJson["alpha"]);
-	CPPUNIT_ASSERT_EQUAL(3, (int)(Number)timerJson["ppr"]);
+	CPPUNIT_ASSERT_EQUAL(timerCfg->pulsePerRevolution,
+			     (float)(Number)timerJson["ppr"]);
 	CPPUNIT_ASSERT_EQUAL(2, (int)(Number)timerJson["speed"]);
 }
 
@@ -685,7 +686,7 @@ void LoggerApiTest::testSetTimerConfigFile(string filename){
 
 	CPPUNIT_ASSERT_EQUAL(1, (int)timerCfg->mode);
 	CPPUNIT_ASSERT_EQUAL(0.5F, timerCfg->filterAlpha);
-	CPPUNIT_ASSERT_EQUAL(4, (int)timerCfg->pulsePerRevolution);
+	CPPUNIT_ASSERT_EQUAL((float) 4, timerCfg->pulsePerRevolution);
 	CPPUNIT_ASSERT_EQUAL(2, (int)timerCfg->timerSpeed);
         CPPUNIT_ASSERT_EQUAL(-2, (int)timerCfg->filter_period_us);
         CPPUNIT_ASSERT_EQUAL(TIMER_EDGE_RISING, timerCfg->edge);


### PR DESCRIPTION
Not all pulse per revolution counts line up on whole numbers.
To account for that I have moved this value over to a float value
so that our users may specify arbitrary numbers for this.

I have also removed the filter check and instead added checks for
0 so that should a user pass in a value of 0 we will simply return
0 values and handle it accordingly.

Issue #470