### PR TITLE
Support Higher WiFi Baud Rate; Improve Init Process

### DIFF
--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -36,6 +36,8 @@ CPP_GUARD_BEGIN
 #define ESP8266_IPV4_LEN_MAX	16
 #define ESP8266_PASSWD_LEN_MAX	24
 
+bool esp8266_setup(struct Serial *s, const size_t max_cmd_len);
+
 void esp8266_do_loop(const size_t timeout);
 
 /**
@@ -86,8 +88,7 @@ bool esp8266_register_callbacks(const struct esp8266_event_hooks* hooks);
 
 typedef void esp8266_init_cb_t(const bool status);
 
-bool esp8266_init(struct Serial *s, const size_t max_cmd_len,
-                  esp8266_init_cb_t* cb);
+bool esp8266_init(esp8266_init_cb_t* cb);
 
 enum dev_init_state esp8266_get_dev_init_state();
 

--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -31,10 +31,14 @@
 
 CPP_GUARD_BEGIN
 
-#define ESP8266_SSID_LEN_MAX	24
-#define ESP8266_MAC_LEN_MAX	18
-#define ESP8266_IPV4_LEN_MAX	16
-#define ESP8266_PASSWD_LEN_MAX	24
+#define ESP8266_SSID_LEN_MAX		24
+#define ESP8266_MAC_LEN_MAX		18
+#define ESP8266_IPV4_LEN_MAX		16
+#define ESP8266_PASSWD_LEN_MAX		24
+#define ESP8266_SERIAL_DEF_BAUD		115200
+#define ESP8266_SERIAL_DEF_BITS		8
+#define ESP8266_SERIAL_DEF_PARITY	0
+#define ESP8266_SERIAL_DEF_STOP		1
 
 bool esp8266_setup(struct Serial *s, const size_t max_cmd_len);
 
@@ -201,6 +205,7 @@ bool esp8266_set_uart_config(const size_t baud, const size_t bits,
 			     const size_t parity, const size_t stop_bits,
 			     esp8266_set_uart_config_cb_t* cb);
 
+bool esp8266_probe_device(struct Serial* serial, const int fast_baud);
 
 CPP_GUARD_END
 

--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -40,15 +40,12 @@ bool esp8266_setup(struct Serial *s, const size_t max_cmd_len);
 
 void esp8266_do_loop(const size_t timeout);
 
-/**
- * The various initialization states of the device.  Probably should
- * get put in a more generic file.  Here is good for now.
- */
+bool esp8266_set_default_serial_params(struct Serial* serial);
+
 enum dev_init_state {
-        DEV_INIT_STATE_NOT_READY = 0,
-        DEV_INIT_INITIALIZING,
-        DEV_INIT_STATE_READY,
-        DEV_INIT_STATE_FAILED,
+	DEV_INIT_STATE_FAILED	 = -1,
+	DEV_INIT_STATE_NOT_READY =  0,
+	DEV_INIT_STATE_READY	 =  1,
 };
 
 /**
@@ -197,10 +194,6 @@ enum esp8266_server_action {
 
 bool esp8266_server_cmd(const enum esp8266_server_action action, int port,
                         void (*cb)(bool));
-
-typedef void esp8266_soft_reset_cb_t(const bool status);
-
-bool esp8266_soft_reset(esp8266_soft_reset_cb_t* cb);
 
 typedef void esp8266_set_uart_config_cb_t(const bool status);
 

--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -33,6 +33,7 @@ CPP_GUARD_BEGIN
 
 #define ESP8266_SSID_LEN_MAX		24
 #define ESP8266_MAC_LEN_MAX		18
+#define ESP8266_INIT_TIMEOUT_MS		4000
 #define ESP8266_IPV4_LEN_MAX		16
 #define ESP8266_PASSWD_LEN_MAX		24
 #define ESP8266_SERIAL_DEF_BAUD		115200
@@ -206,6 +207,8 @@ bool esp8266_set_uart_config(const size_t baud, const size_t bits,
 			     esp8266_set_uart_config_cb_t* cb);
 
 bool esp8266_probe_device(struct Serial* serial, const int fast_baud);
+
+bool esp8266_wait_for_ready(struct Serial* serial);
 
 CPP_GUARD_END
 

--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -201,6 +201,13 @@ typedef void esp8266_soft_reset_cb_t(const bool status);
 
 bool esp8266_soft_reset(esp8266_soft_reset_cb_t* cb);
 
+typedef void esp8266_set_uart_config_cb_t(const bool status);
+
+bool esp8266_set_uart_config(const size_t baud, const size_t bits,
+			     const size_t parity, const size_t stop_bits,
+			     esp8266_set_uart_config_cb_t* cb);
+
+
 CPP_GUARD_END
 
 #endif /* _ESP8266_H_ */

--- a/include/modem/at_basic.h
+++ b/include/modem/at_basic.h
@@ -29,6 +29,9 @@
 
 CPP_GUARD_BEGIN
 
+bool at_basic_wait_for_msg(struct Serial* serial, const char* msg,
+			   const size_t delay_ms);
+
 bool at_basic_ping(struct Serial* serial, const size_t tries,
 		   const size_t delay_ms);
 

