### PR TITLE
Add strip feature to json setter; strip ssid and other values

### DIFF
--- a/include/jsmn/jsmn.h
+++ b/include/jsmn/jsmn.h
@@ -135,7 +135,8 @@ bool jsmn_exists_set_val_bool(const jsmntok_t* root, const char* field,
                               void* val);
 
 bool jsmn_exists_set_val_string(const jsmntok_t* root, const char* field,
-                                void* val, const size_t max_len);
+                                void* val, const size_t max_len,
+				const bool strip);
 
 CPP_GUARD_END
 

--- a/include/jsmn/jsmn.h
+++ b/include/jsmn/jsmn.h
@@ -135,7 +135,7 @@ bool jsmn_exists_set_val_bool(const jsmntok_t* root, const char* field,
                               void* val);
 
 bool jsmn_exists_set_val_string(const jsmntok_t* root, const char* field,
-                                void* val, const size_t max_len,
+				void* val, const size_t max_len,
 				const bool strip);
 
 CPP_GUARD_END

--- a/src/jsmn/jsmn.c
+++ b/src/jsmn/jsmn.c
@@ -367,56 +367,56 @@ const jsmntok_t * jsmn_find_get_node_value_prim(const jsmntok_t *node, const cha
 bool jsmn_exists_set_val_int(const jsmntok_t* root, const char* field,
                              void* val)
 {
-    const jsmntok_t *node = jsmn_find_get_node_value_prim(root, field);
+	const jsmntok_t *node = jsmn_find_get_node_value_prim(root, field);
 
-    if (!node)
-            return false;
+	if (!node)
+		return false;
 
-    int* value = val;
-    *value = atoi(node->data);
-    return true;
+	int* value = val;
+	*value = atoi(node->data);
+	return true;
 }
 
 bool jsmn_exists_set_val_float(const jsmntok_t* root, const char* field,
                                void* val)
 {
-    const jsmntok_t *node = jsmn_find_get_node_value_prim(root, field);
+	const jsmntok_t *node = jsmn_find_get_node_value_prim(root, field);
 
-    if (!node)
-            return false;
+	if (!node)
+		return false;
 
-    float* value = val;
-    *value = atof(node->data);
-    return true;
+	float* value = val;
+	*value = atof(node->data);
+	return true;
 }
 
 bool jsmn_exists_set_val_bool(const jsmntok_t* root, const char* field,
                               void* val)
 {
-    const jsmntok_t *node = jsmn_find_get_node_value_prim(root, field);
+	const jsmntok_t *node = jsmn_find_get_node_value_prim(root, field);
 
-    if (!node)
-            return false;
+	if (!node)
+		return false;
 
-    bool* value = val;
-    *value = STR_EQ("true", node->data);
-    return true;
+	bool* value = val;
+	*value = STR_EQ("true", node->data);
+	return true;
 }
 
 
 bool jsmn_exists_set_val_string(const jsmntok_t* root, const char* field,
-                                void* val, const size_t max_len,
+				void* val, const size_t max_len,
 				const bool strip)
 {
-    const jsmntok_t *node = jsmn_find_get_node_value_string(root, field);
+	const jsmntok_t *node = jsmn_find_get_node_value_string(root, field);
 
-    if (!node)
-            return false;
+	if (!node)
+		return false;
 
-    char* data = node->data;
-    if (strip)
-	    data = strip_inline(data);
+	char* data = node->data;
+	if (strip)
+		data = strip_inline(data);
 
-    strncpy(val, data, max_len);
-    return true;
+	strncpy(val, data, max_len);
+	return true;
 }

--- a/src/jsmn/jsmn.c
+++ b/src/jsmn/jsmn.c
@@ -21,6 +21,7 @@
 
 #include "jsmn.h"
 #include "macros.h"
+#include "str_util.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -404,13 +405,18 @@ bool jsmn_exists_set_val_bool(const jsmntok_t* root, const char* field,
 
 
 bool jsmn_exists_set_val_string(const jsmntok_t* root, const char* field,
-                                void* val, const size_t max_len)
+                                void* val, const size_t max_len,
+				const bool strip)
 {
     const jsmntok_t *node = jsmn_find_get_node_value_string(root, field);
 
     if (!node)
             return false;
 
-    strncpy(val, node->data, max_len);
+    char* data = node->data;
+    if (strip)
+	    data = strip_inline(data);
+
+    strncpy(val, data, max_len);
     return true;
 }

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -903,9 +903,12 @@ static void setCellConfig(const jsmntok_t *root)
         CellularConfig *cellCfg = &(getWorkingLoggerConfig()->ConnectivityConfigs.cellularConfig);
         cellCfgNode++;
         setUnsignedCharValueIfExists(cellCfgNode, "cellEn", &cellCfg->cellEnabled, NULL);
