### PR TITLE
Fix Duplicate Telemetry Streams Bug

### DIFF
--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -128,6 +128,13 @@ xQueueHandle serial_get_rx_queue(struct Serial *s);
 
 xQueueHandle serial_get_tx_queue(struct Serial *s);
 
+enum serial_ioctl_status {
+	SERIAL_IOCTL_STATUS_OK = 0,
+	SERIAL_IOCTL_STATUS_ERR = -1,
+	SERIAL_IOCTL_STATUS_UNSUPPORTED	= -2,
+};
+
+
 enum serial_ioctl {
         SERIAL_IOCTL_TELEMETRY = 1,
 };
@@ -135,17 +142,18 @@ enum serial_ioctl {
 /**
  * The call back that gets fired when an ioctl is invoked on a Serial device.
  * @param req The request to be handled.
- * @param argp Memory pointer that may be useful for the command.
+ * @param data Memory pointer that may be useful for the command.
  * @return Usually on success 0 is returned, but this is dependent on the
  * ioctl request.  The return value may be a parameter.  Values < 0 usually
  * indicate an error.
  */
-typedef int serial_ioctl_cb_t(struct Serial *s, unsigned long req,
-                              void* argp);
+typedef enum serial_ioctl_status serial_ioctl_cb_t(struct Serial *s,
+						   unsigned long req, void* data);
 
 void serial_set_ioctl_cb(struct Serial *s, serial_ioctl_cb_t* cb);
 
-int serial_ioctl(struct Serial *s, unsigned long req, void* argp);
+enum serial_ioctl_status serial_ioctl(struct Serial *s,
+				      unsigned long req, void* argp);
 
 const struct serial_cfg* serial_get_config(const struct Serial* s);
 

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -1881,26 +1881,24 @@ int api_get_wifi_cfg(struct Serial *serial, const jsmntok_t *json)
         return API_SUCCESS_NO_RETURN;
 }
 
-static int get_telemetry_api_return_code(const int cmd_result)
-{
-        switch(cmd_result) {
-        case 0:
-                return API_SUCCESS;
-        case -1:
-                return API_ERROR_UNSUPPORTED;
-        default:
-                return API_ERROR_UNSPECIFIED;
-       }
-}
-
 int api_set_telemetry(struct Serial *serial, const jsmntok_t *json)
 {
         int sample_rate = 0;
         jsmn_exists_set_val_int(json, "rate", &sample_rate);
+	void* data = (void*) (long) sample_rate;
 
-        const int cmd_result = serial_ioctl(serial, SERIAL_IOCTL_TELEMETRY,
-					    (void*) (long) sample_rate);
-        return get_telemetry_api_return_code(cmd_result);
+        const enum serial_ioctl_status status =
+		serial_ioctl(serial, SERIAL_IOCTL_TELEMETRY, data);
+
+	switch(status) {
+        case SERIAL_IOCTL_STATUS_OK:
+                return API_SUCCESS;
+        case SERIAL_IOCTL_STATUS_UNSUPPORTED:
+                return API_ERROR_UNSUPPORTED;
+	case SERIAL_IOCTL_STATUS_ERR:
+        default:
+                return API_ERROR_UNSPECIFIED;
+	}
 }
 
 int api_set_active_track(struct Serial *serial, const jsmntok_t *json)

--- a/src/serial/serial.c
+++ b/src/serial/serial.c
@@ -461,9 +461,13 @@ void serial_set_ioctl_cb(struct Serial *s, serial_ioctl_cb_t* cb)
  * @param req The request to enact.
  * @param argp Memory address that may be useful for these commands.
  */
-int serial_ioctl(struct Serial *s, unsigned long req, void* argp)
+enum serial_ioctl_status serial_ioctl(struct Serial *s,
+				      unsigned long req, void* argp)
 {
-        return s->ioctl_cb ? s->ioctl_cb(s, req, argp) : -1;
+	if(!s->ioctl_cb)
+		return SERIAL_IOCTL_STATUS_UNSUPPORTED;
+
+	return s->ioctl_cb(s, req, argp);
 }
 
 /* STIEG: Replace vsnprintf with vfprintf if you can make a stream */

--- a/src/usb_comm/usb_comm.c
+++ b/src/usb_comm/usb_comm.c
@@ -118,20 +118,22 @@ static int set_telemetry(int rate)
 				serial_name);
 
 		if (!logger_sample_destroy_callback(usb_state.ls_handle))
-			return -2;
+			return SERIAL_IOCTL_STATUS_ERR;
 
 		usb_state.ls_handle = -1;
-		return 0;
+		return SERIAL_IOCTL_STATUS_OK;
 	}
 
 	pr_info_str_msg(LOG_PFX "Starting telem stream on ", serial_name);
 	usb_state.ls_handle = logger_sample_create_callback(usb_sample_cb,
 							    rate, NULL);
-	return usb_state.ls_handle < 0 ? -2 : 0;
+	return usb_state.ls_handle < 0 ?
+		SERIAL_IOCTL_STATUS_ERR : SERIAL_IOCTL_STATUS_OK;
 }
 
-static int usb_serial_ioctl(struct Serial* serial, unsigned long req,
-                            void* argp)
+static enum serial_ioctl_status usb_serial_ioctl(struct Serial* serial,
+						 unsigned long req,
+						 void* argp)
 {
         switch(req) {
         case SERIAL_IOCTL_TELEMETRY:


### PR DESCRIPTION
Turns out that my optimization caused a regression.  If a user was to try to adjust the rate of a stream that currently existed, then we would simply create a new one, causing a duplicate stream to appear and also causing the handle to the original stream to be lost.  The end result was the stream failing to close, which would cause the unit to hang :(.

This fixes that bug.  It also adds strong typing to serial ioctl return values so I know the meaning of the code with certainty.