--- a/include/modem/at_basic.h
+++ b/include/modem/at_basic.h
@@ -1,0 +1,43 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _AT_BASIC_H_
+#define _AT_BASIC_H_
+
+#include "cpp_guard.h"
+#include "serial.h"
+#include <stdbool.h>
+#include <stddef.h>
+
+CPP_GUARD_BEGIN
+
+bool at_basic_ping(struct Serial* serial, const size_t tries,
+		   const size_t delay_ms);
+
+int at_basic_probe(struct Serial* serial, const int bauds[],
+		   const size_t tries, const size_t delay,
+		   const size_t msg_bits, const size_t parity,
+		   const size_t stop_bits);
+
+CPP_GUARD_END
+
+
+#endif /* _AT_BASIC_H_ */

--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -32,6 +32,13 @@
 
 CPP_GUARD_BEGIN
 
+struct serial_cfg {
+	size_t baud;
+	size_t data_bits;
+	size_t parity_bits;
+	size_t stop_bits;
+};
+
 /**
  * The callback that gets fired when a user attempts to configure a
  * serial device.
@@ -87,7 +94,7 @@ const char* serial_get_name(struct Serial *s);
 void serial_init(struct Serial *s, unsigned int bits, unsigned int parity,
                  unsigned int stopBits, unsigned int baud);
 
-bool serial_config(const struct Serial *s, const size_t bits,
+bool serial_config(struct Serial *s, const size_t bits,
                    const size_t parity, const size_t stop_bits,
                    const size_t baud);
 
@@ -136,6 +143,8 @@ typedef int serial_ioctl_cb_t(struct Serial *s, unsigned long req,
 void serial_set_ioctl_cb(struct Serial *s, serial_ioctl_cb_t* cb);
 
 int serial_ioctl(struct Serial *s, unsigned long req, void* argp);
+
+const struct serial_cfg* serial_get_config(const struct Serial* s);
 
 int put_int(struct Serial * serial, int n);
 

--- a/platform/mk2/capabilities.h
+++ b/platform/mk2/capabilities.h
@@ -16,6 +16,9 @@
 #define VIRTUAL_CHANNEL_SUPPORT	1
 #define WIFI_SUPPORT		1
 
+/* Wifi Specific Info */
+#define WIFI_MAX_BAUD	230400
+
 /* Configuration */
 #define MAX_TRACKS	240
 #define MAX_SECTORS	20

--- a/platform/mk2/config.mk
+++ b/platform/mk2/config.mk
@@ -108,6 +108,7 @@ APP_SRC = 	$(APP_PATH)/main.c \
 			$(RCP_SRC)/auto_config/auto_track.c \
 			$(RCP_SRC)/messaging/messaging.c \
 			$(RCP_SRC)/modem/at.c \
+			$(RCP_SRC)/modem/at_basic.c \
 			$(RCP_SRC)/LED/led.c \
 			$(RCP_SRC)/PWM/PWM.c \
 			$(RCP_SRC)/logging/printk.c \

--- a/platform/rct/capabilities.h
+++ b/platform/rct/capabilities.h
@@ -17,6 +17,9 @@
 #define VIRTUAL_CHANNEL_SUPPORT	0
 #define WIFI_SUPPORT		1
 
+/* Wifi Specific Info */
+#define WIFI_MAX_BAUD	921600
+
 /* Configuration */
 #define MAX_TRACKS	5
 #define MAX_SECTORS	20

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -628,7 +628,7 @@ static void set_fast_baud_cb(const bool status)
 	cmd_completed();
 	cmd_set_check(CHECK_WIFI_DEVICE);
 
