### PR TITLE
Add Ring Buffer DMA Support, Improve File Writing Stability

### DIFF
--- a/include/util/ring_buffer.h
+++ b/include/util/ring_buffer.h
@@ -44,6 +44,9 @@ size_t ring_buffer_put(struct ring_buff *rb, const void *data,
                        size_t size);
 size_t ring_buffer_write(struct ring_buff *rb, const void *data,
                          size_t size);
+const void* ring_buffer_dma_read_init(struct ring_buff* rb, size_t* avail);
+void ring_buffer_dma_read_fini(struct ring_buff* rb, const size_t read);
+
 CPP_GUARD_END
 
 #endif /* __RING_BUFFER_H__ */


### PR DESCRIPTION
Adds a form of DMA support for the f_write command so we can directly read large buffers when writing to file on SD cards.  This seems to add more stability in testing as there are almost no remounts now.