### PR TITLE
Align firmeware in linker to prevent CRC errors in Bootloader

### DIFF
--- a/platform/mk2/cpu/common/link_sections.ld
+++ b/platform/mk2/cpu/common/link_sections.ld
@@ -53,7 +53,7 @@ ENTRY(Reset_Handler)
     . = ALIGN(4);
     KEEP (*(.channels))
   } > CHANNELS
-    
+
   script :
   {
     . = ALIGN(4);
@@ -110,6 +110,7 @@ ENTRY(Reset_Handler)
    } >FLASH
 
    /* used by the startup to initialize data */
+   . = ALIGN(4);
    _sidata = .;
 
    /* Initialized data sections goes into CCM, load LMA copy after code */

--- a/platform/rct/Project/STM32_FLASH.ld
+++ b/platform/rct/Project/STM32_FLASH.ld
@@ -46,8 +46,8 @@ MEMORY
   FLASH     (rx)    : ORIGIN = 0x08004000, LENGTH = 256K - 48K
 
   CONFIG    (rx)    : ORIGIN = 0x08038000, LENGTH = 16K
-  TRACKS    (rx)    : ORIGIN = 0x0803C000, LENGTH = 16K  
-  
+  TRACKS    (rx)    : ORIGIN = 0x0803C000, LENGTH = 16K
+
   HANDSHAKE (rwx)   : ORIGIN = 0x20000000, LENGTH = 8
   RAM       (xrw)   : ORIGIN = 0x20000008, LENGTH = 40K - 8
   CCM_RAM   (rxw)   : ORIGIN = 0x10000000, LENGTH = 8K
@@ -128,6 +128,7 @@ SECTIONS
   } >FLASH
 
   /* used by the startup to initialize data */
+  . = ALIGN(4);
   _sidata = .;
 
   /* Initialized data sections goes into RAM, load LMA copy after code */


### PR DESCRIPTION
Aligns firmware along word boundaries to prevent issues with the
CRC checksum code in the bootloader.  Without it we may get random
failures that make us sad pandas.