-	if (status) {
+	if (!status) {
 		pr_warning(LOG_PFX "Set uart mode failed!\r\n");
 		return;
 	}

--- a/src/modem/at.c
+++ b/src/modem/at.c
@@ -181,27 +181,31 @@ static bool _process_msg_generic(struct at_info *ati,
 
 static void process_urc_msg(struct at_info *ati, char *msg)
 {
-        const bool no_strip = ati->urc_ip->flags & AT_URC_FLAGS_NO_RSTRIP;
-        if (!no_strip)
-                msg = rstrip_inline(msg);
+	const bool no_strip = ati->urc_ip->flags & AT_URC_FLAGS_NO_RSTRIP;
+	if (!no_strip) {
+		const size_t msg_len = serial_msg_strlen(msg);
+		msg[msg_len] = '\0';
+	}
 
-        _process_msg_generic(ati, AT_RX_STATE_URC, msg);
+	_process_msg_generic(ati, AT_RX_STATE_URC, msg);
 
-        const bool no_status = !!(ati->urc_ip->flags & AT_URC_FLAGS_NO_RSP_STATUS);
-        enum at_rsp_status status = AT_RSP_STATUS_NONE;
-        if (no_status || is_rsp_status(&status, msg))
-                complete_urc(ati, status);
+	const bool no_status = !!(ati->urc_ip->flags & AT_URC_FLAGS_NO_RSP_STATUS);
+	enum at_rsp_status status = AT_RSP_STATUS_NONE;
+	if (no_status || is_rsp_status(&status, msg))
+		complete_urc(ati, status);
 }
 
 static void process_cmd_msg(struct at_info *ati, char *msg)
 {
-        /* We always strip trialing message characters on cmd messages */
-        msg = rstrip_inline(msg);
-        _process_msg_generic(ati, AT_RX_STATE_CMD, msg);
+	/* We always strip trialing message characters on cmd messages */
+	const size_t msg_len = serial_msg_strlen(msg);
+	msg[msg_len] = '\0';
 
-        enum at_rsp_status status;
-        if (is_rsp_status(&status, msg))
-                complete_cmd(ati, status);
+	_process_msg_generic(ati, AT_RX_STATE_CMD, msg);
+
+	enum at_rsp_status status;
+	if (is_rsp_status(&status, msg))
+		complete_cmd(ati, status);
 }
 
 static void begin_urc_msg(struct at_info *ati, struct at_urc *urc)

--- a/src/modem/at_basic.c
+++ b/src/modem/at_basic.c
@@ -1,0 +1,86 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "at_basic.h"
+#include "macros.h"
+#include "serial.h"
+#include "str_util.h"
+#include <stdbool.h>
+#include <stddef.h>
+
+#define MAX_AT_REPLY_READS	10
+#define PROBE_PING_ATTEMPTS	3
+#define PROBE_PING_DELAY_MS	100
+
+/**
+ * Sends a basic Ping command to the device and waits for a reply.
+ * @param serial The serial device.
+ * @param tries The number of timest to ping before giving up.
+ * @param delay_ms The time to wait for each ping in ms before giving up.
+ */
+bool at_basic_ping(struct Serial* serial, const size_t tries,
+		   const size_t delay_ms)
+{
+	char buff[16];
+	const char cmd[] = "AT\r\n";
+	const size_t len = ARRAY_LEN(buff) - 1;
+
+	for (size_t try = 0; try < tries; ++try) {
+		serial_flush(serial);
+		serial_put_s(serial, cmd);
+
+		for (size_t reads = MAX_AT_REPLY_READS;
+		     reads && serial_get_line_wait(serial, buff, len, delay_ms);
+		     --reads) {
+			const char* msg = strip_inline(buff);
+			if (STR_EQ("OK", msg))
+				return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Probes a Serial port for a device that will respond to the basic
+ * AT command.
+ * @param Serial The serial device
+ * @param bauds A NULL terminated list of baud rates.
+ * @param tries The number of tries per baud rate before giving up.
+ * @param delay_ms The time we wait in ms for a response before giving up.
+ * @param msg_bits Serial configuration of # of bits per message
+ * @param parity 0 - Even parity, 1 - odd parity.
+ * @param stop_bits Number of stop bits per message.
+ * @return The baud rate that the device responded to. 0 if no response.
+ */
+int at_basic_probe(struct Serial* serial, const int bauds[],
+		   const size_t tries, const size_t delay_ms,
+		   const size_t msg_bits, const size_t parity,
+		   const size_t stop_bits)
+{
+	for (const int* baud = bauds; bauds && *baud; ++baud) {
+		serial_config(serial, msg_bits, parity, stop_bits, *baud);
+		if (at_basic_ping(serial, tries, delay_ms))
+			return *baud;
+	}
+
+	return 0;
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -213,6 +213,7 @@ $(RCP_SRC)/logger/versionInfo.c \
 $(RCP_SRC)/logging/printk.c \
 $(RCP_SRC)/lua/luaScript.c \
 $(RCP_SRC)/memory/memory.c \
+$(RCP_SRC)/modem/at_basic.c \
 $(RCP_SRC)/predictive_timer/predictive_timer_2.c \
 $(RCP_SRC)/serial/rx_buff.c \
 $(RCP_SRC)/serial/serial_buffer.c \

--- a/test/capabilities.h
+++ b/test/capabilities.h
@@ -45,6 +45,8 @@ CPP_GUARD_BEGIN
 #define MAX_TRACKS				240
 #define MAX_SECTORS				20
 #define MAX_VIRTUAL_CHANNELS	10
+
+#define WIFI_MAX_BAUD	921600
 /*
  * What is the maximum number of samples available per predictive time
  * buffer.  More samples == better resolution. Each slot is 12 bytes.


### PR DESCRIPTION
Initially I just wanted to add support for a faster baud rate for the WiFi device.  However after completing a working prototype I ran into many many issues with how the wifi init system worked and frankly determined that it was broken and needed to be fixed before this baud rate change could go in.  Thus why this patch is so very large.

This PR does two things.  One is that it makes our Wifi init process sane.  By sane I mean we guarantee that we will always get back to a useable and readable state after a reset (either soft or hard) and that we can find a Wifi device at all times using a basic serial connection if we know the baud rates it could be at.

Then we added support for incrementing the baud rate to the maximum supported value possible.  In doing so I encountered a bug in the esp8266 subsystem where the uart change message doesn't always return the final `\n` character in its ack reply.  This exposed a need to change how we handle stripping of messages in the AT subsys.

Issue #684 