### PR TITLE
Fix Serial Closing and Close Socket on Send Fail

### DIFF
--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -358,6 +358,7 @@ static void socket_state_changed_cb(const size_t chan_id,
 		/* Use Defaults for rx and tx buff sizes */
 		if (!channel_setup(chan_id, 0, 0)) {
 			/* Close the channel.  Best effort here. */
+			channel_close(ch);
 			esp8266_close(chan_id, NULL);
 			break;
 		}
@@ -366,8 +367,9 @@ static void socket_state_changed_cb(const size_t chan_id,
 			esp8266_state.comm.new_conn_cb(ch->serial);
 		} else {
 			pr_warning(LOG_PFX "No incoming server callback "
-				   "defined. Data \r\n");
+				   "defined. Dropping data...\r\n");
 		}
+
                 break;
         default:
                 pr_warning_int_msg(LOG_PFX "Unknown socket action: ",

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -433,8 +433,8 @@ static void _send_data_cb(const bool status, const size_t bytes,
 		 * Issue #807
 		 */
 		struct channel *ch = esp8266_state.comm.channels + chan;
+		esp8266_close(chan, NULL);
 		channel_close(ch);
-
 		return;
 	}
 }

--- a/test/FreeRTOS_Kernel/include/queue.h
+++ b/test/FreeRTOS_Kernel/include/queue.h
@@ -1244,7 +1244,8 @@ portBASE_TYPE xQueueGiveMutexRecursive( xQueueHandle xMutex );
 void vQueueAddToRegistry( xQueueHandle xQueue, signed char *pcName );
 #endif
 
-
+portBASE_TYPE xQueueGenericReset( xQueueHandle xQueue, portBASE_TYPE xNewQueue ) PRIVILEGED_FUNCTION;
+#define xQueueReset( xQueue ) xQueueGenericReset( xQueue, pdFALSE )
 
 
 CPP_GUARD_END

--- a/test/FreeRTOS_Kernel/stubs/queue.c
+++ b/test/FreeRTOS_Kernel/stubs/queue.c
@@ -99,3 +99,8 @@ unsigned portBASE_TYPE uxQueueMessagesWaiting( const xQueueHandle xQueue )
 {
 	return 0;
 }
+
+portBASE_TYPE xQueueGenericReset( xQueueHandle pxQueue, portBASE_TYPE xNewQueue )
+{
+	return pdTRUE;
+}


### PR DESCRIPTION
Fixes a critical bug that could cause threads to die on our firmware.  Also fixes bad send ops by terminating the connection (because we lose data).