### PR TITLE
Add support for non read modify write operations to flash

### DIFF
--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -27,12 +27,12 @@
 #include "channel_config.h"
 #include "cpp_guard.h"
 #include "geopoint.h"
+#include "macros.h"
 #include "serial_device.h"
 #include "timer_config.h"
 #include "tracks.h"
 #include "versionInfo.h"
 #include "wifi.h"
-
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -460,62 +460,60 @@ struct logging_config {
         enum serial_log_type serial[__SERIAL_COUNT];
 };
 
-typedef struct _LoggerConfig {
-    VersionInfo RcpVersionInfo;
+typedef struct ALIGNED_WORD _LoggerConfig {
+	VersionInfo RcpVersionInfo;
 
-    //PWM/Analog out configurations
-    unsigned short PWMClockFrequency;
+	//PWM/Analog out configurations
+	unsigned short PWMClockFrequency;
 
-    // Time Config
-    struct TimeConfig TimeConfigs[CONFIG_TIME_CHANNELS];
+	// Time Config
+	struct TimeConfig TimeConfigs[CONFIG_TIME_CHANNELS];
 
-    //ADC Calibrations
+	//ADC Calibrations
 #if ANALOG_CHANNELS > 0
-    ADCConfig ADCConfigs[CONFIG_ADC_CHANNELS];
+	ADCConfig ADCConfigs[CONFIG_ADC_CHANNELS];
 #endif
 
 #if PWM_CHANNELS > 0
-    //PWM configuration
-    PWMConfig PWMConfigs[CONFIG_PWM_CHANNELS];
+	//PWM configuration
+	PWMConfig PWMConfigs[CONFIG_PWM_CHANNELS];
 #endif
 
 #if GPIO_CHANNELS > 0
-    //GPIO configurations
-    GPIOConfig GPIOConfigs[CONFIG_GPIO_CHANNELS];
+	//GPIO configurations
+	GPIOConfig GPIOConfigs[CONFIG_GPIO_CHANNELS];
 #endif
 
 #if TIMER_CHANNELS > 0
-    //Timer Configurations
-    TimerConfig TimerConfigs[CONFIG_TIMER_CHANNELS];
+	//Timer Configurations
+	TimerConfig TimerConfigs[CONFIG_TIMER_CHANNELS];
 #endif
 
 #if IMU_CHANNELS > 0
-    //IMU Configurations
-    ImuConfig ImuConfigs[CONFIG_IMU_CHANNELS];
+	//IMU Configurations
+	ImuConfig ImuConfigs[CONFIG_IMU_CHANNELS];
 #endif
 
-    //CAN Configuration
-    CANConfig CanConfig;
+	//CAN Configuration
+	CANConfig CanConfig;
 
-    //OBD2 Config
-    OBD2Config OBD2Configs;
+	//OBD2 Config
+	OBD2Config OBD2Configs;
 
-    //GPS Configuration
-    GPSConfig GPSConfigs;
+	//GPS Configuration
+	GPSConfig GPSConfigs;
 
-    //Lap Configuration
-    LapConfig LapConfigs;
+	//Lap Configuration
+	LapConfig LapConfigs;
 
-    //Track configuration
-    TrackConfig TrackConfigs;
+	//Track configuration
+	TrackConfig TrackConfigs;
 
-    //Connectivity Configuration
-    ConnectivityConfig ConnectivityConfigs;
+	//Connectivity Configuration
+	ConnectivityConfig ConnectivityConfigs;
 
         struct logging_config logging_cfg;
         struct auto_logger_config auto_logger_cfg;
-    //Padding data to accommodate flash routine
-    char padding_data[FLASH_PAGE_SIZE];
 } LoggerConfig;
 
 

--- a/include/logger/versionInfo.h
+++ b/include/logger/versionInfo.h
@@ -23,7 +23,7 @@
 #define VERSIONINFO_H_
 
 #include "cpp_guard.h"
-
+#include "macros.h"
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -35,7 +35,7 @@ enum release_type {
         RELEASE_TYPE_OFFICIAL,
 };
 
-typedef struct _VersionInfo {
+typedef struct ALIGNED_WORD _VersionInfo {
         uint32_t major;
         uint32_t minor;
         uint32_t bugfix;

--- a/include/lua/luaScript.h
+++ b/include/lua/luaScript.h
@@ -24,6 +24,7 @@
 
 #include "cpp_guard.h"
 #include "capabilities.h"
+#include "macros.h"
 #include "memory.h"
 
 #include <stdint.h>
@@ -46,9 +47,9 @@ enum script_add_mode {
 #define SCRIPT_PAGE_SIZE	256
 #define MAX_SCRIPT_PAGES	(SCRIPT_MEMORY_LENGTH / SCRIPT_PAGE_SIZE)
 
-typedef struct _ScriptConfig {
-        uint32_t magicInit;
-        char script[SCRIPT_MEMORY_LENGTH - 4];
+typedef struct ALIGNED_WORD _ScriptConfig {
+	uint32_t magicInit;
+	char script[SCRIPT_MEMORY_LENGTH - 4];
 } ScriptConfig;
 
 void initialize_script();

--- a/include/memory/memory.h
+++ b/include/memory/memory.h
@@ -27,11 +27,13 @@
 CPP_GUARD_BEGIN
 
 enum memory_flash_result_t {
-    MEMORY_FLASH_SUCCESS = 0,
-    MEMORY_FLASH_WRITE_ERROR = -1
+	MEMORY_FLASH_SUCCESS = 0,
+	MEMORY_FLASH_WRITE_ERROR = -1
 };
 
-enum memory_flash_result_t memory_flash_region(const void *vAddress, const void *vData, unsigned int length);
+enum memory_flash_result_t memory_flash_region(const volatile void *vAddress,
+					       const void *vData,
+					       unsigned int length);
 
 CPP_GUARD_END
 

--- a/include/memory/memory_device.h
+++ b/include/memory/memory_device.h
@@ -24,10 +24,19 @@
 
 #include "cpp_guard.h"
 #include "memory.h"
+#include <stdbool.h>
+#include <stddef.h>
 
 CPP_GUARD_BEGIN
 
-enum memory_flash_result_t memory_device_flash_region(const void *vAddress, const void *vData, unsigned int length);
+bool memory_device_region_clear(const volatile void *address);
+
+int memory_device_write_words(const volatile void* address, const void* data,
+			      const size_t len);
+
+enum memory_flash_result_t memory_device_flash_region(const volatile void *vAddress,
+						      const void *vData,
+						      unsigned int length);
 
 CPP_GUARD_END
 

--- a/include/tracks/tracks.h
+++ b/include/tracks/tracks.h
@@ -24,6 +24,7 @@
 
 #include "cpp_guard.h"
 #include "capabilities.h"
+#include "macros.h"
 #include "geopoint.h"
 #include "stddef.h"
 #include "versionInfo.h"
@@ -65,7 +66,11 @@ typedef struct _Stage {
     GeoPoint sectors[STAGE_SECTOR_COUNT];
 } Stage;
 
-typedef struct _Track {
+/*
+ * The ALIGNED_WORD attributes are present to ensure that the values
+ * are always word
+ */
+typedef struct ALIGNED_WORD _Track {
     int32_t trackId;
     enum TrackType track_type;
     union {
@@ -75,10 +80,10 @@ typedef struct _Track {
     };
 } Track;
 
-typedef struct _Tracks {
-    VersionInfo versionInfo;
-    size_t count;
-    Track tracks[MAX_TRACK_COUNT];
+typedef struct ALIGNED_WORD _Tracks {
+    ALIGNED_WORD VersionInfo versionInfo;
+    ALIGNED_WORD size_t count;
+    ALIGNED_WORD Track tracks[MAX_TRACK_COUNT];
 } Tracks;
 
 void initialize_tracks();

--- a/include/util/macros.h
+++ b/include/util/macros.h
@@ -23,7 +23,7 @@
 #define _MACROS_H_
 
 #include "cpp_guard.h"
-
+#include <stdint.h>
 #include <string.h>
 
 CPP_GUARD_BEGIN
@@ -47,6 +47,11 @@ CPP_GUARD_BEGIN
  * Chooses the minimum of two values.
  */
 #define MIN(a,b) (((a)<(b))?(a):(b))
+
+/**
+ * Ensures the parameter is aligned to a word boundary and size.
+ */
+#define ALIGNED_WORD __attribute__((aligned(sizeof(uint32_t))))
 
 CPP_GUARD_END
 

--- a/platform/mk2/hal/memory_stm32/memory_device_stm32.c
+++ b/platform/mk2/hal/memory_stm32/memory_device_stm32.c
@@ -1,64 +1,132 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "macros.h"
 #include "memory_device.h"
+#include "printk.h"
 #include "stm32f4xx_flash.h"
+#include <stddef.h>
 
-#define MEMORY_PAGE_SIZE	2048
+static const struct sector_info {
+	void* addr;
+	size_t size;
+	uint32_t sector;
+} flash_sectors[] = {
+	{(void*) 0x08004000, 16384, FLASH_Sector_1},
+	{(void*) 0x08008000, 16384, FLASH_Sector_2},
+	{(void*) 0x0800C000, 16384, FLASH_Sector_3},
+	{(void*) 0x08010000, 65536, FLASH_Sector_4},
+};
 
-/* Base @ of Sector 0, 16 Kbytes */
-#define ADDR_FLASH_SECTOR_0 ((uint32_t)0x08000000)
-/* Base @ of Sector 1, 16 Kbytes */
-#define ADDR_FLASH_SECTOR_1 ((uint32_t)0x08004000)
-/* Base @ of Sector 2, 16 Kbytes */
-#define ADDR_FLASH_SECTOR_2 ((uint32_t)0x08008000)
-/* Base @ of Sector 3, 16 Kbytes */
-#define ADDR_FLASH_SECTOR_3 ((uint32_t)0x0800C000)
-/* Base @ of Sector 4, 64 Kbytes */
-#define ADDR_FLASH_SECTOR_4 ((uint32_t)0x08010000)
-
-static uint32_t selectFlashSector(const void *address)
+static const struct sector_info* get_flash_sector(
+	const volatile void* const addr)
 {
-    uint32_t addr = (uint32_t) address;
-    //we don't support writing flash sector 0 since that's where the bootloader lives.
-    switch (addr) {
-    case ADDR_FLASH_SECTOR_1:
-        return FLASH_Sector_1;
-    case ADDR_FLASH_SECTOR_2:
-        return FLASH_Sector_2;
-    case ADDR_FLASH_SECTOR_3:
-        return FLASH_Sector_3;
-    case ADDR_FLASH_SECTOR_4:
-        return FLASH_Sector_4;
-    default:
-        return 0;
-    }
+	for (size_t i = 0; i < ARRAY_LEN(flash_sectors); ++i) {
+		const struct sector_info* si = flash_sectors + i;
+		if (si->addr <= addr && addr < si->addr + si->size)
+			return si;
+	}
+
+	pr_warning("Failed to find flash sector\r\n");
+	return NULL;
 }
 
-enum memory_flash_result_t memory_device_flash_region(const void *address, const void *data,
-        unsigned int length)
+/**
+ * Clears the entirety of a region of flash.
+ * @param addr The address of any byte within the region of flash.
+ */
+bool memory_device_region_clear(const volatile void *addr)
 {
+	const struct sector_info* si = get_flash_sector(addr);
+	if (!si)
+		return false;
 
-    enum memory_flash_result_t rc = MEMORY_FLASH_SUCCESS;
-    /* Erase the entire page before you can write.  This filters
-     * the incoming addresses to available flash pages for the STM32F4 */
-    uint32_t flashSector = selectFlashSector(address);
-    if (flashSector) {
-        FLASH_Unlock();
-        FLASH_ClearFlag(FLASH_FLAG_EOP | FLASH_FLAG_OPERR |
-                        FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR |
-                        FLASH_FLAG_PGPERR | FLASH_FLAG_PGSERR);
-        FLASH_EraseSector(flashSector, VoltageRange_3);
+	FLASH_Unlock();
+	FLASH_ClearFlag(FLASH_FLAG_EOP | FLASH_FLAG_OPERR |
+			FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR |
+			FLASH_FLAG_PGPERR | FLASH_FLAG_PGSERR);
 
-        uint32_t addrTarget = (uint32_t) address;
-        uint8_t *dataTarget = (uint8_t *) data;
+	const FLASH_Status fs = FLASH_EraseSector(si->sector, VoltageRange_3);
 
-        for (unsigned int i = 0; i < length; i++) {
-            if (FLASH_ProgramByte(addrTarget + i, *(dataTarget + i)) != FLASH_COMPLETE) {
-                rc = MEMORY_FLASH_WRITE_ERROR;
-                break;
-            }
-        }
-        FLASH_Lock();
-    } else {
-        rc = MEMORY_FLASH_WRITE_ERROR;
-    }
-    return rc;
+	FLASH_Lock();
+
+	if (FLASH_COMPLETE != fs) {
+		pr_warning_int_msg("Failed to erase sector ",
+				   (uint32_t) si->addr);
+		pr_warning_int_msg("Error code: ", (int) fs);
+		return false;
+	}
+
+	return true;
+}
+
+
+/**
+ * Writes bits to a region in flash that was previously cleared using the
+ * #memory_device_region_clear method. If that was not used then this may
+ * fail to write properly.
+ */
+int memory_device_write_words(const volatile void* addr, const void* data,
+			      const size_t len)
+{
+	const struct sector_info* si = get_flash_sector(addr);
+	if (!si)
+		return -1;
+
+	/* Check for word alignment */
+	const size_t word_size = sizeof(uint32_t);
+	if ((size_t) addr % word_size ||
+	    (size_t) data % word_size ||
+	    len % word_size) {
+		pr_warning("Dest or Data or Len value not word aligned!\r\n");
+		return -2;
+	}
+
+	FLASH_Unlock();
+	FLASH_ClearFlag(FLASH_FLAG_EOP | FLASH_FLAG_OPERR |
+			FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR |
+			FLASH_FLAG_PGPERR | FLASH_FLAG_PGSERR);
+
+	size_t i = 0;
+	const uint32_t* data_ptr = (const uint32_t*) data;
+	const size_t words_len = len / word_size;
+	for (; i < words_len; ++i) {
+		const uint32_t dest_addr = (uint32_t) addr + word_size * i;
+		const uint32_t dest_data = data_ptr[i];
+		if (FLASH_COMPLETE != FLASH_ProgramWord(dest_addr, dest_data))
+			/* If here, error scenario */
+			pr_warning_int_msg("Failed to flash ", dest_addr);
+	}
+
+	FLASH_Lock();
+	return i * word_size;
+}
+
+enum memory_flash_result_t memory_device_flash_region(const volatile void *address,
+						      const void *data,
+						      unsigned int length)
+{
+	const bool status =
+		memory_device_region_clear(address) &&
+		length <= memory_device_write_words(address, data, length);
+
+	return status ? MEMORY_FLASH_SUCCESS : MEMORY_FLASH_WRITE_ERROR;
 }

--- a/platform/rct/hal/memory_stm32/memory_device_stm32.c
+++ b/platform/rct/hal/memory_stm32/memory_device_stm32.c
@@ -1,47 +1,126 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "macros.h"
 #include "memory_device.h"
+#include "printk.h"
 #include "stm32f30x_flash.h"
 #include <stddef.h>
 
 #define MEMORY_PAGE_SIZE	2048
 
-/* STM32F3 is on 2K page sizes */
-static uint32_t selectFlashSector(const void *address)
+static const struct sector_info {
+	void* addr;
+	size_t size;
+} flash_sectors[] = {
+	{(void*) 0x08038000, 16384},
+	{(void*) 0x0803C000, 16384},
+};
+
+static const struct sector_info* get_flash_sector(
+	const volatile void* const addr)
 {
-    uint32_t addr = (uint32_t) address;
-    return addr % MEMORY_PAGE_SIZE == 0 ? addr : 0;
+	for (size_t i = 0; i < ARRAY_LEN(flash_sectors); ++i) {
+		const struct sector_info* si = flash_sectors + i;
+		if (si->addr <= addr && addr < si->addr + si->size)
+			return si;
+	}
+
+	pr_warning("Failed to find flash sector\r\n");
+	return NULL;
 }
 
-enum memory_flash_result_t memory_device_flash_region(const void *address, const void *data,
-        unsigned int length)
+/**
+ * Clears the entirety of a region of flash.
+ * @param addr The address of any byte within the region of flash.
+ */
+bool memory_device_region_clear(const volatile void *addr)
 {
-    enum memory_flash_result_t rc = MEMORY_FLASH_SUCCESS;
+	const struct sector_info* si = get_flash_sector(addr);
+	if (!si)
+		return false;
 
-    /* adjust length to word boundary */
-	length += (length % sizeof(uint32_t) == 0) ? 0 : sizeof(uint32_t) - length % sizeof(uint32_t);
+	FLASH_Unlock();
+	FLASH_ClearFlag(FLASH_FLAG_PGERR | FLASH_FLAG_WRPERR | FLASH_FLAG_EOP);
 
-    uint32_t flash_page = selectFlashSector(address);
-    if (flash_page) {
-        FLASH_Unlock();
-        FLASH_ClearFlag(FLASH_FLAG_PGERR | FLASH_FLAG_WRPERR | FLASH_FLAG_EOP);
+	uint32_t addr_val = (uint32_t) si->addr;
+	const uint32_t end = addr_val + si->size;
+	bool status = true;
+	for (; addr_val < end; addr_val += MEMORY_PAGE_SIZE) {
+		const bool erased = FLASH_COMPLETE == FLASH_ErasePage(addr_val);
+		status &= erased;
+		if (!erased)
+			pr_warning_int_msg("Failed to erase sector ", addr_val);
+	}
 
-        /*flash all sectors in range */
-        for (size_t i = flash_page; i < flash_page + length; i += MEMORY_PAGE_SIZE) {
-        	FLASH_ErasePage(i);
-        }
+	FLASH_Lock();
+	return status;
+}
 
-        uint32_t addrTarget = (uint32_t) address;
-        uint32_t *dataTarget = (uint32_t *) data;
+/**
+ * Writes bits to a region in flash that was previously cleared using the
+ * #memory_device_region_clear method. If that was not used then this may
+ * fail to write properly.
+ */
+int memory_device_write_words(const volatile void* addr, const void* data,
+			      const size_t len)
+{
+	const struct sector_info* si = get_flash_sector(addr);
+	if (!si)
+		return -1;
 
-        size_t data_index = 0;
-        for (size_t i = 0; i < length; i+=sizeof(uint32_t)) {
-            if (FLASH_ProgramWord(addrTarget + i, dataTarget[data_index++]) != FLASH_COMPLETE) {
-                rc = MEMORY_FLASH_WRITE_ERROR;
-                break;
-            }
-        }
-        FLASH_Lock();
-    } else {
-        rc = MEMORY_FLASH_WRITE_ERROR;
-    }
-    return rc;
+	/* Check for word alignment */
+	const size_t word_size = sizeof(uint32_t);
+	if ((size_t) addr % word_size ||
+	    (size_t) data % word_size ||
+	    len % word_size) {
+		pr_warning("Dest or Data or Len value not word aligned!\r\n");
+		return -2;
+	}
+
+	FLASH_Unlock();
+	FLASH_ClearFlag(FLASH_FLAG_PGERR | FLASH_FLAG_WRPERR | FLASH_FLAG_EOP);
+
+	size_t i = 0;
+	const uint32_t* data_ptr = (const uint32_t*) data;
+	const size_t words_len = len / word_size;
+	for (; i < words_len; ++i) {
+		const uint32_t dest_addr = (uint32_t) addr + word_size * i;
+		const uint32_t dest_data = data_ptr[i];
+		if (FLASH_COMPLETE != FLASH_ProgramWord(dest_addr, dest_data))
+			/* If here, error scenario */
+			pr_warning_int_msg("Failed to flash ", dest_addr);
+	}
+
+	FLASH_Lock();
+	return i * word_size;
+}
+
+enum memory_flash_result_t memory_device_flash_region(const volatile void *address,
+						      const void *data,
+						      unsigned int length)
+{
+	const bool status =
+		memory_device_region_clear(address) &&
+		length <= memory_device_write_words(address, data, length);
+
+	return status ? MEMORY_FLASH_SUCCESS : MEMORY_FLASH_WRITE_ERROR;
 }

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -1654,6 +1654,7 @@ int api_getTrackDb(struct Serial *serial, const jsmntok_t *json)
     json_arrayEnd(serial, 0);
     json_objEnd(serial, 0);
     json_objEnd(serial, 0);
+
     return API_SUCCESS_NO_RETURN;
 }
 

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -667,7 +667,6 @@ int flash_default_logger_config(void)
     resetConnectivityConfig(&lc->ConnectivityConfigs);
     reset_logging_config(&lc->logging_cfg);
     auto_logger_reset_config(&lc->auto_logger_cfg);
-    strcpy(lc->padding_data, "");
 
     int result = flashLoggerConfig();
 
@@ -677,8 +676,8 @@ int flash_default_logger_config(void)
 
 int flashLoggerConfig(void)
 {
-    return memory_flash_region((void *) &g_savedLoggerConfig,
-                               (void *) &g_workingLoggerConfig,
+    return memory_flash_region(&g_savedLoggerConfig,
+                               &g_workingLoggerConfig,
                                sizeof (LoggerConfig));
 }
 

--- a/src/memory/memory.c
+++ b/src/memory/memory.c
@@ -24,7 +24,9 @@
 #include "memory_device.h"
 
 
-enum memory_flash_result_t memory_flash_region(const void *address, const void *data, unsigned int length)
+enum memory_flash_result_t memory_flash_region(const volatile void *address,
+					       const void *data,
+					       unsigned int length)
 {
     return memory_device_flash_region(address, data, length);
 }

--- a/src/tracks/tracks.c
+++ b/src/tracks/tracks.c
@@ -19,13 +19,15 @@
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #include "luaTask.h"
 #include "mem_mang.h"
 #include "memory.h"
-#include <string.h>
+#include "memory_device.h"
 #include "printk.h"
 #include "tracks.h"
+#include <string.h>
+
+#define LOG_PFX	"[Tracks] "
 
 #ifndef RCP_TESTING
 #include "memory.h"
@@ -36,148 +38,134 @@ static Tracks g_tracks = {};
 
 void initialize_tracks()
 {
-        const VersionInfo vi = g_tracks.versionInfo;
-        if (version_check_changed(&vi, "Tracks DB"))
-                flash_default_tracks();
+	const VersionInfo vi = g_tracks.versionInfo;
+	if (version_check_changed(&vi, "Tracks DB"))
+		flash_default_tracks();
+}
+
+static bool clear_tracks_region()
+{
+	return memory_device_region_clear(&g_tracks);
+}
+
+static bool write_version_info()
+{
+	const VersionInfo* vi = get_current_version_info();
+	const size_t vi_size = sizeof(VersionInfo);
+	const volatile void* dst = &g_tracks.versionInfo;
+	return vi_size == memory_device_write_words(dst, vi, vi_size);
+}
+
+static bool write_track_count(const size_t count)
+{
+	const size_t size = sizeof(size_t);
+	const volatile void* dst = &g_tracks.count;
+	return size == memory_device_write_words(dst, &count, size);
+}
+
+static bool write_track(const Track *track, const size_t idx)
+{
+	const size_t size = sizeof(Track);
+	const volatile void* dst = g_tracks.tracks + idx;
+	return size == memory_device_write_words(dst, track, size);
 }
 
 int flash_default_tracks(void)
 {
-        Tracks* def_tracks = calloc(1, sizeof(Tracks));
-        const VersionInfo* cv = get_current_version_info();
-        memcpy(&def_tracks->versionInfo, cv, sizeof(VersionInfo));
-
-        pr_info("flashing default tracks...");
-        const int status = flash_tracks(def_tracks, sizeof(Tracks));
-
-        free(def_tracks);
-        return status;
+	return clear_tracks_region() &&
+		write_version_info() &&
+		write_track_count(0) ? 0 : 1;
 }
 
-int flash_tracks(const Tracks *source, size_t rawSize)
+const Tracks* get_tracks()
 {
-    int result = memory_flash_region((void *)&g_tracks, (void *)source, rawSize);
-    if (result == 0) pr_info("win\r\n");
-    else pr_info("fail\r\n");
-    return result;
+	return (Tracks*) &g_tracks;
 }
-
-const Tracks * get_tracks()
-{
-    return (Tracks *)&g_tracks;
-}
-
 
 enum track_add_result add_track(const Track *track, const size_t index,
                                 const enum track_add_mode mode)
 {
-        if (index >= MAX_TRACK_COUNT) {
-                pr_error("tracks: Invalid track index\r\n");
-                return TRACK_ADD_RESULT_FAIL;
-        }
-
         switch (mode) {
         case TRACK_ADD_MODE_IN_PROGRESS:
         case TRACK_ADD_MODE_COMPLETE:
                 /* Valid cases.  Carry on */
                 break;
         default:
-                pr_error_int_msg("tracks: Unknown track_add_mode: ", mode);
+                pr_error_int_msg(LOG_PFX "Unknown track_add_mode: ", mode);
                 return TRACK_ADD_RESULT_FAIL;
         }
 
-        static Tracks *g_tracksBuffer;
-        if (NULL == g_tracksBuffer) {
+	bool status = true;
+	static size_t idx = 0;
+	if (0 == idx) {
+		/* Then start the add process */
+		status &= clear_tracks_region();
+		status &= write_version_info();
+	}
 
-#if LUA_SUPPORT
-                lua_task_stop();
-#endif /* LUA_SUPPORT */
-
-                pr_debug("tracks: Allocating new tracks buffer\r\n");
-                g_tracksBuffer = (Tracks *) portMalloc(sizeof(Tracks));
-                memcpy(g_tracksBuffer, (void*) &g_tracks, sizeof(Tracks));
-        }
-
-        if (NULL == g_tracksBuffer) {
-                pr_error("tracks: Failed to allocate memory for track buffer.\r\n");
-                return TRACK_ADD_RESULT_FAIL;
-        }
-
-        Track *trackToAdd = g_tracksBuffer->tracks + index;
-        memcpy(trackToAdd, track, sizeof(Track));
-        g_tracksBuffer->count = index + 1;
+	status &= write_track(track, idx);
+	++idx;
 
         /* If we made it here and are still in progress, then we are done */
-        if (TRACK_ADD_MODE_IN_PROGRESS == mode)
-                return TRACK_ADD_RESULT_OK;
+        if (TRACK_ADD_MODE_COMPLETE == mode) {
+		/* If here, time to flash and tidy up */
+		status &= write_track_count(idx);
+		pr_info(LOG_PFX "Completed updating tracks.\r\n");
+		idx = 0;
+	}
 
-        /* If here, time to flash and tidy up */
-        pr_info("tracks: Completed updating tracks. Flashing... ");
-        const int rc = flash_tracks(g_tracksBuffer, sizeof(Tracks));
-        portFree(g_tracksBuffer);
-        g_tracksBuffer = NULL;
-
-        if (0 != rc) {
-                pr_info_int_msg("failed with code ", rc);
-                return TRACK_ADD_RESULT_FAIL;
-        }
-
-        pr_info("win!\r\n");
-
-#if LUA_SUPPORT
-        lua_task_start();
-#endif /* LUA_SUPPORT */
-
-        return TRACK_ADD_RESULT_OK;
+        return status ? TRACK_ADD_RESULT_OK : TRACK_ADD_RESULT_FAIL;
 }
 
 static int isStage(const Track *t)
 {
-    return t->track_type == TRACK_TYPE_STAGE;
+	return t->track_type == TRACK_TYPE_STAGE;
 }
 
 GeoPoint getFinishPoint(const Track *t)
 {
-    return isStage(t) ? t->stage.finish : t->circuit.startFinish;
+	return isStage(t) ? t->stage.finish : t->circuit.startFinish;
 }
 
 int isFinishPointValid(const Track *t)
 {
-    if (NULL == t)
-        return 0;
+	if (NULL == t)
+		return 0;
 
-    const GeoPoint p = getFinishPoint(t);
-    return isValidPoint(&p);
+	const GeoPoint p = getFinishPoint(t);
+	return isValidPoint(&p);
 }
 
 GeoPoint getStartPoint(const Track *t)
 {
-    return isStage(t) ? t->stage.start : t->circuit.startFinish;
+	return isStage(t) ? t->stage.start : t->circuit.startFinish;
 }
 
 int isStartPointValid(const Track *t)
 {
-    if (NULL == t)
-        return 0;
+	if (NULL == t)
+		return 0;
 
-    const GeoPoint p = getStartPoint(t);
-    return isValidPoint(&p);
+	const GeoPoint p = getStartPoint(t);
+	return isValidPoint(&p);
 }
 
 GeoPoint getSectorGeoPointAtIndex(const Track *t, int index)
 {
-    if (index < 0) index = 0;
-    const int max = isStage(t) ? STAGE_SECTOR_COUNT : CIRCUIT_SECTOR_COUNT;
-    const GeoPoint *sectors = isStage(t) ? t->stage.sectors : t->circuit.sectors;
+	if (index < 0) index = 0;
+	const int max = isStage(t) ?
+		STAGE_SECTOR_COUNT : CIRCUIT_SECTOR_COUNT;
+	const GeoPoint *sectors = isStage(t) ?
+		t->stage.sectors : t->circuit.sectors;
 
-    if (index < max && isValidPoint(sectors + index))
-        return sectors[index];
+	if (index < max && isValidPoint(sectors + index))
+		return sectors[index];
 
-    // If here, return the finish since that is logically the next sector point.
-    return getFinishPoint(t);
+	/* If here, return the finish since logically next sector point */
+	return getFinishPoint(t);
 }
 
 int areGeoPointsEqual(const GeoPoint a, const GeoPoint b)
 {
-    return a.latitude == b.latitude && a.longitude == b.longitude;
+	return a.latitude == b.latitude && a.longitude == b.longitude;
 }


### PR DESCRIPTION
In cases where it is unreasonable to load the entire DB of a particular
object into RAM we need to be able to write the contents to flash
directly so as to avoid the large/impossible allocation. This change
adds that support so that we may write to flash without the need of
allocating such a ridiculously large buffer.

Issue #536

**NOTE:** We need to discuss if this can actually go into firmware due to existence of https://github.com/autosportlabs/RaceCapture_App/issues/1059 the implications of how this will break backwards compatibility.  If we put it in then at a minimum a user must use the latest app for things to work.  