### PR TITLE
Disable autologger by default

### DIFF
--- a/src/logger/auto_logger.c
+++ b/src/logger/auto_logger.c
@@ -57,7 +57,7 @@ static struct {
 
 void auto_logger_reset_config(struct auto_logger_config* cfg)
 {
-        cfg->active = true;
+        cfg->active = false;
 
         cfg->start.time = DEFAULT_START_TIME_SEC;
         cfg->start.speed = DEFAULT_START_SPEED_KPH;


### PR DESCRIPTION
Since the app code might not be ready to control this feature we
thought it best to disable it now with the intention of enabling
it later by default.  That work is tracked by issue #757

Issue #755