### PR TITLE
Reduce Track DB size to 2/3 of original size

### DIFF
--- a/platform/mk2/capabilities.h
+++ b/platform/mk2/capabilities.h
@@ -22,7 +22,7 @@
 #define WIFI_ENABLED_DEFAULT	false
 
 /* Configuration */
-#define MAX_TRACKS	240
+#define MAX_TRACKS	160
 #define MAX_SECTORS	20
 #define MAX_VIRTUAL_CHANNELS	100
 #define LOGGER_MESSAGE_BUFFER_SIZE	10


### PR DESCRIPTION
Because we were occationally hitting malloc issues while trying to
get a memory block large enough to hold the entire track DB, I am
reducing its size here because:

* It is more probable we can allocate the memory block we need
* It is likely to not be noticed since most people don't put
  240 tracks into their DB (wonder how many even hit 100).

With this change we go from needing 40K to only needing just over
25K.  Much more managable.

Issue #780 #536