### PR TITLE
Move to CGREG command from CREG command

### DIFF
--- a/src/gsm/gsm.c
+++ b/src/gsm/gsm.c
@@ -156,15 +156,15 @@ bool gsm_get_imei(struct serial_buffer *sb,
 enum cellular_net_status gsm_get_network_reg_status(
         struct serial_buffer *sb, struct cellular_info *ci)
 {
-        const char *cmd = "AT+CREG?";
+        const char *cmd = "AT+CGREG?";
         const char *msgs[2];
         const size_t msgs_len = ARRAY_LEN(msgs);
-        const char *answrs[] = {"+CREG: 0,0",
-                                "+CREG: 0,1",
-                                "+CREG: 0,2",
-                                "+CREG: 0,3",
-                                "+CREG: 0,4",
-                                "+CREG: 0,5"};
+        const char *answrs[] = {"+CGREG: 0,0",
+                                "+CGREG: 0,1",
+                                "+CGREG: 0,2",
+                                "+CGREG: 0,3",
+                                "+CGREG: 0,4",
+                                "+CGREG: 0,5"};
         const size_t answrs_len = ARRAY_LEN(answrs);
 
         serial_buffer_reset(sb);


### PR DESCRIPTION
After in-depth conversation with our friends at U-Blox we learned
that CREG is a registration command that does more than just GPRS.
It also covers registration of voice services. While this is ok in
many cases it likely will not work with some data-only sims because
they have no voice capabilities and the MNO may configure the SIM to
disallow any registration of voice services (which is logical).

So instead of checking if voice services are registered, this command
will only check if GPRS services are registered.  From there if we
are registered then we can activate a PDP context through the APN.
Hopefully this will add the ability to use more data-only sims as
they become more prevelant.

Issue #742