### PR TITLE
Fix the default label on the timer channels.

### DIFF
--- a/src/timer/timer_config.c
+++ b/src/timer/timer_config.c
@@ -21,11 +21,12 @@
 
 #include "api.h"
 #include "loggerConfig.h"
+#include "macros.h"
 #include "timer_config.h"
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
-#define RPM_CHAN_LABEL	"RPM"
 #define RPM_CHAN_UNITS	"rpm"
 #define RPM_CHAN_MIN	0
 #define RPM_CHAN_MAX	8000
@@ -50,23 +51,24 @@ TimerConfig* get_timer_config(int channel)
 
 void set_default_timer_config(TimerConfig tim_cfg[], const size_t cnt)
 {
-        for (size_t i = 0; i < cnt; ++i) {
-                TimerConfig *tc = tim_cfg + i;
-                set_default_channel_config(&tc->cfg);
-                tc->filterAlpha = TIMER_DEFAULT_FILTER_ALPHA;
-                tc->mode = MODE_LOGGING_TIMER_RPM;
-                tc->pulsePerRevolution = TIMER_DEFAULT_PULSE_PER_REV;
-                tc->timerSpeed = TIMER_MEDIUM;
-                tc->filter_period_us = TIMER_DEFAULT_FILTER;
-                tc->edge = TIMER_DEFAULT_EDGE;
-        }
+	for (int i = 0; i < cnt; ++i) {
+		TimerConfig *tc = tim_cfg + i;
 
-        /* Make Channel 1 the default RPM config. */
-        ChannelConfig *t0cc = &tim_cfg[0].cfg;
-        strcpy(t0cc->label, RPM_CHAN_LABEL);
-        strcpy(t0cc->units, RPM_CHAN_UNITS);
-        t0cc->min = RPM_CHAN_MIN;
-        t0cc->max = RPM_CHAN_MAX;
+		ChannelConfig *tcc = &tc->cfg;
+		set_default_channel_config(tcc);
+		snprintf(tcc->label, ARRAY_LEN(tcc->label),
+			 i ? "RPM%d" : "RPM", i + 1);
+		strcpy(tcc->units, RPM_CHAN_UNITS);
+		tcc->min = RPM_CHAN_MIN;
+		tcc->max = RPM_CHAN_MAX;
+
+		tc->filterAlpha = TIMER_DEFAULT_FILTER_ALPHA;
+		tc->mode = MODE_LOGGING_TIMER_RPM;
+		tc->pulsePerRevolution = TIMER_DEFAULT_PULSE_PER_REV;
+		tc->timerSpeed = TIMER_MEDIUM;
+		tc->filter_period_us = TIMER_DEFAULT_FILTER;
+		tc->edge = TIMER_DEFAULT_EDGE;
+	}
 }
 
 enum timer_edge get_timer_edge_enum(const char *val)

--- a/src/timer/timer_config.c
+++ b/src/timer/timer_config.c
@@ -51,7 +51,7 @@ TimerConfig* get_timer_config(int channel)
 
 void set_default_timer_config(TimerConfig tim_cfg[], const size_t cnt)
 {
-	for (int i = 0; i < cnt; ++i) {
+	for (unsigned int i = 0; i < cnt; ++i) {
 		TimerConfig *tc = tim_cfg + i;
 
 		ChannelConfig *tcc = &tc->cfg;

--- a/test/loggerConfig_test.cpp
+++ b/test/loggerConfig_test.cpp
@@ -104,24 +104,24 @@ void LoggerConfigTest::testLoggerInitGpioConfig() {
 }
 
 void LoggerConfigTest::testLoggerInitTimerConfig() {
-        LoggerConfig *lc = getWorkingLoggerConfig();
-        TimerConfig *tc = lc->TimerConfigs;
-        set_default_timer_config(tc, CONFIG_TIMER_CHANNELS);
+	LoggerConfig *lc = getWorkingLoggerConfig();
+	set_default_timer_config(lc->TimerConfigs, CONFIG_TIMER_CHANNELS);
 
-        for (size_t i = 0; i < CONFIG_TIMER_CHANNELS; ++i) {
-                if (0 == i) {
-                        CPPUNIT_ASSERT(strlen(tc[0].cfg.label));
-                } else {
-                        CPPUNIT_ASSERT(!strlen(tc[i].cfg.label));
-                }
+	for (size_t i = 0; i < CONFIG_TIMER_CHANNELS; ++i) {
+		TimerConfig *tc = lc->TimerConfigs + i;
+		char label[8];
+		if (i)
+			snprintf(label, 8, "RPM%d", i + 1);
+		else
+			strcpy(label, "RPM");
 
-                CPPUNIT_ASSERT(tc[i].cfg.sampleRate == SAMPLE_DISABLED);
-        }
 
-        CPPUNIT_ASSERT(!strcmp("RPM", tc[0].cfg.label));
-        CPPUNIT_ASSERT(!strcmp("rpm", tc[0].cfg.units));
-        CPPUNIT_ASSERT_EQUAL((float) 0, tc[0].cfg.min);
-        CPPUNIT_ASSERT_EQUAL((float) 8000, tc[0].cfg.max);
+		CPPUNIT_ASSERT_EQUAL(string(label), string(tc->cfg.label));
+		CPPUNIT_ASSERT_EQUAL(string("rpm"), string(tc->cfg.units));
+		CPPUNIT_ASSERT_EQUAL((float) 0, tc->cfg.min);
+		CPPUNIT_ASSERT_EQUAL((float) 8000, tc->cfg.max);
+		CPPUNIT_ASSERT(tc->cfg.sampleRate == SAMPLE_DISABLED);
+	}
 }
 
 void LoggerConfigTest::testLoggerInitImuConfig() {


### PR DESCRIPTION
This adjusts the label so that these channels are always labeled with
"RPM", "RPM2", "RPM3" respectively.  They also have default units set
for all channels.

Issue #800