### PR TITLE
Support Serial Close

### DIFF
--- a/include/logger/loggerApi.h
+++ b/include/logger/loggerApi.h
@@ -33,44 +33,44 @@ CPP_GUARD_BEGIN
 
 #define API_METHOD(_NAME, _FUNC) {(_NAME), (_FUNC)},
 
-#define BASE_API_METHODS                                                \
-        API_METHOD("addTrackDb", api_addTrackDb)                        \
-        API_METHOD("calImu", api_calibrateImu)                          \
-        API_METHOD("facReset", api_factoryReset)                        \
-        API_METHOD("flashCfg", api_flashConfig)                         \
-        API_METHOD("getAutoLoggerCfg", api_get_auto_logger_cfg)         \
-        API_METHOD("getCanCfg", api_getCanConfig)                       \
-        API_METHOD("getCapabilities", api_getCapabilities)              \
-        API_METHOD("getConnCfg", api_getConnectivityConfig)             \
-        API_METHOD("getGpsCfg", api_getGpsConfig)                       \
-        API_METHOD("getImuCfg", api_getImuConfig)                       \
-        API_METHOD("getLapCfg", api_getLapConfig)                       \
-        API_METHOD("getLogfile", api_getLogfile)                        \
-        API_METHOD("getMeta", api_getMeta)                              \
-        API_METHOD("getObd2Cfg", api_getObd2Config)                     \
-        API_METHOD("getStatus", api_getStatus)                          \
-        API_METHOD("getTrackCfg", api_getTrackConfig)                   \
-        API_METHOD("getTrackDb", api_getTrackDb)                        \
-        API_METHOD("getVer", api_getVersion)                            \
-        API_METHOD("getWifiCfg", api_get_wifi_cfg)                      \
-        API_METHOD("hb", api_heart_beat)                                \
-        API_METHOD("log", api_log)                                      \
-        API_METHOD("s", api_sampleData)                                 \
-        API_METHOD("setActiveTrack", api_set_active_track)              \
-        API_METHOD("setAutoLoggerCfg", api_set_auto_logger_cfg)         \
-        API_METHOD("setCanCfg", api_setCanConfig)                       \
-        API_METHOD("setConnCfg", api_setConnectivityConfig)             \
-        API_METHOD("setGpsCfg", api_setGpsConfig)                       \
-        API_METHOD("setImuCfg", api_setImuConfig)                       \
-        API_METHOD("setLapCfg", api_setLapConfig)                       \
-        API_METHOD("setLogfileLevel", api_setLogfileLevel)              \
-        API_METHOD("setObd2Cfg", api_setObd2Config)                     \
-        API_METHOD("setTelemetryStart", api_set_telemetry_start)        \
-        API_METHOD("setTelemetryStop", api_set_telemetry_stop)          \
-        API_METHOD("setTrackCfg", api_setTrackConfig)                   \
-        API_METHOD("setWifiCfg", api_set_wifi_cfg)                      \
-        API_METHOD("sysReset", api_systemReset)                         \
-
+#define BASE_API_METHODS						\
+	API_METHOD("addTrackDb", api_addTrackDb)			\
+	API_METHOD("calImu", api_calibrateImu)				\
+	API_METHOD("facReset", api_factoryReset)			\
+	API_METHOD("flashCfg", api_flashConfig)				\
+	API_METHOD("getAutoLoggerCfg", api_get_auto_logger_cfg)		\
+	API_METHOD("getCanCfg", api_getCanConfig)			\
+	API_METHOD("getCapabilities", api_getCapabilities)		\
+	API_METHOD("getConnCfg", api_getConnectivityConfig)		\
+	API_METHOD("getGpsCfg", api_getGpsConfig)			\
+	API_METHOD("getImuCfg", api_getImuConfig)			\
+	API_METHOD("getLapCfg", api_getLapConfig)			\
+	API_METHOD("getLogfile", api_getLogfile)			\
+	API_METHOD("getMeta", api_getMeta)				\
+	API_METHOD("getObd2Cfg", api_getObd2Config)			\
+	API_METHOD("getStatus", api_getStatus)				\
+	API_METHOD("getTrackCfg", api_getTrackConfig)			\
+	API_METHOD("getTrackDb", api_getTrackDb)			\
+	API_METHOD("getVer", api_getVersion)				\
+	API_METHOD("getWifiCfg", api_get_wifi_cfg)			\
+	API_METHOD("hb", api_heart_beat)				\
+	API_METHOD("log", api_log)					\
+	API_METHOD("s", api_sampleData)					\
+	API_METHOD("setActiveTrack", api_set_active_track)		\
+	API_METHOD("setAutoLoggerCfg", api_set_auto_logger_cfg)		\
+	API_METHOD("setCanCfg", api_setCanConfig)			\
+	API_METHOD("setConnCfg", api_setConnectivityConfig)		\
+	API_METHOD("setGpsCfg", api_setGpsConfig)			\
+	API_METHOD("setImuCfg", api_setImuConfig)			\
+	API_METHOD("setLapCfg", api_setLapConfig)			\
+	API_METHOD("setLogfileLevel", api_setLogfileLevel)		\
+	API_METHOD("setObd2Cfg", api_setObd2Config)			\
+	API_METHOD("setTelemetry", api_set_telemetry)			\
+	API_METHOD("setTelemetryStart", api_set_telemetry)		\
+	API_METHOD("setTelemetryStop", api_set_telemetry)		\
+	API_METHOD("setTrackCfg", api_setTrackConfig)			\
+	API_METHOD("setWifiCfg", api_set_wifi_cfg)			\
+	API_METHOD("sysReset", api_systemReset)				\
 
 #if ANALOG_CHANNELS > 0
 #define ANALOG_API_METHODS                              \
@@ -181,8 +181,7 @@ int api_get_wifi_cfg(struct Serial *s, const jsmntok_t *json);
 int api_set_wifi_cfg(struct Serial *s, const jsmntok_t *json);
 
 /* Telemetry Stream Actions */
-int api_set_telemetry_start(struct Serial *serial, const jsmntok_t *json);
-int api_set_telemetry_stop(struct Serial *serial, const jsmntok_t *json);
+int api_set_telemetry(struct Serial *serial, const jsmntok_t *json);
 
 /* Volatile setter of active Track */
 int api_set_active_track(struct Serial *serial, const jsmntok_t *json);

