### PR TITLE
Fix CAN Filtering, CAN Filtering Init Procedure & Add CAN Filter Enable/Disable

### DIFF
--- a/include/CAN/CAN.h
+++ b/include/CAN/CAN.h
@@ -47,7 +47,8 @@ typedef struct _CAN_msg {
 
 int CAN_init(LoggerConfig *loggerConfig);
 int CAN_init_port(uint8_t port, uint32_t baud);
-int CAN_set_filter(uint8_t, uint8_t id, uint8_t extended, uint32_t filter, uint32_t mask);
+int CAN_set_filter(uint8_t, uint8_t id, uint8_t extended, uint32_t filter,
+		   uint32_t mask, const bool enabled);
 int CAN_tx_msg(uint8_t channel, CAN_msg *msg, unsigned int timeoutMs);
 int CAN_rx_msg(uint8_t channel, CAN_msg *msg, unsigned int timeoutMs);
 

--- a/include/CAN/CAN_device.h
+++ b/include/CAN/CAN_device.h
@@ -25,13 +25,14 @@
 #include "cpp_guard.h"
 #include "CAN.h"
 #include "loggerConfig.h"
-
+#include <stdbool.h>
 #include <stdint.h>
 
 CPP_GUARD_BEGIN
 
 int CAN_device_init(uint8_t channel, uint32_t baud);
-int CAN_device_set_filter(uint8_t channel, uint8_t id, uint8_t extended, uint32_t filter, uint32_t mask);
+int CAN_device_set_filter(uint8_t channel, uint8_t id, uint8_t extended,
+			  uint32_t filter, uint32_t mask, const bool enabled);
 int CAN_device_tx_msg(uint8_t channel, CAN_msg *msg, unsigned int timeoutMs);
 int CAN_device_rx_msg(uint8_t channel, CAN_msg *msg, unsigned int timeoutMs);
 

--- a/src/CAN/CAN.c
+++ b/src/CAN/CAN.c
@@ -42,9 +42,11 @@ int CAN_init_port(uint8_t port, uint32_t baud)
     return CAN_device_init(port, baud);
 }
 
-int CAN_set_filter(uint8_t channel, uint8_t id, uint8_t extended, uint32_t filter, uint32_t mask)
+int CAN_set_filter(uint8_t channel, uint8_t id, uint8_t extended,
+		   uint32_t filter, uint32_t mask, const bool enabled)
 {
-    return CAN_device_set_filter(channel, id, extended, filter, mask);
+	return CAN_device_set_filter(channel, id, extended, filter,
+				     mask, enabled);
 }
 
 int CAN_tx_msg(uint8_t channel, CAN_msg *msg, unsigned int timeoutMs)

--- a/src/lua/luaLoggerBinding.c
+++ b/src/lua/luaLoggerBinding.c
@@ -629,19 +629,33 @@ static int lua_init_can(lua_State *L)
 
 static int lua_set_can_filter(lua_State *L)
 {
-        lua_validate_args_count(L, 5, 5);
-        for (int i = 1; i <= 5; ++i)
-                lua_validate_arg_number(L, i);
+	lua_validate_args_count(L, 5, 6);
 
-        const uint8_t channel = lua_tointeger(L, 1);
-        const uint8_t id = lua_tointeger(L, 2);
-        const uint8_t extended = lua_tointeger(L, 3);
-        const uint32_t filter = lua_tointeger(L, 4);
-        const uint32_t mask = lua_tointeger(L, 5);
+	bool enable = true;
+	switch(lua_gettop(L)) {
+	default:
+		return lua_panic(L);
+	case 6:
+		lua_validate_arg_boolean(L, 6);
+		enable = lua_toboolean(L, 6);
+	case 5:
+		break;
+	}
 
-        lua_pushinteger(L, CAN_set_filter(channel, id, extended,
-                                          filter, mask, true));
-        return 1;
+	for (int i = 1; i <= 5; ++i)
+		lua_validate_arg_number(L, i);
+
+	const uint8_t channel = lua_tointeger(L, 1);
+	const uint8_t id = lua_tointeger(L, 2);
+	const uint8_t extended = lua_tointeger(L, 3);
+	const uint32_t filter = lua_tointeger(L, 4);
+	const uint32_t mask = lua_tointeger(L, 5);
+
+	const int result = CAN_set_filter(channel, id, extended, filter,
+					  mask, enable);
+	lua_pushinteger(L, result);
+
+	return 1;
 }
 
 static int lua_send_can_msg(lua_State *L)

--- a/src/lua/luaLoggerBinding.c
+++ b/src/lua/luaLoggerBinding.c
@@ -638,8 +638,9 @@ static int lua_set_can_filter(lua_State *L)
         const uint8_t extended = lua_tointeger(L, 3);
         const uint32_t filter = lua_tointeger(L, 4);
         const uint32_t mask = lua_tointeger(L, 5);
+
         lua_pushinteger(L, CAN_set_filter(channel, id, extended,
-                                          filter, mask));
+                                          filter, mask, true));
         return 1;
 }
 

--- a/test/logger_mock/CAN_device_mock.c
+++ b/test/logger_mock/CAN_device_mock.c
@@ -21,6 +21,7 @@
 
 
 #include "CAN_device.h"
+#include <stdbool.h>
 
 int CAN_device_init(uint8_t channel, uint32_t baud)
 {
@@ -37,7 +38,8 @@ int CAN_device_rx_msg(uint8_t channel, CAN_msg *msg, unsigned int timeoutMs)
     return 1;
 }
 
-int CAN_device_set_filter(uint8_t channel, uint8_t id, uint8_t extended, uint32_t filter, uint32_t mask)
+int CAN_device_set_filter(uint8_t channel, uint8_t id, uint8_t extended,
+			  uint32_t filter, uint32_t mask, const bool enabled)
 {
     return 1;
 }


### PR DESCRIPTION
Does the following for our CAN subsystem:

* Fixes the CAN filtering issue as tracked by #737 
* Fixes the Init routine to reset all filters for a given CAN channel except filter 0 which is set to receive all.
* Adds support to LUA so users may enable/disable filters.