-        jsmn_exists_set_val_string(cellCfgNode, "apnHost", cellCfg->apnHost, CELL_APN_HOST_LENGTH);
-        jsmn_exists_set_val_string(cellCfgNode, "apnUser", cellCfg->apnUser, CELL_APN_USER_LENGTH);
-        jsmn_exists_set_val_string(cellCfgNode, "apnPass", cellCfg->apnPass, CELL_APN_PASS_LENGTH);
+        jsmn_exists_set_val_string(cellCfgNode, "apnHost", cellCfg->apnHost,
+				   CELL_APN_HOST_LENGTH, true);
+        jsmn_exists_set_val_string(cellCfgNode, "apnUser", cellCfg->apnUser,
+				   CELL_APN_USER_LENGTH, true);
+        jsmn_exists_set_val_string(cellCfgNode, "apnPass", cellCfg->apnPass,
+				   CELL_APN_PASS_LENGTH, false);
     }
 }
 
@@ -916,8 +919,10 @@ static void setBluetoothConfig(const jsmntok_t *root)
         btCfgNode++;
         BluetoothConfig *btCfg = &(getWorkingLoggerConfig()->ConnectivityConfigs.bluetoothConfig);
         setUnsignedCharValueIfExists(btCfgNode, "btEn", &btCfg->btEnabled, NULL);
-        jsmn_exists_set_val_string(btCfgNode, "name", btCfg->new_name, BT_DEVICE_NAME_LENGTH);
-        jsmn_exists_set_val_string(btCfgNode, "pass", btCfg->new_pin, BT_PASSCODE_LENGTH);
+        jsmn_exists_set_val_string(btCfgNode, "name", btCfg->new_name,
+				   BT_DEVICE_NAME_LENGTH, true);
+        jsmn_exists_set_val_string(btCfgNode, "pass", btCfg->new_pin,
+				   BT_PASSCODE_LENGTH, false);
     }
 }
 
@@ -927,9 +932,15 @@ static void setTelemetryConfig(const jsmntok_t *root)
     if (telemetryCfgNode) {
         telemetryCfgNode++;
         TelemetryConfig *telemetryCfg = &(getWorkingLoggerConfig()->ConnectivityConfigs.telemetryConfig);
-        jsmn_exists_set_val_string(telemetryCfgNode, "deviceId", telemetryCfg->telemetryDeviceId, DEVICE_ID_LENGTH);
-        jsmn_exists_set_val_string(telemetryCfgNode, "host", telemetryCfg->telemetryServerHost, TELEMETRY_SERVER_HOST_LENGTH);
-        setUnsignedCharValueIfExists(telemetryCfgNode, "bgStream", &telemetryCfg->backgroundStreaming, filterBgStreamingMode);
+        jsmn_exists_set_val_string(telemetryCfgNode, "deviceId",
+				   telemetryCfg->telemetryDeviceId,
+				   DEVICE_ID_LENGTH, true);
+        jsmn_exists_set_val_string(telemetryCfgNode, "host",
+				   telemetryCfg->telemetryServerHost,
+				   TELEMETRY_SERVER_HOST_LENGTH, true);
+        setUnsignedCharValueIfExists(telemetryCfgNode, "bgStream",
+				     &telemetryCfg->backgroundStreaming,
+				     filterBgStreamingMode);
     }
 }
 
@@ -1700,9 +1711,9 @@ static void set_wifi_client_cfg(const jsmntok_t *json,
 {
         jsmn_exists_set_val_bool(json, "active", &cfg->active);
         jsmn_exists_set_val_string(json, "ssid", cfg->ssid,
-                               ARRAY_LEN(cfg->ssid));
+				   ARRAY_LEN(cfg->ssid), true);
         jsmn_exists_set_val_string(json, "password", cfg->passwd,
-                               ARRAY_LEN(cfg->passwd));
+				   ARRAY_LEN(cfg->passwd), false);
 
         /* Inform the Wifi device that settings may have changed */
         wifi_update_client_config(cfg);
@@ -1716,14 +1727,14 @@ static bool set_wifi_ap_cfg(const jsmntok_t *json,
 
         jsmn_exists_set_val_bool(json, "active", &tmp_cfg.active);
         jsmn_exists_set_val_string(json, "ssid", tmp_cfg.ssid,
-                               ARRAY_LEN(tmp_cfg.ssid));
+				   ARRAY_LEN(tmp_cfg.ssid), true);
         jsmn_exists_set_val_string(json, "password", tmp_cfg.password,
-                               ARRAY_LEN(tmp_cfg.password));
+				   ARRAY_LEN(tmp_cfg.password), false);
         jsmn_exists_set_val_int(json, "channel", (int*) &tmp_cfg.channel);
 
         char enc_str[12];
         jsmn_exists_set_val_string(json, "encryption", enc_str,
-                               ARRAY_LEN(enc_str));
+				   ARRAY_LEN(enc_str), true);
         tmp_cfg.encryption = wifi_api_get_encryption_enum_val(enc_str);
 
         if (!wifi_validate_ap_config(&tmp_cfg)) {


### PR DESCRIPTION
Now we can strip user input of whitespace if needed.  This is wise
since whitespace is not valid in several places.  This change adds
that support along with supporting stripping of SSID values for wifi.

Issue #728