### PR TITLE
Disable track auto-detect by default if trackDB size is 0

### DIFF
--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -393,8 +393,6 @@ typedef struct _TrackConfig {
     Track track;
 } TrackConfig;
 
-#define DEFAULT_TRACK_AUTO_DETECT 1
-
 #define BT_DEVICE_NAME_LENGTH 21
 #define BT_PASSCODE_LENGTH 5
 #define DEFAULT_BT_ENABLED 1

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -237,9 +237,10 @@ static void resetLapConfig(LapConfig *cfg)
 
 static void resetTrackConfig(TrackConfig *cfg)
 {
-    memset(cfg, 0, sizeof(TrackConfig));
-    cfg->radius = DEFAULT_TRACK_TARGET_RADIUS;
-    cfg->auto_detect = DEFAULT_TRACK_AUTO_DETECT;
+	memset(cfg, 0, sizeof(TrackConfig));
+	cfg->radius = DEFAULT_TRACK_TARGET_RADIUS;
+	/* True if we support a track DB, false otherwise */
+	cfg->auto_detect = !!MAX_TRACKS;
 }
 
 static void resetBluetoothConfig(BluetoothConfig *cfg)


### PR DESCRIPTION
If we have no track DB, then auto-detect is useless.  So we should
disable it by default in that case. Otherwise we should keep the
traditional behavior of enabling it by default if we do have a
track DB available (whether or not it has tracks is another story).

Issue #814