### PR TITLE
Adjust Max Supported Sample Rates For Channels and WiFi

### DIFF
--- a/platform/mk2/capabilities.h
+++ b/platform/mk2/capabilities.h
@@ -17,7 +17,8 @@
 #define WIFI_SUPPORT		1
 
 /* Wifi Specific Info */
-#define WIFI_MAX_BAUD	230400
+#define WIFI_MAX_BAUD		230400
+#define WIFI_MAX_SAMPLE_RATE	50
 
 /* Configuration */
 #define MAX_TRACKS	240

--- a/platform/rct/capabilities.h
+++ b/platform/rct/capabilities.h
@@ -18,7 +18,8 @@
 #define WIFI_SUPPORT		1
 
 /* Wifi Specific Info */
-#define WIFI_MAX_BAUD	921600
+#define WIFI_MAX_BAUD		921600
+#define WIFI_MAX_SAMPLE_RATE	50
 
 /* Configuration */
 #define MAX_TRACKS	5
@@ -41,9 +42,9 @@
 #define CONNECTIVITY_CHANNELS	2
 
 //sample rates
-#define MAX_SENSOR_SAMPLE_RATE	100
+#define MAX_SENSOR_SAMPLE_RATE	50
 #define MAX_GPS_SAMPLE_RATE	50
-#define MAX_OBD2_SAMPLE_RATE	100
+#define MAX_OBD2_SAMPLE_RATE	50
 
 //logger message buffering
 #define LOGGER_MESSAGE_BUFFER_SIZE  5

--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -58,8 +58,6 @@
 #define RX_BUFF_SIZE		512
 /* How much stack does this task deserve */
 #define STACK_SIZE		256
-/* Max telemetry stream sample rate */
-#define TELEMETRY_SAMPLE_RATE	10
 /* Make all task names 16 chars including NULL char */
 #define THREAD_NAME		"WiFi Task      "
 /* How many events can be pending before we overflow */
@@ -169,10 +167,10 @@ static int wifi_serial_ioctl(struct Serial* serial, unsigned long req,
                 pr_info_int_msg(LOG_PFX "Starting telem stream on serial ",
                                 (int) (long) serial);
                 int rate = (int) (long) argp;
-                if (rate > TELEMETRY_SAMPLE_RATE) {
+                if (rate > WIFI_MAX_SAMPLE_RATE) {
                         pr_info_int_msg(LOG_PFX "Telemetry stream rate too "
                                         "high.  Reducing to ", rate);
-                        rate = TELEMETRY_SAMPLE_RATE;
+                        rate = WIFI_MAX_SAMPLE_RATE;
                 }
 
                 const bool success = logger_sample_register_callback(

--- a/test/capabilities.h
+++ b/test/capabilities.h
@@ -46,7 +46,9 @@ CPP_GUARD_BEGIN
 #define MAX_SECTORS				20
 #define MAX_VIRTUAL_CHANNELS	10
 
-#define WIFI_MAX_BAUD	921600
+/* Wifi Specific Info */
+#define WIFI_MAX_BAUD		921600
+#define WIFI_MAX_SAMPLE_RATE	50
 /*
  * What is the maximum number of samples available per predictive time
  * buffer.  More samples == better resolution. Each slot is 12 bytes.


### PR DESCRIPTION
Adjusts RCT max sample rate to 50Hz since that is its limit.  Also
adjusts the WiFi system to limit the WiFi stream rate to 50Hz,
up from 10Hz.

Issue #752