### PR TITLE
Demote wifi msg received log entry to trace level

### DIFF
--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -225,7 +225,7 @@ static bool process_partial_and_continue()
 static void process_ready_msg(struct Serial* s)
 {
         char *data_in = rx_buff_get_msg(state.rx_msgs.rxb);
-        pr_info_str_msg(LOG_PFX "Received CMD: ", data_in);
+        pr_trace_str_msg(LOG_PFX "Received CMD: ", data_in);
         process_read_msg(s, data_in, strlen(data_in));
 }
 


### PR DESCRIPTION
Because otherwise it pollutes the log file under active polling.
Issue #767