--- a/include/logger/loggerSampleData.h
+++ b/include/logger/loggerSampleData.h
@@ -42,20 +42,17 @@ void init_channel_sample_buffer(LoggerConfig *loggerConfig,
 
 float get_mapped_value(float value, ScalingMap *scalingMap);
 
-typedef void logger_sample_cb_t(struct Serial* const serial,
-                                const struct sample* sample,
-                                const int ticks);
-
-bool logger_sample_register_callback(logger_sample_cb_t* cb,
-                                     struct Serial* const serial);
+typedef void logger_sample_cb_t(const struct sample* sample,
+                                const int ticks,
+				void* data);
 
 void logger_sample_process_callbacks(const int sample_tick,
                                      const struct sample* sample);
 
-bool logger_sample_enable_callback(struct Serial* const serial,
-                                   const int sample_rate);
+int logger_sample_create_callback(logger_sample_cb_t* cb, const int rate,
+				  void* data);
 
-bool logger_sample_disable_callback(struct Serial* const serial);
+bool logger_sample_destroy_callback(const int handle);
 
 CPP_GUARD_END
 

--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -129,8 +129,7 @@ xQueueHandle serial_get_rx_queue(struct Serial *s);
 xQueueHandle serial_get_tx_queue(struct Serial *s);
 
 enum serial_ioctl {
-        SERIAL_IOCTL_TELEMETRY_ENABLE  = 1,
-        SERIAL_IOCTL_TELEMETRY_DISABLE = 2,
+        SERIAL_IOCTL_TELEMETRY = 1,
 };
 
 /**

--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -102,27 +102,27 @@ bool serial_config(struct Serial *s, const size_t bits,
                    const size_t parity, const size_t stop_bits,
                    const size_t baud);
 
-int serial_get_c_wait(struct Serial *s, char *c, const size_t delay);
+int serial_read_c_wait(struct Serial *s, char *c, const size_t delay);
 
-int serial_get_c(struct Serial *s, char* c);
-
-int serial_get_line(struct Serial *s, char *l, const size_t len);
-
-int serial_get_line_wait(struct Serial *s, char *l, const size_t len,
-                         const size_t delay);
-
-int serial_put_c(struct Serial *s, const char c);
-
-int serial_put_buff_wait(struct Serial *s, const char *buf,
-                         const size_t len, const size_t delay);
-
-int serial_put_buff(struct Serial *s, const char *buf, const size_t len);
-
-int serial_put_s_wait(struct Serial *s, const char *l, const size_t delay);
-
-int serial_put_s(struct Serial *s, const char *l);
+int serial_read_c(struct Serial *s, char* c);
 
 int serial_read_byte(struct Serial *serial, uint8_t *b, const size_t delay);
+
+int serial_read_line(struct Serial *s, char *l, const size_t len);
+
+int serial_read_line_wait(struct Serial *s, char *l, const size_t len,
+			  const size_t delay);
+
+int serial_write_c(struct Serial *s, const char c);
+
+int serial_write_buff_wait(struct Serial *s, const char *buf,
+			   const size_t len, const size_t delay);
+
+int serial_write_buff(struct Serial *s, const char *buf, const size_t len);
+
+int serial_write_s_wait(struct Serial *s, const char *l, const size_t delay);
+
+int serial_write_s(struct Serial *s, const char *l);
 
 xQueueHandle serial_get_rx_queue(struct Serial *s);
 

--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -71,6 +71,10 @@ struct Serial;
 
 void serial_destroy(struct Serial *s);
 
+void serial_close(struct Serial* s);
+
+bool serial_is_connected(const struct Serial* s);
+
 struct Serial* serial_create(const char *name, const size_t tx_cap,
                              const size_t rx_cap, config_func_t *cfg_cb,
                              void *cfg_cb_arg, post_tx_func_t *post_tx_cb,
@@ -98,16 +102,16 @@ bool serial_config(struct Serial *s, const size_t bits,
                    const size_t parity, const size_t stop_bits,
                    const size_t baud);
 
-bool serial_get_c_wait(struct Serial *s, char *c, const size_t delay);
+int serial_get_c_wait(struct Serial *s, char *c, const size_t delay);
 
-char serial_get_c(struct Serial *s);
+int serial_get_c(struct Serial *s, char* c);
 
 int serial_get_line(struct Serial *s, char *l, const size_t len);
 
 int serial_get_line_wait(struct Serial *s, char *l, const size_t len,
                          const size_t delay);
 
-bool serial_put_c(struct Serial *s, const char c);
+int serial_put_c(struct Serial *s, const char c);
 
 int serial_put_buff_wait(struct Serial *s, const char *buf,
                          const size_t len, const size_t delay);
@@ -118,7 +122,7 @@ int serial_put_s_wait(struct Serial *s, const char *l, const size_t delay);
 
 int serial_put_s(struct Serial *s, const char *l);
 
-bool serial_read_byte(struct Serial *serial, uint8_t *b, const size_t delay);
+int serial_read_byte(struct Serial *serial, uint8_t *b, const size_t delay);
 
 xQueueHandle serial_get_rx_queue(struct Serial *s);
 

--- a/platform/mk2/hal/gps_skytraq/gps_device_skytraq.c
+++ b/platform/mk2/hal/gps_skytraq/gps_device_skytraq.c
@@ -221,22 +221,22 @@ static void txGpsMessage(GpsMessage * msg, struct Serial * serial)
          */
         delayMs(20);
 
-        serial_put_c(serial, 0xA0);
-        serial_put_c(serial, 0xA1);
+        serial_write_c(serial, 0xA0);
+        serial_write_c(serial, 0xA1);
 
         uint16_t payloadLength = msg->payloadLength;
-        serial_put_c(serial, (uint8_t) payloadLength >> 8);
-        serial_put_c(serial, (uint8_t) payloadLength & 0xFF);
+        serial_write_c(serial, (uint8_t) payloadLength >> 8);
+        serial_write_c(serial, (uint8_t) payloadLength & 0xFF);
 
         uint8_t *payload = msg->payload;
         while (payloadLength--) {
-                serial_put_c(serial, *(payload++));
+                serial_write_c(serial, *(payload++));
         }
 
-        serial_put_c(serial, msg->checksum);
+        serial_write_c(serial, msg->checksum);
 
-        serial_put_c(serial, 0x0D);
-        serial_put_c(serial, 0x0A);
+        serial_write_c(serial, 0x0D);
+        serial_write_c(serial, 0x0A);
 }
 
 static gps_msg_result_t rxGpsMessage(GpsMessage* msg, struct Serial* serial,

--- a/platform/rct/hal/gps_skytraq/gps_device_skytraq.c
+++ b/platform/rct/hal/gps_skytraq/gps_device_skytraq.c
@@ -221,22 +221,22 @@ static void txGpsMessage(GpsMessage * msg, struct Serial * serial)
          */
         delayMs(20);
 
-        serial_put_c(serial, 0xA0);
-        serial_put_c(serial, 0xA1);
+        serial_write_c(serial, 0xA0);
+        serial_write_c(serial, 0xA1);
 
         uint16_t payloadLength = msg->payloadLength;
-        serial_put_c(serial, (uint8_t) payloadLength >> 8);
-        serial_put_c(serial, (uint8_t) payloadLength & 0xFF);
+        serial_write_c(serial, (uint8_t) payloadLength >> 8);
+        serial_write_c(serial, (uint8_t) payloadLength & 0xFF);
 
         uint8_t *payload = msg->payload;
         while (payloadLength--) {
-                serial_put_c(serial, *(payload++));
+                serial_write_c(serial, *(payload++));
         }
 
-        serial_put_c(serial, msg->checksum);
+        serial_write_c(serial, msg->checksum);
 
-        serial_put_c(serial, 0x0D);
-        serial_put_c(serial, 0x0A);
+        serial_write_c(serial, 0x0D);
+        serial_write_c(serial, 0x0A);
 }
 
 static gps_msg_result_t rxGpsMessage(GpsMessage* msg, struct Serial* serial,

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -41,26 +41,26 @@ void initApi()
 
 static void putQuotedStr(struct Serial *serial, const char *str)
 {
-    serial_put_c(serial, '"');
-    serial_put_s(serial, str);
-    serial_put_c(serial, '"');
+    serial_write_c(serial, '"');
+    serial_write_s(serial, str);
+    serial_write_c(serial, '"');
 }
 
 static void putKeyAndColon(struct Serial *serial, const char *key)
 {
     putQuotedStr(serial, key);
-    serial_put_c(serial, ':');
+    serial_write_c(serial, ':');
 }
 
 static void putNull(struct Serial *serial)
 {
-    serial_put_s(serial, "null");
+    serial_write_s(serial, "null");
 }
 
 static void putCommaIfNecessary(struct Serial *serial, int necessary)
 {
     if (necessary)
-        serial_put_c(serial, ',');
+        serial_write_c(serial, ',');
 }
 
 void json_valueStart(struct Serial *serial, const char *name)
@@ -92,9 +92,9 @@ void json_uint(struct Serial *serial, const char *name, unsigned int value, int 
 void json_escapedString(struct Serial *serial, const char *name, const char *value, int more)
 {
     putKeyAndColon(serial, name);
-    serial_put_c(serial, '"');
+    serial_write_c(serial, '"');
     put_escapedString(serial, value, strlen(value));
-    serial_put_c(serial, '"');
+    serial_write_c(serial, '"');
     putCommaIfNecessary(serial, more);
 }
 
@@ -122,32 +122,32 @@ void json_bool(struct Serial *serial, const char *name,
                const bool value, bool more)
 {
     putKeyAndColon(serial, name);
-    serial_put_s(serial, value ? "true" : "false");
+    serial_write_s(serial, value ? "true" : "false");
     putCommaIfNecessary(serial, more);
 }
 
 void json_objStartString(struct Serial *serial, const char *label)
 {
     putKeyAndColon(serial, label);
-    serial_put_c(serial, '{');
+    serial_write_c(serial, '{');
 }
 
 // Call itoa here and use above?
 void json_objStartInt(struct Serial *serial, int label)
 {
-    serial_put_c(serial, '"');
+    serial_write_c(serial, '"');
     put_int(serial, label);
-    serial_put_s(serial, "\":{");
+    serial_write_s(serial, "\":{");
 }
 
 void json_objStart(struct Serial *serial)
 {
-    serial_put_c(serial, '{');
+    serial_write_c(serial, '{');
 }
 
 void json_objEnd(struct Serial *serial, int more)
 {
-    serial_put_c(serial, '}');
+    serial_write_c(serial, '}');
     putCommaIfNecessary(serial, more);
 }
 
@@ -156,7 +156,7 @@ void json_arrayStart(struct Serial *serial, const char * name)
     if (name != NULL)
         putKeyAndColon(serial, name);
 
-    serial_put_c(serial, '[');
+    serial_write_c(serial, '[');
 }
 
 void json_arrayElementString(struct Serial *serial, const char *value, int more)
@@ -179,7 +179,7 @@ void json_arrayElementFloat(struct Serial *serial, float value, int precision, i
 
 void json_arrayEnd(struct Serial *serial, int more)
 {
-    serial_put_c(serial, ']');
+    serial_write_c(serial, ']');
     putCommaIfNecessary(serial, more);
 }
 

--- a/src/command/baseCommands.c
+++ b/src/command/baseCommands.c
@@ -37,16 +37,16 @@ extern unsigned int _CONFIG_HEAP_SIZE;
 static void putHeader(struct Serial *serial, const char *str)
 {
     put_crlf(serial);
-    serial_put_s(serial, "- - - ");
-    serial_put_s(serial, str);
-    serial_put_s(serial, " - - -");
+    serial_write_s(serial, "- - - ");
+    serial_write_s(serial, str);
+    serial_write_s(serial, " - - -");
     put_crlf(serial);
 }
 
 static void putDataRowHeader(struct Serial *serial, const char *str)
 {
-    serial_put_s(serial, str);
-    serial_put_s(serial, " : ");
+    serial_write_s(serial, str);
+    serial_write_s(serial, " : ");
 }
 
 void ShowStats(struct Serial *serial, unsigned int argc, char **argv)
@@ -91,7 +91,7 @@ void ShowTaskInfo(struct Serial *serial, unsigned int argc, char **argv)
 {
         putHeader(serial, "Task Info");
 
-        serial_put_s(serial, "Name\t\t\tStatus\tPri\tStackHR\tTask#");
+        serial_write_s(serial, "Name\t\t\tStatus\tPri\tStackHR\tTask#");
         put_crlf(serial);
 
         /*
@@ -102,16 +102,16 @@ void ShowTaskInfo(struct Serial *serial, unsigned int argc, char **argv)
         char *taskList = portMalloc(1024);
         if (NULL != taskList) {
                 vTaskList((signed char*) taskList);
-                serial_put_s(serial, taskList);
+                serial_write_s(serial, taskList);
                 portFree(taskList);
         } else {
-                serial_put_s(serial, "Out of Memory!");
+                serial_write_s(serial, "Out of Memory!");
         }
 
         put_crlf(serial);
         put_crlf(serial);
-        serial_put_s(serial, "[Note] StackHR: If StackHR < 0; then "
-                     "stack smash");
+        serial_write_s(serial, "[Note] StackHR: If StackHR < 0; then "
+		       "stack smash");
         put_crlf(serial);
 }
 

--- a/src/command/command.c
+++ b/src/command/command.c
@@ -58,24 +58,24 @@ static void clear_command_context()
 
 static void show_help(struct Serial *serial)
 {
-        serial_put_s(serial, "Available Commands:");
+        serial_write_s(serial, "Available Commands:");
         put_crlf(serial);
         put_crlf(serial);
 
     const cmd_t * cmd = commands;
     while (cmd->cmd != NULL) {
-            serial_put_s(serial, cmd->cmd);
+            serial_write_s(serial, cmd->cmd);
         int padding = menuPadding - strlen(cmd->cmd);
 
         while (padding-- > 0)
-                serial_put_c(serial, ' ');
+                serial_write_c(serial, ' ');
 
-        serial_put_s(serial, ": ");
-        serial_put_s(serial, cmd->help);
-        serial_put_s(serial, " Usage: ");
-        serial_put_s(serial, cmd->cmd);
-        serial_put_c(serial, ' ');
-        serial_put_s(serial, cmd->paramHelp);
+        serial_write_s(serial, ": ");
+        serial_write_s(serial, cmd->help);
+        serial_write_s(serial, " Usage: ");
+        serial_write_s(serial, cmd->cmd);
+        serial_write_c(serial, ' ');
+        serial_write_s(serial, cmd->paramHelp);
 
         put_crlf(serial);
         cmd++;
@@ -99,7 +99,7 @@ static void calculateMenuPadding()
 static void send_header(struct Serial *serial, unsigned int len)
 {
     while (len-- > 0) {
-        serial_put_c(serial, '=');
+        serial_write_c(serial, '=');
     }
     put_crlf(serial);
 }
@@ -109,7 +109,7 @@ void show_welcome(struct Serial *serial)
     put_crlf(serial);
     size_t len = strlen(welcomeMsg);
     send_header(serial, len);
-    serial_put_s(serial, welcomeMsg);
+    serial_write_s(serial, welcomeMsg);
     put_crlf(serial);
     send_header(serial, len);
     put_crlf(serial);
@@ -118,8 +118,8 @@ void show_welcome(struct Serial *serial)
 
 void show_command_prompt(struct Serial *serial)
 {
-    serial_put_s(serial, cmdPrompt);
-    serial_put_s(serial, " > ");
+    serial_write_s(serial, cmdPrompt);
+    serial_write_s(serial, " > ");
 }
 
 static int execute_command(struct Serial *serial, char *buffer)
@@ -159,23 +159,23 @@ int process_command(struct Serial *serial, char * buffer, size_t bufferSize)
 
 void put_commandOK(struct Serial *serial)
 {
-    serial_put_s(serial, COMMAND_OK_MSG);
+    serial_write_s(serial, COMMAND_OK_MSG);
 }
 
 void put_commandParamError(struct Serial *serial, char *msg)
 {
-    serial_put_s(serial, COMMAND_ERROR_MSG);
-    serial_put_s(serial, "extended=\"");
-    serial_put_s(serial, msg);
-    serial_put_s(serial, "\";");
+    serial_write_s(serial, COMMAND_ERROR_MSG);
+    serial_write_s(serial, "extended=\"");
+    serial_write_s(serial, msg);
+    serial_write_s(serial, "\";");
 }
 
 void put_commandError(struct Serial *serial, int result)
 {
-    serial_put_s(serial, COMMAND_ERROR_MSG);
-    serial_put_s(serial, "code=");
+    serial_write_s(serial, COMMAND_ERROR_MSG);
+    serial_write_s(serial, "code=");
     put_int(serial, result);
-    serial_put_s(serial, ";");
+    serial_write_s(serial, ";");
 }
 
 void init_command(void)

--- a/src/devices/cellular.c
+++ b/src/devices/cellular.c
@@ -353,7 +353,7 @@ static bool auth_telem_stream(struct serial_buffer *sb,
         json_string(serial, "sn", cpu_get_serialnumber(), 0);
         json_objEnd(serial, 0);
         json_objEnd(serial, 0);
-        serial_put_c(serial, '\n');
+        serial_write_c(serial, '\n');
 
         pr_debug_str_msg("sending auth- deviceId: ", deviceId);
 

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -912,7 +912,7 @@ static bool send_data_cb(struct at_rsp *rsp, void *up)
                         if (!xQueueReceive(q, &c, 0))
                             c = 0;
 
-                        serial_put_c(s, c);
+                        serial_write_c(s, c);
                 }
 
                 return true;

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -96,9 +96,6 @@ struct server {
 struct channel {
         struct Serial *serial;
         size_t tx_chars_buffered;
-        bool in_use;
-        bool connected;
-        bool created_externally;
 };
 
 struct channel_sync_op {
@@ -230,14 +227,32 @@ static bool cmd_ready() {
         return !esp8266_state.cmd.in_progress;
 }
 
-/* Begin code for sending/receiving data */
+/* Begin code for sending/receiving data using our internal channels */
 
-static bool is_valid_socket_channel_id(const size_t chan_id)
+static bool channel_is_valid_id(const size_t chan_id)
 {
         return chan_id < ARRAY_LEN(esp8266_state.comm.channels);
 }
 
-static const char* get_channel_name(const size_t chan_id)
+static bool channel_is_open(struct channel* ch)
+{
+	return !!ch->serial;
+}
+
+/**
+ * Called when we close a channel.  If we own the channel, reap it
+ * completely to avoid memory leaks.  Else simply close it.
+ */
+static void channel_close(struct channel* ch)
+{
+	if (!ch->serial)
+		return;
+
+	serial_close(ch->serial);
+	ch->serial = NULL;
+}
+
+static const char* channel_get_name(const size_t chan_id)
 {
         static const char* _serial_names[] = {
                 "Wifi Chan 0",
@@ -260,49 +275,39 @@ static void _tx_char_cb(xQueueHandle queue, void *post_tx_arg)
         cmd_set_check(CHECK_DATA);
 }
 
-static struct Serial* setup_channel_serial(const unsigned int i)
+static struct channel* channel_setup(const unsigned int i)
 {
-        const char* name = get_channel_name(i);
-        struct channel* ch =esp8266_state.comm.channels + i;
-        struct Serial *s = serial_create(name, SERIAL_TX_BUFF_SIZE,
-                                         SERIAL_RX_BUFF_SIZE, NULL, NULL,
-                                         _tx_char_cb, ch);
-        if (s)
-                return s;
-
-        /* Fail state */
-        pr_warning(LOG_PFX "Failed to create serial port\r\n");
-        return NULL;
-}
-
-static struct channel* get_channel_for_use(const unsigned int i)
-{
-        if (!is_valid_socket_channel_id(i))
+        if (!channel_is_valid_id(i))
                 return NULL;
 
         struct channel* ch = esp8266_state.comm.channels + i;
-        if (ch->serial)
-                return ch;
+        if (ch->serial) {
+		/* Channel is in use!  Something is wrong */
+                pr_warning_int_msg(LOG_PFX "Setup called on allocated "
+				   "channel ", i);
+		pr_warning(LOG_PFX "Closing stale Serial object");
+		channel_close(ch);
+	}
 
-        /* If here, channel has no serial.  Try to set one up */
-        ch->serial = setup_channel_serial(i);
-        return ch->serial ? ch : NULL;
+	const char* name = channel_get_name(i);
+        struct Serial *s = serial_create(name, SERIAL_TX_BUFF_SIZE,
+                                         SERIAL_RX_BUFF_SIZE, NULL, NULL,
+                                         _tx_char_cb, ch);
+
+	if (!s) {
+		/* Fail state */
+		pr_warning(LOG_PFX "Insufficient resources for new "
+			   "Serial\r\n");
+		return NULL;
+	}
+
+        ch->serial = s;
+        return ch;
 }
 
-static int get_next_free_channel_num()
+static int channel_find_serial(struct Serial *serial)
 {
-        for (size_t i = 0; is_valid_socket_channel_id(i); ++i) {
-                struct channel *ch = esp8266_state.comm.channels + i;
-                if (!ch->in_use)
-                        return i;
-        }
-
-        return -1;
-}
-
-static int find_channel_with_serial(struct Serial *serial)
-{
-        for (size_t i = 0; is_valid_socket_channel_id(i); ++i) {
+        for (size_t i = 0; channel_is_valid_id(i); ++i) {
                 struct channel *ch = esp8266_state.comm.channels + i;
                 if (serial == ch->serial)
                         return i;
@@ -311,6 +316,51 @@ static int find_channel_with_serial(struct Serial *serial)
         return -1;
 }
 
+static int channel_get_next_available()
+{
+	return channel_find_serial(NULL);
+}
+
+
+/**
+ * Callback that gets invoked when a socket state changes.
+ */
+static void socket_state_changed_cb(const size_t chan_id,
+                                    const enum socket_action action)
+{
+        if (!channel_is_valid_id(chan_id)) {
+                pr_warning_int_msg(LOG_PFX "Invalid socket id: ",
+                                   chan_id);
+                return;
+        }
+
+        struct channel *ch = esp8266_state.comm.channels + chan_id;
+        switch (action) {
+        case SOCKET_ACTION_DISCONNECT:
+                pr_info_int_msg(LOG_PFX "Socket closed on channel ",
+                                chan_id);
+		channel_close(ch);
+                break;
+        case SOCKET_ACTION_CONNECT:
+                pr_info_int_msg(LOG_PFX "Socket connected on channel ",
+                                chan_id);
+
+		channel_setup(chan_id);
+		if (!esp8266_state.comm.new_conn_cb) {
+			pr_error(LOG_PFX "No incomming server callback "
+				 "defined. Data \r\n");
+			return;
+		} else {
+			esp8266_state.comm.new_conn_cb(ch->serial);
+		}
+                break;
+        default:
+                pr_warning(LOG_PFX "Unknown socket action\r\n");
+                break;
+        }
+
+        cmd_set_check(CHECK_DATA);
+}
 
 /**
  * Callback that gets invoked by the device code whenever new data
@@ -319,45 +369,24 @@ static int find_channel_with_serial(struct Serial *serial)
 static void rx_data_cb(int chan_id, size_t len, const char* data)
 {
         trigger_led();
-        pr_debug_str_msg(LOG_PFX "Rx: ", data);
+        pr_trace_str_msg(LOG_PFX "Rx: ", data);
 
-        if (!is_valid_socket_channel_id(chan_id)) {
-                pr_error_int_msg(LOG_PFX "Channel id to big: ", chan_id);
+        if (!channel_is_valid_id(chan_id)) {
+                pr_error_int_msg(LOG_PFX "Invalid Channel ID: ", chan_id);
                 return;
         }
 
-        struct channel *ch = get_channel_for_use(chan_id);
-        if (NULL == ch) {
-                pr_error(LOG_PFX "No channel available.  Dropping\r\n");
-                return;
-        }
+	/*
+	 * Check that we have a backing serial device before we read in
+	 * the data. If none, gotta dump it.
+	 */
+	struct channel *ch = esp8266_state.comm.channels + chan_id;
+	if (!channel_is_open(ch)) {
+		pr_error(LOG_PFX "Channel has no backing serial device. "
+			 "Dropping data\r\n");
+		return;
+	}
 
-        /*
-         * Since these connections are created by an external source,
-         * we set the created_externally flag here.  This way
-         * we know to reap the channel when the connection disappears.
-         */
-        ch->created_externally = true;
-        ch->in_use = true;
-        ch->connected = true;
-
-        /*
-         * Check that we actually have a call back set to handle the
-         * incoming data.  If not then the socket stays open until it is
-         * closed by our WiFi host.
-         */
-        if (!esp8266_state.comm.new_conn_cb) {
-                pr_error(LOG_PFX "No Serial callback defined\r\n");
-                return;
-        }
-
-        esp8266_state.comm.new_conn_cb(ch->serial);
-
-        /*
-         * Now that the upper layer has been informed about the incoming
-         * data, start sending it said data.  It will unblock and read this
-         * data very shortly.
-         */
         xQueueHandle q = serial_get_rx_queue(ch->serial);
         bool data_dropped = false;
         for (size_t i = 0; i < len && !data_dropped; ++i)
@@ -365,7 +394,7 @@ static void rx_data_cb(int chan_id, size_t len, const char* data)
                         data_dropped = true;
 
         if (data_dropped)
-                pr_warning(LOG_PFX "Rx data dropped!\r\n");
+                pr_warning(LOG_PFX "Rx Buffer Overflow Detected\r\n");
 
         cmd_set_check(CHECK_DATA);
 }
@@ -394,6 +423,7 @@ static void check_data()
         for (size_t i = 0; i < ARRAY_LEN(esp8266_state.comm.channels); ++i) {
                 struct channel *ch = esp8266_state.comm.channels + i;
                 const size_t size = ch->tx_chars_buffered;
+		struct Serial* serial = ch->serial;
 
                 /* If the size is 0, nothing to send */
                 if (0 == size)
@@ -401,19 +431,16 @@ static void check_data()
 
                 /*
                  * If here, then we have data to send.  Check that the
-                 * connection is still active.  If not, dump the data
+                 * connection is still active.  If not, clear our count
+		 * and be done.
                  */
-                if (!ch->connected) {
-                        serial_purge_tx_queue(ch->serial);
+		if (!serial_is_connected(ch->serial)) {
                         ch->tx_chars_buffered = 0;
                         continue;
                 }
 
                 /* If here, we have a connection and data to send. Do Eet! */
-                const bool cmd_queued =
-                        esp8266_send_data(i, ch->serial, size, _send_data_cb);
-
-                if (!cmd_queued) {
+                if (!esp8266_send_data(i, serial, size, _send_data_cb)) {
                         pr_warning(LOG_PFX "Failed to queue send "
                                    "data command!!!\r\n");
                         /* We will retry */
@@ -440,56 +467,6 @@ static void client_state_changed_cb(const char* msg)
                sizeof(esp8266_state.client.ipv4));
 
         pr_info_str_msg(LOG_PFX "Client state changed: ", msg);
-}
-
-/**
- * Callback that gets invoked when a socket state changes.
- */
-static void socket_state_changed_cb(const size_t chan_id,
-                                    const enum socket_action action)
-{
-        if (!is_valid_socket_channel_id(chan_id)) {
-                pr_warning_int_msg(LOG_PFX "Invalid socket id: ",
-                                   chan_id);
-                return;
-        }
-
-        struct channel *ch = esp8266_state.comm.channels + chan_id;
-        switch (action) {
-        case SOCKET_ACTION_DISCONNECT:
-                pr_info_int_msg(LOG_PFX "Socket closed on channel ",
-                                chan_id);
-                /*
-                 * If channel created externally, then when closed it
-                 * means it is no longer in use.
-                 */
-                if (ch->created_externally)
-                        ch->in_use = false;
-
-                ch->created_externally = false;
-                ch->connected = false;
-
-                /*
-                 * Clear the serial data out since channel is now closed
-                 * we don't want any cruft in there the next time a channel
-                 * gets opened.  Also be sure the serial exists, as it could
-                 * fail to get created.
-                 */
-                if (ch->serial)
-                        serial_clear(ch->serial);
-
-                break;
-        case SOCKET_ACTION_CONNECT:
-                pr_info_int_msg(LOG_PFX "Socket connected on channel ",
-                                chan_id);
-                ch->connected = true;
-                break;
-        default:
-                pr_warning(LOG_PFX "Unknown socket action\r\n");
-                break;
-        }
-
-        cmd_set_check(CHECK_DATA);
 }
 
 /* *** Methods that handle device init and reset *** */
@@ -1310,16 +1287,15 @@ static void connect_cb(const bool status, const bool already_connected)
         struct channel_sync_op *cso = &esp8266_state.comm.connect_op;
         struct channel *ch = esp8266_state.comm.channels + cso->chan_id;
 
-        ch->connected = status;
-
-        if (!status && already_connected) {
-                /* Attempt to close the connection to rectify state */
-                pr_info(LOG_PFX "Closing unexpectedly open connection\r\n");
-                esp8266_close(cso->chan_id, NULL);
-        }
+        if (already_connected) {
+		pr_info(LOG_PFX "State Mismatch. Channel already connected\r\n");
+                channel_close(ch);
+        } else if (!status) {
+		pr_info(LOG_PFX "Channel failed to connect\r\n");
+		channel_close(ch);
+	}
 
         cmd_set_check(CHECK_DATA);
-
         xSemaphoreGive(cso->cb_semaphore);
 }
 
@@ -1339,18 +1315,19 @@ struct Serial* esp8266_drv_connect(const enum protocol proto,
         xSemaphoreTake(cso->op_semaphore, portMAX_DELAY);
 
         struct Serial* serial = NULL;
-        cso->chan_id = get_next_free_channel_num();
+        cso->chan_id = channel_get_next_available();
         if (cso->chan_id < 0) {
                 pr_warning(LOG_PFX "Failed to acquire a free channel\r\n");
                 goto done;
         }
 
-        struct channel *ch = get_channel_for_use(cso->chan_id);
+        struct channel *ch = channel_setup(cso->chan_id);
         if (NULL == ch) {
                 pr_warning(LOG_PFX "Can't allocate resources for channel\r\n");
                 goto done;
         }
 
+	ch->serial = serial;
         bool connect_result = false;
         switch(proto) {
         case PROTOCOL_TCP:
@@ -1382,12 +1359,14 @@ struct Serial* esp8266_drv_connect(const enum protocol proto,
                 goto done;
         }
 
-        if (!ch->connected) {
+	/* If unsuccessful, the callback will close the channel */
+        if (!channel_is_open(ch)) {
                 pr_info_str_msg(LOG_PFX "Failed to connect: ", addr);
+		serial_destroy(serial);
+		serial = NULL;
                 goto done;
         }
 
-        ch->in_use = true;
         serial = ch->serial;
         pr_info_int_msg(LOG_PFX "Connected on comm channel ", cso->chan_id);
 
@@ -1402,12 +1381,11 @@ done:
 static void close_cb(const bool status)
 {
         struct channel_sync_op *cso = &esp8266_state.comm.close_op;
-        struct channel *ch = esp8266_state.comm.channels + cso->chan_id;
-
-        if (status)
-                ch->connected = false;
-
         cmd_set_check(CHECK_DATA);
+
+	if (!status)
+		pr_warning_int_msg(LOG_PFX "Failed to close channel ",
+				   (int) cso->chan_id);
 
         xSemaphoreGive(cso->cb_semaphore);
 }
@@ -1425,16 +1403,19 @@ bool esp8266_drv_close(struct Serial* serial)
         xSemaphoreTake(cso->op_semaphore, portMAX_DELAY);
         bool status = false;
 
-        cso->chan_id = find_channel_with_serial(serial);
-        if (0 > cso->chan_id) {
+        cso->chan_id = channel_find_serial(serial);
+        if (cso->chan_id < 0) {
                 pr_warning(LOG_PFX "Unable to find channel with associated "
                            "Serial device.\r\n");
                 goto done;
         }
 
         struct channel *ch = esp8266_state.comm.channels + cso->chan_id;
-        if (!ch->connected)
-                pr_warning(LOG_PFX "Channel supposedly not connected.\r\n");
+        if (channel_is_open(ch)) {
+		struct Serial* s = ch->serial;
+		channel_close(ch);
+		serial_destroy(s);
+	}
 
         if (!esp8266_close(cso->chan_id, close_cb)) {
                 pr_warning(LOG_PFX "Failed to issue close command\r\n");
@@ -1447,14 +1428,6 @@ bool esp8266_drv_close(struct Serial* serial)
                            "response\r\n");
                 goto done;
         }
-
-        if (ch->connected) {
-                pr_info_int_msg(LOG_PFX "Failed to close channel ", cso->chan_id);
-                goto done;
-        }
-
-        ch->in_use = false;
-        ch->created_externally = false;
 
 done:
         xSemaphoreGive(cso->op_semaphore);

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -353,7 +353,7 @@ static void socket_state_changed_cb(const size_t chan_id,
 		if (esp8266_state.comm.new_conn_cb) {
 			esp8266_state.comm.new_conn_cb(ch->serial);
 		} else {
-			pr_warning(LOG_PFX "No incomming server callback "
+			pr_warning(LOG_PFX "No incoming server callback "
 				   "defined. Data \r\n");
 		}
                 break;
@@ -1291,10 +1291,12 @@ static void connect_cb(const bool status, const bool already_connected)
         struct channel *ch = esp8266_state.comm.channels + cso->chan_id;
 
         if (already_connected) {
-		pr_info(LOG_PFX "State Mismatch. Channel already connected\r\n");
+		pr_info_int_msg(LOG_PFX "State mismatch. Channel already "
+				"connected: ", cso->chan_id);
                 channel_close(ch);
         } else if (!status) {
-		pr_info(LOG_PFX "Channel failed to connect\r\n");
+		pr_info_int_msg(LOG_PFX "Failed to connect channel: ",
+				cso->chan_id);
 		channel_close(ch);
 	}
 
@@ -1408,7 +1410,7 @@ bool esp8266_drv_close(struct Serial* serial)
         cso->chan_id = channel_find_serial(serial);
         if (cso->chan_id < 0) {
                 pr_warning(LOG_PFX "Unable to find channel with associated "
-                           "Serial device.\r\n");
+                           "serial device.\r\n");
                 goto done;
         }
 

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -1327,7 +1327,6 @@ struct Serial* esp8266_drv_connect(const enum protocol proto,
                 goto done;
         }
 
-	ch->serial = serial;
         bool connect_result = false;
         switch(proto) {
         case PROTOCOL_TCP:

--- a/src/logger/connectivityTask.c
+++ b/src/logger/connectivityTask.c
@@ -83,8 +83,13 @@ static size_t trimBuffer(char *buffer, size_t count)
 
 static int processRxBuffer(struct Serial *serial, char *buffer, size_t *rxCount)
 {
-        size_t count = serial_get_line_wait(serial, buffer + *rxCount,
-                                            BUFFER_SIZE - *rxCount, 0);
+        const int count = serial_read_line_wait(serial, buffer + *rxCount,
+						BUFFER_SIZE - *rxCount, 0);
+
+	if (count < 0) {
+		pr_error("[connectivityTask] Serial device closed\r\n");
+		return 0;
+	}
 
     *rxCount += count;
     int processMsg = 0;

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -1893,21 +1893,13 @@ static int get_telemetry_api_return_code(const int cmd_result)
        }
 }
 
-int api_set_telemetry_start(struct Serial *serial, const jsmntok_t *json)
+int api_set_telemetry(struct Serial *serial, const jsmntok_t *json)
 {
-        int sample_rate = 1;
+        int sample_rate = 0;
         jsmn_exists_set_val_int(json, "rate", &sample_rate);
 
-        const int cmd_result =
-                serial_ioctl(serial, SERIAL_IOCTL_TELEMETRY_ENABLE,
-                             (void*) (long) sample_rate);
-        return get_telemetry_api_return_code(cmd_result);
-}
-
-int api_set_telemetry_stop(struct Serial *serial, const jsmntok_t *json)
-{
-        const int cmd_result =
-                serial_ioctl(serial, SERIAL_IOCTL_TELEMETRY_DISABLE, NULL);
+        const int cmd_result = serial_ioctl(serial, SERIAL_IOCTL_TELEMETRY,
+					    (void*) (long) sample_rate);
         return get_telemetry_api_return_code(cmd_result);
 }
 

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -423,11 +423,11 @@ static void write_sample_meta(struct Serial *serial, const struct sample *sample
 
         for (size_t i = 0; i < sample->channel_count; ++i, ++channel_sample) {
                 if (0 < i)
-                        serial_put_c(serial, ',');
+                        serial_write_c(serial, ',');
 
-                serial_put_c(serial, '{');
+                serial_write_c(serial, '{');
                 json_channelConfig(serial, channel_sample->cfg, 0);
-                serial_put_c(serial, '}');
+                serial_write_c(serial, '}');
         }
 
         json_arrayEnd(serial, more);
@@ -517,7 +517,7 @@ void api_send_sample_record(struct Serial *serial,
                                                    cs->sampleData);
                                 break;
                         }
-                        serial_put_c(serial, ',');
+                        serial_write_c(serial, ',');
                 }
         }
 
@@ -525,7 +525,7 @@ void api_send_sample_record(struct Serial *serial,
         for (size_t i = 0; i < channelBitmaskCount; i++) {
                 put_uint(serial, channelBitmask[i]);
                 if (i < channelBitmaskCount - 1)
-                        serial_put_c(serial, ',');
+                        serial_write_c(serial, ',');
         }
 
         json_arrayEnd(serial, 0);
@@ -714,7 +714,7 @@ static void sendAnalogConfig(struct Serial *serial, size_t startIndex, size_t en
         for (size_t b = 0; b < ANALOG_SCALING_BINS; b++) {
             put_float(serial,  adcCfg->scalingMap.rawValues[b], SCALING_MAP_BIN_PRECISION);
             if (b < ANALOG_SCALING_BINS - 1)
-                serial_put_c(serial, ',');
+                serial_write_c(serial, ',');
         }
 
         json_arrayEnd(serial, 1);
@@ -723,7 +723,7 @@ static void sendAnalogConfig(struct Serial *serial, size_t startIndex, size_t en
         for (size_t b = 0; b < ANALOG_SCALING_BINS; b++) {
             put_float(serial, adcCfg->scalingMap.scaledValues[b], DEFAULT_ANALOG_SCALING_PRECISION);
             if (b < ANALOG_SCALING_BINS - 1)
-                serial_put_c(serial, ',');
+                serial_write_c(serial, ',');
         }
 
         json_arrayEnd(serial, 0);
@@ -867,9 +867,9 @@ int api_getLogfile(struct Serial *serial, const jsmntok_t *json)
 {
     json_objStart(serial);
     json_valueStart(serial, "logfile");
-    serial_put_c(serial, '"');
+    serial_write_c(serial, '"');
     read_log_to_serial(serial, 1);
-    serial_put_c(serial, '"');
+    serial_write_c(serial, '"');
     json_objEnd(serial,0);
     return API_SUCCESS_NO_RETURN;
 }

--- a/src/logging/printk.c
+++ b/src/logging/printk.c
@@ -51,7 +51,7 @@ size_t read_log_to_serial(struct Serial *s, int escape)
                 if (escape) {
                         put_escapedString(s, buff, bytes);
                 } else {
-                        serial_put_s(s, buff);
+                        serial_write_s(s, buff);
                 }
         }
 

--- a/src/lua/luaBaseBinding.c
+++ b/src/lua/luaBaseBinding.c
@@ -235,7 +235,7 @@ static int log_print(lua_State *L, bool addNewline)
         if (in_interactive_mode()) {
                 struct Serial *serial = get_command_context()->serial;
                 if (serial) {
-                        serial_put_s(serial, lua_tostring(L,1));
+                        serial_write_s(serial, lua_tostring(L,1));
                         if (addNewline)
                                 put_crlf(serial);
                 }

--- a/src/lua/luaCommands.c
+++ b/src/lua/luaCommands.c
@@ -35,7 +35,7 @@ static int g_interactive_mode = 0;
 
 void ExecLuaInterpreter(struct Serial *serial, unsigned int argc, char **argv)
 {
-        serial_put_s(serial, "Entering Lua Interpreter. enter 'exit' "
+        serial_write_s(serial, "Entering Lua Interpreter. enter 'exit' "
                      "to leave");
         put_crlf(serial);
 
@@ -45,7 +45,7 @@ void ExecLuaInterpreter(struct Serial *serial, unsigned int argc, char **argv)
         g_interactive_mode = 1;
 
         for(;;) {
-                serial_put_s(serial, "> ");
+                serial_write_s(serial, "> ");
                 interactive_read_line(serial, luaLine, cmdContext->lineBufferSize);
 
                 if (0 == strcmp(luaLine, "exit"))

--- a/src/lua/luaLoggerBinding.c
+++ b/src/lua/luaLoggerBinding.c
@@ -350,7 +350,7 @@ static int lua_serial_read_char(lua_State *L)
 
         char c;
         struct Serial *serial = lua_get_serial(L, port);
-        if (serial_get_c_wait(serial, &c, timeout)) {
+        if (0 < serial_read_c_wait(serial, &c, timeout)) {
                 lua_pushlstring(L, &c, 1);
         } else {
                 lua_pushnil(L);
@@ -386,11 +386,12 @@ static int lua_serial_read_line(lua_State *L)
 
         struct Serial *serial = lua_get_serial(L, port);
         /* STIEG: Would be nice to be rid of that tempBuffer */
-        const size_t len = serial_get_line_wait(serial, g_tempBuffer,
-                                                TEMP_BUFFER_LEN - 1,
-                                                timeout);
-        g_tempBuffer[len] = 0;
-        if (len) {
+        const int len = serial_read_line_wait(serial, g_tempBuffer,
+					      TEMP_BUFFER_LEN - 1,
+					      timeout);
+
+        if (0 < len) {
+		g_tempBuffer[len] = 0;
                 lua_pushstring(L, g_tempBuffer);
         } else {
                 lua_pushnil(L);
@@ -420,8 +421,8 @@ static int lua_serial_write_line(lua_State *L)
         const char *data = lua_tostring(L, 2);
 
         struct Serial *serial = lua_get_serial(L, port);
-        serial_put_s(serial, data);
-        serial_put_c(serial, '\n');
+        serial_write_s(serial, data);
+        serial_write_c(serial, '\n');
 
         return 0;
 }
@@ -448,7 +449,7 @@ static int lua_serial_write_char(lua_State *L)
         const char *data = lua_tostring(L, 2);
 
         struct Serial *serial = lua_get_serial(L, port);
-        serial_put_c(serial, *data);
+        serial_write_c(serial, *data);
 
         return 0;
 }

--- a/src/lua/luaTask.c
+++ b/src/lua/luaTask.c
@@ -311,7 +311,7 @@ static lua_State* setup_lua_state()
 void lua_task_run_interactive_cmd(struct Serial *serial, const char* cmd)
 {
         if (!is_init(false) || !is_runtime_active()) {
-                serial_put_s(serial, "error: LUA not initialized or active.");
+                serial_write_s(serial, "error: LUA not initialized or active.");
                 put_crlf(serial);
                 return;
         }
@@ -319,7 +319,7 @@ void lua_task_run_interactive_cmd(struct Serial *serial, const char* cmd)
         const size_t ticks = msToTicks(LUA_LOCK_WAIT_MS);
         const bool got_lock = get_lock_wait(ticks);
         if (!got_lock) {
-                serial_put_s(serial, "Error: Lua Runtime unresponsive.  "
+                serial_write_s(serial, "Error: Lua Runtime unresponsive.  "
                              "Check script.");
                 put_crlf(serial);
                 return;
@@ -339,9 +339,9 @@ void lua_task_run_interactive_cmd(struct Serial *serial, const char* cmd)
          */
         int result = luaL_loadstring(ls, cmd) || lua_pcall(ls, 0, 0, 0);
         if (0 != result) {
-                serial_put_s(serial, "error: (");
-                serial_put_s(serial, lua_tostring(ls, -1));
-                serial_put_c(serial, ')');
+                serial_write_s(serial, "error: (");
+                serial_write_s(serial, lua_tostring(ls, -1));
+                serial_write_c(serial, ')');
                 put_crlf(serial);
                 lua_pop(ls, 1);
         }

--- a/src/messaging/messaging.c
+++ b/src/messaging/messaging.c
@@ -52,7 +52,7 @@ int process_read_msg(struct Serial *serial, char *buff, size_t len)
                 ;
                 const int res = process_command(serial, buff, len);
                 if (res != COMMAND_OK) {
-                        serial_put_s(serial, "Unknown Command- Press "
+                        serial_write_s(serial, "Unknown Command- Press "
                                      "Enter for Help.");
                         put_crlf(serial);
                 }
@@ -82,8 +82,8 @@ void process_msg(struct Serial *serial, char * buffer, size_t bufferSize)
             } else {
                 int res = process_command(serial, buffer, bufferSize);
                 if (res != COMMAND_OK) {
-                        serial_put_s(serial, "Unknown Command- Press Enter "
-                                     "for Help.");
+                        serial_write_s(serial, "Unknown Command- Press Enter "
+				       "for Help.");
                         put_crlf(serial);
                 }
             }

--- a/src/modem/at_basic.c
+++ b/src/modem/at_basic.c
@@ -45,7 +45,7 @@ bool at_basic_wait_for_msg(struct Serial* serial, const char* msg,
 	while (!date_time_is_past(term) && *ptr) {
 		const size_t max_delay_ms = term - getUptime();
 		char rx_char;
-		if (serial_get_c_wait(serial, &rx_char, max_delay_ms))
+		if (0 < serial_read_c_wait(serial, &rx_char, max_delay_ms))
 			ptr = rx_char == *ptr ? ptr + 1 : msg;
 	}
 
@@ -65,7 +65,7 @@ bool at_basic_ping(struct Serial* serial, const size_t tries,
 
 	for (size_t try = 0; try < tries; ++try) {
 		serial_flush(serial);
-		serial_put_s(serial, cmd);
+		serial_write_s(serial, cmd);
 		if (at_basic_wait_for_msg(serial, "OK", delay_ms))
 			return true;
 	}

--- a/src/sdcard/sdcard.c
+++ b/src/sdcard/sdcard.c
@@ -81,19 +81,19 @@ void TestSDWrite(struct Serial *serial, int lines, int doFlush, int quiet)
 
         fatFile = pvPortMalloc(sizeof(FIL));
         if (NULL == fatFile) {
-                if (!quiet) serial_put_s(serial,
-                                         "could not allocate file object\r\n");
+                if (!quiet) serial_write_s(serial,
+					   "could not allocate file object\r\n");
                 goto exit;
         }
 
         if (!quiet) {
-                serial_put_s(serial,"Test Write: Lines: ");
+                serial_write_s(serial,"Test Write: Lines: ");
                 put_int(serial, lines);
                 put_crlf(serial);
-                serial_put_s(serial,"Flushing Enabled: " );
+                serial_write_s(serial,"Flushing Enabled: " );
                 put_int(serial, doFlush);
                 put_crlf(serial);
-                serial_put_s(serial,"Card Init... ");
+                serial_write_s(serial,"Card Init... ");
         }
 
         res = InitFS();
@@ -102,7 +102,7 @@ void TestSDWrite(struct Serial *serial, int lines, int doFlush, int quiet)
         if (!quiet) {
                 put_int(serial, res);
                 put_crlf(serial);
-                serial_put_s(serial,"Opening File... ");
+                serial_write_s(serial,"Opening File... ");
         }
 
         res = f_open(fatFile,"test1.txt", FA_WRITE | FA_CREATE_ALWAYS);
@@ -115,7 +115,7 @@ void TestSDWrite(struct Serial *serial, int lines, int doFlush, int quiet)
                 goto exit;
 
         if (!quiet)
-                serial_put_s(serial, "Writing file..");
+                serial_write_s(serial, "Writing file..");
 
         portTickType startTicks = xTaskGetTickCount();
         for (int i = 1; i <= lines; i++) {
@@ -123,12 +123,12 @@ void TestSDWrite(struct Serial *serial, int lines, int doFlush, int quiet)
                 if (doFlush) f_sync(fatFile);
                 if (res == EOF) {
                         if (!quiet)
-                                serial_put_s(serial, "failed writing at line ");
+                                serial_write_s(serial, "failed writing at line ");
 
                         put_int(serial, i);
-                        serial_put_s(serial,"(");
+                        serial_write_s(serial,"(");
                         put_int(serial, res);
-                        serial_put_s(serial,")");
+                        serial_write_s(serial,")");
                         put_crlf(serial);
                         goto exit;
                 }
@@ -137,10 +137,10 @@ void TestSDWrite(struct Serial *serial, int lines, int doFlush, int quiet)
         portTickType endTicks = xTaskGetTickCount();
 
         if (!quiet) {
-                serial_put_s(serial,"Ticks to write: ");
+                serial_write_s(serial,"Ticks to write: ");
                 put_int(serial, endTicks - startTicks);
                 put_crlf(serial);
-                serial_put_s(serial,"Closing... ");
+                serial_write_s(serial,"Closing... ");
         }
 
         res = f_close(fatFile);
@@ -151,7 +151,7 @@ void TestSDWrite(struct Serial *serial, int lines, int doFlush, int quiet)
         if (res) goto exit;
 
         if (!quiet)
-                serial_put_s(serial,"Unmounting... ");
+                serial_write_s(serial,"Unmounting... ");
 
         res = UnmountFS();
 
@@ -165,9 +165,9 @@ exit:
                 put_int(serial, res == 0 ? 1 : 0);
         } else {
                 if(res == 0) {
-                        serial_put_s(serial,"SUCCESS");
+                        serial_write_s(serial,"SUCCESS");
                 } else {
-                        serial_put_s(serial,"ERROR");
+                        serial_write_s(serial,"ERROR");
                         put_int(serial, res);
                         put_crlf(serial);
                 }

--- a/src/serial/rx_buff.c
+++ b/src/serial/rx_buff.c
@@ -120,8 +120,8 @@ bool rx_buff_read(struct rx_buff *rxb, struct Serial *s, const bool echo)
                         if (rxb->idx) {
                                 --rxb->idx;
                                 if (rxb->echo) {
-                                        serial_put_c(s, 0x08);
-                                        serial_put_c(s, 0x7f);
+                                        serial_write_c(s, 0x08);
+                                        serial_write_c(s, 0x7f);
                                 }
                         }
                         break;
@@ -132,7 +132,7 @@ bool rx_buff_read(struct rx_buff *rxb, struct Serial *s, const bool echo)
                 default:
                         /* If we are echoing, do it */
                         if (rxb->echo)
-                                serial_put_c(s, c);
+                                serial_write_c(s, c);
 
                         rxb->buff[rxb->idx] = c;
                         ++rxb->idx;
@@ -153,7 +153,7 @@ bool rx_buff_read(struct rx_buff *rxb, struct Serial *s, const bool echo)
             (rxb->idx == rxb->cap && rxb->msg_ready)) {
                 /* Turn the term character into the null */
                 if (rxb->echo)
-                        serial_put_c(s, c);
+                        serial_write_c(s, c);
 
                 rxb->buff[rxb->idx - 1] = 0;
         } else {
@@ -168,7 +168,7 @@ bool rx_buff_read(struct rx_buff *rxb, struct Serial *s, const bool echo)
         if ('\r' == c && xQueuePeek(h, &c, 0) && '\n' == c) {
                 xQueueReceive(h, &c, 0);
                 if (rxb->echo)
-                        serial_put_c(s, c);
+                        serial_write_c(s, c);
         }
 
         return true;

--- a/src/serial/serial.c
+++ b/src/serial/serial.c
@@ -253,7 +253,7 @@ bool serial_config(struct Serial *s, const size_t bits,
 
 bool serial_is_connected(const struct Serial* s)
 {
-	return s->rx_queue || s->tx_queue;
+	return s && (s->rx_queue || s->tx_queue);
 }
 
 /**

--- a/src/serial/serial.c
+++ b/src/serial/serial.c
@@ -298,7 +298,7 @@ void serial_flush(struct Serial *s)
         /* STIEG: TODO Figure out how to flush Tx sanely */
 }
 
-int serial_get_c_wait(struct Serial *s, char *c, const size_t delay)
+int serial_read_c_wait(struct Serial *s, char *c, const size_t delay)
 {
 	if (!s->rx_queue)
 		return -1;
@@ -310,9 +310,9 @@ int serial_get_c_wait(struct Serial *s, char *c, const size_t delay)
         return 1;
 }
 
-int serial_get_c(struct Serial *s, char* c)
+int serial_read_c(struct Serial *s, char* c)
 {
-        return serial_get_c_wait(s, c, portMAX_DELAY);
+        return serial_read_c_wait(s, c, portMAX_DELAY);
 }
 
 /**
@@ -325,12 +325,12 @@ int serial_get_c(struct Serial *s, char* c)
  * @param delay The number of ticks to wait.
  * @return Number of characters read.
  */
-int serial_get_line_wait(struct Serial *s, char *buff, const size_t len,
+int serial_read_line_wait(struct Serial *s, char *buff, const size_t len,
                          const size_t delay)
 {
         int i = 0;
         for (; i < len; ++i) {
-                switch(serial_get_c_wait(s, buff + i, delay)) {
+                switch(serial_read_c_wait(s, buff + i, delay)) {
 		default:
 			panic(PANIC_CAUSE_UNREACHABLE);
 			break;
@@ -348,12 +348,12 @@ int serial_get_line_wait(struct Serial *s, char *buff, const size_t len,
         return i;
 }
 
-int serial_get_line(struct Serial *s, char *l, const size_t len)
+int serial_read_line(struct Serial *s, char *l, const size_t len)
 {
-        return serial_get_line_wait(s, l, len, portMAX_DELAY);
+        return serial_read_line_wait(s, l, len, portMAX_DELAY);
 }
 
-int serial_put_c_wait(struct Serial *s, const char c, const size_t delay)
+int serial_write_c_wait(struct Serial *s, const char c, const size_t delay)
 {
 	if (!s->tx_queue)
 		return -1;
@@ -369,17 +369,17 @@ int serial_put_c_wait(struct Serial *s, const char c, const size_t delay)
         return 1;
 }
 
-int serial_put_c(struct Serial *s, const char c)
+int serial_write_c(struct Serial *s, const char c)
 {
-        return serial_put_c_wait(s, c, portMAX_DELAY);
+        return serial_write_c_wait(s, c, portMAX_DELAY);
 }
 
-int serial_put_buff_wait(struct Serial *s, const char *buf, const size_t len,
+int serial_write_buff_wait(struct Serial *s, const char *buf, const size_t len,
                          const size_t delay)
 {
         int i = 0;
         for (; i < len; ++i) {
-                switch(serial_put_c_wait(s, buf[i], delay)) {
+                switch(serial_write_c_wait(s, buf[i], delay)) {
 		default:
 			panic(PANIC_CAUSE_UNREACHABLE);
 			break;
@@ -396,24 +396,24 @@ int serial_put_buff_wait(struct Serial *s, const char *buf, const size_t len,
         return i;
 }
 
-int serial_put_buff(struct Serial *s, const char *buf, const size_t len)
+int serial_write_buff(struct Serial *s, const char *buf, const size_t len)
 {
-        return serial_put_buff_wait(s, buf, len, portMAX_DELAY);
+        return serial_write_buff_wait(s, buf, len, portMAX_DELAY);
 }
 
-int serial_put_s_wait(struct Serial *s, const char *l, const size_t delay)
+int serial_write_s_wait(struct Serial *s, const char *l, const size_t delay)
 {
-	return serial_put_buff_wait(s, l, strlen(l), delay);
+	return serial_write_buff_wait(s, l, strlen(l), delay);
 }
 
-int serial_put_s(struct Serial *s, const char *l)
+int serial_write_s(struct Serial *s, const char *l)
 {
-        return serial_put_s_wait(s, l, portMAX_DELAY);
+        return serial_write_s_wait(s, l, portMAX_DELAY);
 }
 
 int serial_read_byte(struct Serial *serial, uint8_t *b, const size_t delay)
 {
-        return serial_get_c_wait(serial, (char*) b, delay);
+        return serial_read_c_wait(serial, (char*) b, delay);
 }
 
 xQueueHandle serial_get_rx_queue(struct Serial *s)
@@ -471,7 +471,7 @@ int serial_ioctl(struct Serial *s, unsigned long req, void* argp)
 /* static ssize_t _read(void *cookie, char *buf, size_t n) */
 /* { */
 /*         struct Serial *s = cookie; */
-/*         return (ssize_t) serial_get_line(s, buf, n); */
+/*         return (ssize_t) serial_read_line(s, buf, n); */
 /* } */
 
 /* typedef ssize_t cookie_write_function_t(void *__cookie, const char *__buf, */
@@ -479,7 +479,7 @@ int serial_ioctl(struct Serial *s, unsigned long req, void* argp)
 /* static ssize_t _write(void *cookie, const char *buf, size_t n) */
 /* { */
 /*         struct Serial *s = cookie; */
-/*         return (ssize_t) serial_put_buff(s, buf, n); */
+/*         return (ssize_t) serial_write_buff(s, buf, n); */
 /* } */
 
 /* typedef struct */
@@ -499,8 +499,8 @@ int serial_ioctl(struct Serial *s, unsigned long req, void* argp)
 /* }; */
 
 /* STIEG: Add "Serial_" prefix to these methods without them */
-/* STIEG: Migrate to _put_numeric_val once figure out float printf issue */
-/* static int _put_numeric_val(struct Serial *s, const char *fmt, ...) */
+/* STIEG: Migrate to _write_numeric_val once figure out float printf issue */
+/* static int _write_numeric_val(struct Serial *s, const char *fmt, ...) */
 /* { */
 /*         char buf[32]; */
 /*         va_list ap; */
@@ -509,189 +509,189 @@ int serial_ioctl(struct Serial *s, unsigned long req, void* argp)
 /*         vsnprintf(buf, ARRAY_LEN(buf), fmt, ap); */
 /*         va_end(ap); */
 
-/*         return serial_put_s(s, str_util_rstrip_zeros_inline(buf)); */
+/*         return serial_write_s(s, str_util_rstrip_zeros_inline(buf)); */
 /* } */
 
 int put_int(struct Serial *s, const int n)
 {
         char buf[12];
         modp_itoa10(n, buf);
-        return serial_put_s(s, buf);
+        return serial_write_s(s, buf);
 }
 
 int put_ll(struct Serial *s, const long long l)
 {
         char buf[22];
         modp_ltoa10(l, buf);
-        return serial_put_s(s, buf);
+        return serial_write_s(s, buf);
 }
 
 int put_hex(struct Serial *s, const int i)
 {
         char buf[30];
         modp_itoaX(i, buf, 16);
-        return serial_put_s(s, buf);
+        return serial_write_s(s, buf);
 }
 
 int put_uint(struct Serial *s, const unsigned int n)
 {
         char buf[20];
         modp_uitoa10(n, buf);
-        return serial_put_s(s, buf);
+        return serial_write_s(s, buf);
 }
 
 int put_float(struct Serial *s, const float f, const int precision)
 {
         char buf[20];
         modp_ftoa(f, buf, precision);
-        return serial_put_s(s, buf);
+        return serial_write_s(s, buf);
 }
 
 int put_double(struct Serial *s, const double f, const int precision)
 {
         char buf[30];
         modp_dtoa(f, buf, precision);
-        return serial_put_s(s, buf);
+        return serial_write_s(s, buf);
 }
 
 void put_nameIndexUint(struct Serial *serial, const char *s, int i, unsigned int n)
 {
-        serial_put_s(serial, s);
-        serial_put_s(serial, "_");
+        serial_write_s(serial, s);
+        serial_write_s(serial, "_");
         put_uint(serial, i);
-        serial_put_s(serial, "=");
+        serial_write_s(serial, "=");
         put_uint(serial, n);
-        serial_put_s(serial, ";");
+        serial_write_s(serial, ";");
 }
 
 void put_nameSuffixUint(struct Serial *serial, const char *s, const char *suf, unsigned int n)
 {
-        serial_put_s(serial, s);
-        serial_put_s(serial, "_");
-        serial_put_s(serial, suf);
-        serial_put_s(serial, "=");
+        serial_write_s(serial, s);
+        serial_write_s(serial, "_");
+        serial_write_s(serial, suf);
+        serial_write_s(serial, "=");
         put_uint(serial, n);
-        serial_put_s(serial, ";");
+        serial_write_s(serial, ";");
 }
 
 void put_nameUint(struct Serial *serial, const char *s, unsigned int n)
 {
-        serial_put_s(serial, s);
-        serial_put_s(serial, "=");
+        serial_write_s(serial, s);
+        serial_write_s(serial, "=");
         put_uint(serial, n);
-        serial_put_s(serial, ";");
+        serial_write_s(serial, ";");
 }
 
 void put_nameIndexInt(struct Serial *serial, const char *s, int i, int n)
 {
-        serial_put_s(serial, s);
-        serial_put_s(serial, "_");
+        serial_write_s(serial, s);
+        serial_write_s(serial, "_");
         put_uint(serial, i);
-        serial_put_s(serial, "=");
+        serial_write_s(serial, "=");
         put_int(serial, n);
-        serial_put_s(serial, ";");
+        serial_write_s(serial, ";");
 }
 
 void put_nameSuffixInt(struct Serial *serial, const char *s, const char *suf, int n)
 {
-        serial_put_s(serial, s);
-        serial_put_s(serial, "_");
-        serial_put_s(serial, suf);
-        serial_put_s(serial, "=");
+        serial_write_s(serial, s);
+        serial_write_s(serial, "_");
+        serial_write_s(serial, suf);
+        serial_write_s(serial, "=");
         put_int(serial, n);
-        serial_put_s(serial, ";");
+        serial_write_s(serial, ";");
 }
 
 void put_nameInt(struct Serial *serial, const char *s, int n)
 {
-        serial_put_s(serial, s);
-        serial_put_s(serial, "=");
+        serial_write_s(serial, s);
+        serial_write_s(serial, "=");
         put_int(serial, n);
-        serial_put_s(serial, ";");
+        serial_write_s(serial, ";");
 }
 
 void put_nameIndexDouble(struct Serial *serial, const char *s, int i, double n, int precision)
 {
-        serial_put_s(serial, s);
-        serial_put_s(serial, "_");
+        serial_write_s(serial, s);
+        serial_write_s(serial, "_");
         put_uint(serial, i);
-        serial_put_s(serial, "=");
+        serial_write_s(serial, "=");
         put_double(serial, n,precision);
-        serial_put_s(serial, ";");
+        serial_write_s(serial, ";");
 }
 
 void put_nameSuffixDouble(struct Serial *serial, const char *s, const char *suf, double n, int precision)
 {
-        serial_put_s(serial, s);
-        serial_put_s(serial, "_");
-        serial_put_s(serial, suf);
-        serial_put_s(serial, "=");
+        serial_write_s(serial, s);
+        serial_write_s(serial, "_");
+        serial_write_s(serial, suf);
+        serial_write_s(serial, "=");
         put_double(serial, n,precision);
-        serial_put_s(serial, ";");
+        serial_write_s(serial, ";");
 }
 
 void put_nameDouble(struct Serial *serial, const char *s, double n, int precision)
 {
-        serial_put_s(serial, s);
-        serial_put_s(serial, "=");
+        serial_write_s(serial, s);
+        serial_write_s(serial, "=");
         put_double(serial, n, precision);
-        serial_put_s(serial, ";");
+        serial_write_s(serial, ";");
 }
 
 void put_nameIndexFloat(struct Serial *serial, const char *s, int i, float n, int precision)
 {
-        serial_put_s(serial, s);
-        serial_put_s(serial, "_");
+        serial_write_s(serial, s);
+        serial_write_s(serial, "_");
         put_uint(serial, i);
-        serial_put_s(serial, "=");
+        serial_write_s(serial, "=");
         put_float(serial, n, precision);
-        serial_put_s(serial, ";");
+        serial_write_s(serial, ";");
 }
 
 void put_nameSuffixFloat(struct Serial *serial, const char *s, const char *suf, float n, int precision)
 {
-        serial_put_s(serial, s);
-        serial_put_s(serial, "_");
-        serial_put_s(serial, suf);
-        serial_put_s(serial, "=");
+        serial_write_s(serial, s);
+        serial_write_s(serial, "_");
+        serial_write_s(serial, suf);
+        serial_write_s(serial, "=");
         put_float(serial, n, precision);
-        serial_put_s(serial, ";");
+        serial_write_s(serial, ";");
 }
 
 void put_nameFloat(struct Serial *serial, const char *s, float n, int precision)
 {
-        serial_put_s(serial, s);
-        serial_put_s(serial, "=");
+        serial_write_s(serial, s);
+        serial_write_s(serial, "=");
         put_float(serial, n, precision);
-        serial_put_s(serial, ";");
+        serial_write_s(serial, ";");
 }
 
 void put_nameString(struct Serial *serial, const char *s, const char *v)
 {
-        serial_put_s(serial, s);
-        serial_put_s(serial, "=\"");
-        serial_put_s(serial, v);
-        serial_put_s(serial, "\";");
+        serial_write_s(serial, s);
+        serial_write_s(serial, "=\"");
+        serial_write_s(serial, v);
+        serial_write_s(serial, "\";");
 }
 
 void put_nameSuffixString(struct Serial *serial, const char *s, const char *suf, const char *v)
 {
-        serial_put_s(serial, s);
-        serial_put_s(serial, "_");
-        serial_put_s(serial, suf);
-        serial_put_s(serial, "=\"");
-        serial_put_s(serial, v);
-        serial_put_s(serial, "\";");
+        serial_write_s(serial, s);
+        serial_write_s(serial, "_");
+        serial_write_s(serial, suf);
+        serial_write_s(serial, "=\"");
+        serial_write_s(serial, v);
+        serial_write_s(serial, "\";");
 }
 
 void put_nameIndexString(struct Serial *serial, const char *s, int i, const char *v)
 {
-        serial_put_s(serial, s);
-        serial_put_s(serial, "_");
+        serial_write_s(serial, s);
+        serial_write_s(serial, "_");
         put_uint(serial, i);
-        serial_put_s(serial, "=\"");
-        serial_put_s(serial, v);
-        serial_put_s(serial, "\";");
+        serial_write_s(serial, "=\"");
+        serial_write_s(serial, v);
+        serial_write_s(serial, "\";");
 }
 
 void put_escapedString(struct Serial * serial, const char *v, int length)
@@ -700,16 +700,16 @@ void put_escapedString(struct Serial * serial, const char *v, int length)
         while (value - v < length) {
                 switch(*value) {
                 case '\n':
-                        serial_put_s(serial, "\\n");
+                        serial_write_s(serial, "\\n");
                         break;
                 case '\r':
-                        serial_put_s(serial, "\\r");
+                        serial_write_s(serial, "\\r");
                         break;
                 case '"':
-                        serial_put_s(serial, "\\\"");
+                        serial_write_s(serial, "\\\"");
                         break;
                 default:
-                        serial_put_c(serial, *value);
+                        serial_write_c(serial, *value);
                         break;
                 }
                 value++;
@@ -718,37 +718,37 @@ void put_escapedString(struct Serial * serial, const char *v, int length)
 
 void put_nameEscapedString(struct Serial *serial, const char *s, const char *v, int length)
 {
-        serial_put_s(serial, s);
-        serial_put_s(serial, "=\"");
+        serial_write_s(serial, s);
+        serial_write_s(serial, "=\"");
         const char *value = v;
         while (value - v < length) {
                 switch(*value) {
                 case ' ':
-                        serial_put_s(serial, "\\_");
+                        serial_write_s(serial, "\\_");
                         break;
                 case '\n':
-                        serial_put_s(serial, "\\n");
+                        serial_write_s(serial, "\\n");
                         break;
                 case '\r':
-                        serial_put_s(serial, "\\r");
+                        serial_write_s(serial, "\\r");
                         break;
                 case '"':
-                        serial_put_s(serial, "\\\"");
+                        serial_write_s(serial, "\\\"");
                         break;
                 default:
-                        serial_put_c(serial, *value);
+                        serial_write_c(serial, *value);
                         break;
                 }
                 value++;
         }
-        serial_put_s(serial, "\";");
+        serial_write_s(serial, "\";");
 }
 
 
 void put_bytes(struct Serial *serial, char *data, unsigned int length)
 {
         while (length > 0) {
-                serial_put_c(serial, *data);
+                serial_write_c(serial, *data);
                 data++;
                 length--;
         }
@@ -756,7 +756,7 @@ void put_bytes(struct Serial *serial, char *data, unsigned int length)
 
 void put_crlf(struct Serial *serial)
 {
-        serial_put_s(serial, "\r\n");
+        serial_write_s(serial, "\r\n");
 }
 
 void read_line(struct Serial *serial, char *buffer, size_t bufferSize)
@@ -764,7 +764,7 @@ void read_line(struct Serial *serial, char *buffer, size_t bufferSize)
         size_t bufIndex = 0;
         while(bufIndex < bufferSize - 1) {
 		char c;
-                if (1 == serial_get_c(serial, &c)) {
+                if (1 == serial_read_c(serial, &c)) {
                         if ('\r' == c) {
                                 break;
                         } else {
@@ -781,20 +781,20 @@ void interactive_read_line(struct Serial *serial, char * buffer, size_t bufferSi
         size_t bufIndex = 0;
         while(bufIndex < bufferSize - 1) {
 		char c;
-                if (1 == serial_get_c(serial, &c)) {
+                if (1 == serial_read_c(serial, &c)) {
                         if ('\r' == c) {
                                 break;
                         } else if ('\b' == c) {
                                 if (bufIndex > 0) {
                                         bufIndex--;
-                                        serial_put_c(serial, c);
+                                        serial_write_c(serial, c);
                                 }
                         } else {
-                                serial_put_c(serial, c);
+                                serial_write_c(serial, c);
                                 buffer[bufIndex++] = c;
                         }
                 }
         }
-        serial_put_s(serial, "\r\n");
+        serial_write_s(serial, "\r\n");
         buffer[bufIndex]='\0';
 }

--- a/src/serial/serial_buffer.c
+++ b/src/serial/serial_buffer.c
@@ -66,10 +66,10 @@ char* serial_buffer_rx(struct serial_buffer *sb,
         int read;
 
         while (!msg_len) {
-                read  = serial_get_line_wait(sb->serial, ptr, available,
-                                             msToTicks(ms_delay));
+                read  = serial_read_line_wait(sb->serial, ptr, available,
+					      msToTicks(ms_delay));
 
-                if (!read)
+                if (read < 1)
                         return NULL;
 
                 msg_len = serial_msg_strlen(ptr);
@@ -117,7 +117,7 @@ void serial_buffer_reset(struct serial_buffer *sb)
 
 void serial_buffer_tx(struct serial_buffer *sb)
 {
-        serial_put_s(sb->serial, sb->buffer);
+        serial_write_s(sb->serial, sb->buffer);
 }
 
 size_t serial_buffer_append(struct serial_buffer *sb, const char *buff)

--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -230,10 +230,8 @@ static int wifi_serial_ioctl(struct Serial* serial, unsigned long req,
 	}
 
         switch(req) {
-	case SERIAL_IOCTL_TELEMETRY_ENABLE:
+	case SERIAL_IOCTL_TELEMETRY:
 		return set_telemetry(conn, (int) (long) argp);
-        case SERIAL_IOCTL_TELEMETRY_DISABLE:
-		return set_telemetry(conn, 0);
         default:
                 pr_warning_int_msg(LOG_PFX "Unhandled ioctl request: ",
                                    (int) req);

--- a/src/usb_comm/usb_comm.c
+++ b/src/usb_comm/usb_comm.c
@@ -41,6 +41,7 @@
 static volatile struct {
         xQueueHandle event_queue;
         struct Serial* serial;
+	int ls_handle;
         struct {
                 struct rx_buff* buff;
         } rx;
@@ -86,9 +87,8 @@ static bool data_rx_isr_cb()
         return !!hpta;
 }
 
-static void usb_sample_cb(struct Serial* const serial,
-                          const struct sample* sample,
-                          const int tick)
+static void usb_sample_cb(const struct sample* sample,
+                          const int tick, void* data)
 {
         const struct usb_sample_data sample_data = {
                 .sample = sample,
@@ -108,27 +108,36 @@ static void usb_sample_cb(struct Serial* const serial,
 
 /* *** USB Serial IOCTL Handler *** */
 
+static int set_telemetry(int rate)
+{
+	const char* serial_name = serial_get_name(usb_state.serial);
+
+	/* Stop the stream if the rate is <= 0 */
+	if (rate <= 0) {
+		pr_info_str_msg(LOG_PFX "Stopping telem stream on ",
+				serial_name);
+
+		if (!logger_sample_destroy_callback(usb_state.ls_handle))
+			return -2;
+
+		usb_state.ls_handle = -1;
+		return 0;
+	}
+
+	pr_info_str_msg(LOG_PFX "Starting telem stream on ", serial_name);
+	usb_state.ls_handle = logger_sample_create_callback(usb_sample_cb,
+							    rate, NULL);
+	return usb_state.ls_handle < 0 ? -2 : 0;
+}
+
 static int usb_serial_ioctl(struct Serial* serial, unsigned long req,
                             void* argp)
 {
         switch(req) {
         case SERIAL_IOCTL_TELEMETRY_ENABLE:
-        {
-                pr_info(LOG_PFX "Starting telem stream\r\n");
-                const int rate = (int) (long) argp;
-                const bool success = logger_sample_register_callback(
-                        usb_sample_cb, serial) &&
-                        logger_sample_enable_callback(serial, rate);
-
-                return success ? 0 : -2;
-        }
+		return set_telemetry((int) (long) argp);
         case SERIAL_IOCTL_TELEMETRY_DISABLE:
-        {
-                pr_info(LOG_PFX "Stopping telem stream\r\n");
-                const bool success = logger_sample_disable_callback(serial);
-
-                return success ? 0 : -2;
-        }
+		return set_telemetry(0);
         default:
                 pr_warning_int_msg(LOG_PFX "Unhandled ioctl request: ",
                                    (int) req);

--- a/src/usb_comm/usb_comm.c
+++ b/src/usb_comm/usb_comm.c
@@ -134,10 +134,8 @@ static int usb_serial_ioctl(struct Serial* serial, unsigned long req,
                             void* argp)
 {
         switch(req) {
-        case SERIAL_IOCTL_TELEMETRY_ENABLE:
+        case SERIAL_IOCTL_TELEMETRY:
 		return set_telemetry((int) (long) argp);
-        case SERIAL_IOCTL_TELEMETRY_DISABLE:
-		return set_telemetry(0);
         default:
                 pr_warning_int_msg(LOG_PFX "Unhandled ioctl request: ",
                                    (int) req);

--- a/src/util/panic.c
+++ b/src/util/panic.c
@@ -102,3 +102,8 @@ void assert_failed(uint8_t* file, uint32_t line)
 	pr_error("ASSERTION Failure\r\n");
 	panic(PANIC_CAUSE_ASSERT);
 }
+
+void HardFault_Handler()
+{
+	panic(PANIC_CAUSE_ASSERT);
+}


### PR DESCRIPTION
This large-ish commit adds the ability for us to be able to "close" a serial device.  This is necessary since in some cases (wifi) the backing serial transport (a TCP session) can die without warning.  Thus we need a sane way to close a serial device without it adversely affecting the system.  This change implements that.

As part of this change I also took the liberty to rename many of the get/put serial methods into read/write methods.  Why?  For one to find all the spots where they were used so that I could ensure that we interpreted the new return values correctly.  Another reason was to make these calls almost the same as those that would be used for f_read and f_write.  The intention that Serial object is becoming our bridge object until we implement full File Stream support to replace it (and oh what a glorious day that will be).

This change also alters how we handle Serial devices on Wifi.  Now the WiFi task is responsible for closing said devices rather than the driver.  This is logical since the driver need only handle creation of Serial devices when asked or when new connections come in or closing Serial devices (but not destroying them) when said connections disappear.

This also optimizes our system a bit so that we use less memory when there are fewer connections.