### PR TITLE
Disable the track DB on RCT

### DIFF
--- a/platform/rct/capabilities.h
+++ b/platform/rct/capabilities.h
@@ -21,7 +21,7 @@
 #define WIFI_MAX_BAUD	921600
 
 /* Configuration */
-#define MAX_TRACKS	5
+#define MAX_TRACKS	0
 #define MAX_SECTORS	20
 #define MAX_VIRTUAL_CHANNELS	30
 /*


### PR DESCRIPTION
Since the track will be either directly uploaded by the user or
managed by the app per design I am disabling the track DB here.

Issue #751