### PR TITLE
Disable Wifi by default on MK2, enable by default everywhere else

### DIFF
--- a/platform/mk2/capabilities.h
+++ b/platform/mk2/capabilities.h
@@ -19,6 +19,7 @@
 /* Wifi Specific Info */
 #define WIFI_MAX_BAUD		230400
 #define WIFI_MAX_SAMPLE_RATE	50
+#define WIFI_ENABLED_DEFAULT	false
 
 /* Configuration */
 #define MAX_TRACKS	240

--- a/platform/rct/capabilities.h
+++ b/platform/rct/capabilities.h
@@ -20,6 +20,7 @@
 /* Wifi Specific Info */
 #define WIFI_MAX_BAUD		921600
 #define WIFI_MAX_SAMPLE_RATE	50
+#define WIFI_ENABLED_DEFAULT	true
 
 /* Configuration */
 #define MAX_TRACKS	0

--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -454,8 +454,8 @@ void wifi_reset_config(struct wifi_cfg *cfg)
         /* For now simply zero this out */
         memset(cfg, 0, sizeof(struct wifi_cfg));
 
-        /* Enable WiFi by Default */
-        cfg->active = true;
+        /* WiFi enable/disable default differs per platform */
+        cfg->active = WIFI_ENABLED_DEFAULT;
 
         /*
          * Set some sane values for the AP configuration.  We turn on our

--- a/test/capabilities.h
+++ b/test/capabilities.h
@@ -49,6 +49,8 @@ CPP_GUARD_BEGIN
 /* Wifi Specific Info */
 #define WIFI_MAX_BAUD		921600
 #define WIFI_MAX_SAMPLE_RATE	50
+#define WIFI_ENABLED_DEFAULT	true
+
 /*
  * What is the maximum number of samples available per predictive time
  * buffer.  More samples == better resolution. Each slot is 12 bytes.


### PR DESCRIPTION
Because WiFi isn't a native part of MK2 like it is on some other
devices.  Hence we don't want it on unless the customer says so.

Issue #778