### PR TITLE
Rude AT Support And More

### DIFF
--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -204,11 +204,8 @@ enum esp8266_server_action {
 bool esp8266_server_cmd(const enum esp8266_server_action action, int port,
                         void (*cb)(bool));
 
-typedef void esp8266_set_uart_config_cb_t(const bool status);
-
-bool esp8266_set_uart_config(const size_t baud, const size_t bits,
-			     const size_t parity, const size_t stop_bits,
-			     esp8266_set_uart_config_cb_t* cb);
+bool esp8266_set_uart_config_raw(const size_t baud, const size_t bits,
+				 const size_t parity, const size_t stop_bits);
 
 bool esp8266_probe_device(struct Serial* serial, const int fast_baud);
 

--- a/include/modem/at.h
+++ b/include/modem/at.h
@@ -101,9 +101,15 @@ struct at_timing {
         tiny_millis_t quiet_start_ms;
 };
 
+enum at_dev_cfg_flag {
+        /* Used for AT devices that will send URCS mid command response */
+        AT_DEV_CFG_FLAG_RUDE = 1 << 0,
+};
+
 struct at_dev_cfg {
         char delim[AT_DEV_CVG_DELIM_MAX_LEN];
         tiny_millis_t quiet_period_ms;
+        enum at_dev_cfg_flag flags;
 };
 
 enum at_urc_flags {

--- a/include/modem/at.h
+++ b/include/modem/at.h
@@ -173,8 +173,7 @@ struct at_info {
 
 void at_reset(struct at_info* ati);
 
-bool init_at_info(struct at_info *ati, struct serial_buffer *sb,
-                  const tiny_millis_t quiet_period_ms, const char *delim);
+bool at_info_init(struct at_info *ati, struct serial_buffer *sb);
 
 void at_task(struct at_info *ati, const size_t ms_delay);
 

--- a/include/modem/at.h
+++ b/include/modem/at.h
@@ -102,6 +102,7 @@ struct at_timing {
 };
 
 enum at_dev_cfg_flag {
+	AT_DEV_CFG_FLAG_NONE = 0,
         /* Used for AT devices that will send URCS mid command response */
         AT_DEV_CFG_FLAG_RUDE = 1 << 0,
 };
@@ -134,9 +135,9 @@ struct at_urc_list {
 };
 
 /**
- * Callback for unhandled URCs.  This is designed to handle cases
- * where AT commands introduce odd messages that would be difficult
- * to register a callback for.  An example would be `0,CONNECTED`,
+ * Callback for sparse URCs.  This is designed to handle cases
+ * where AT commands introduce sparse messages that would be difficult
+ * to register a callback against.  An example would be `0,CONNECTED`;
  * this is hard to register since the 0 indicates the multiplexed
  * channel, and in this case there are 5 potential combinations.
  * Really this is a broken AT URC, so we use as sort of broken way
@@ -146,9 +147,9 @@ struct at_urc_list {
  * imperfect solution for an imperfect world.
  * @param msg The message that was received.
  * @return true if the callback was able to parse the message,
- *         false otherwise.
+ * false otherwise.
  */
-typedef bool unhandled_urc_cb_t(char* msg);
+typedef bool sparse_urc_cb_t(char* msg);
 
 struct at_info {
         /*
@@ -167,16 +168,17 @@ struct at_info {
         struct at_timing timing;
         struct at_cmd_queue cmd_queue;
         struct at_urc_list urc_list;
-        unhandled_urc_cb_t *unhandled_urc_cb;
+        sparse_urc_cb_t *sparse_urc_cb;
 };
 
 void at_reset(struct at_info* ati);
 
 bool init_at_info(struct at_info *ati, struct serial_buffer *sb,
-                  const tiny_millis_t quiet_period_ms, const char *delim,
-                  unhandled_urc_cb_t *unhandled_urc_cb);
+                  const tiny_millis_t quiet_period_ms, const char *delim);
 
 void at_task(struct at_info *ati, const size_t ms_delay);
+
+void at_set_sparse_urc_cb(struct at_info* ati, sparse_urc_cb_t* cb);
 
 struct at_cmd* at_put_cmd(struct at_info *ati, const char *cmd,
                           const tiny_millis_t timeout,

--- a/include/modem/at.h
+++ b/include/modem/at.h
@@ -103,22 +103,22 @@ struct at_timing {
 
 enum at_dev_cfg_flag {
 	AT_DEV_CFG_FLAG_NONE = 0,
-        /* Used for AT devices that will send URCS mid command response */
-        AT_DEV_CFG_FLAG_RUDE = 1 << 0,
+	/* Used for AT devices that will send URCS mid command response */
+	AT_DEV_CFG_FLAG_RUDE = 1 << 0,
 };
 
 struct at_dev_cfg {
-        char delim[AT_DEV_CVG_DELIM_MAX_LEN];
-        tiny_millis_t quiet_period_ms;
-        enum at_dev_cfg_flag flags;
+	char delim[AT_DEV_CVG_DELIM_MAX_LEN];
+	tiny_millis_t quiet_period_ms;
+	enum at_dev_cfg_flag flags;
 };
 
 enum at_urc_flags {
-        AT_URC_FLAGS_NONE = 0, /* For init with no flags set */
-        /* Indicates URC is only one msg with no status */
-        AT_URC_FLAGS_NO_RSP_STATUS = 1 << 0,
-        /* Indicates we should not strip the trailing msg whitespace chars. */
-        AT_URC_FLAGS_NO_RSTRIP     = 1 << 1,
+	AT_URC_FLAGS_NONE = 0, /* For init with no flags set */
+	/* Indicates URC is only one msg with no status */
+	AT_URC_FLAGS_NO_RSP_STATUS = 1 << 0,
+	/* Indicates we should not strip the trailing msg whitespace chars. */
+	AT_URC_FLAGS_NO_RSTRIP	   = 1 << 1,
 };
 
 struct at_urc {
@@ -190,7 +190,7 @@ struct at_urc* at_register_urc(struct at_info *ati, const char *pfx,
                                void *rsp_up);
 
 bool at_configure_device(struct at_info *ati, const tiny_millis_t qp_ms,
-                         const char *delim);
+                         const char *delim, const enum at_dev_cfg_flag flags);
 
 bool at_ok(struct at_rsp *rsp);
 

--- a/include/modem/at_basic.h
+++ b/include/modem/at_basic.h
@@ -23,6 +23,7 @@
 #define _AT_BASIC_H_
 
 #include "cpp_guard.h"
+#include "dateTime.h"
 #include "serial.h"
 #include <stdbool.h>
 #include <stddef.h>
@@ -30,13 +31,13 @@
 CPP_GUARD_BEGIN
 
 bool at_basic_wait_for_msg(struct Serial* serial, const char* msg,
-			   const size_t delay_ms);
+			   const tiny_millis_t delay_ms);
 
 bool at_basic_ping(struct Serial* serial, const size_t tries,
-		   const size_t delay_ms);
+		   const tiny_millis_t delay_ms);
 
 int at_basic_probe(struct Serial* serial, const int bauds[],
-		   const size_t tries, const size_t delay,
+		   const size_t tries, const tiny_millis_t delay,
 		   const size_t msg_bits, const size_t parity,
 		   const size_t stop_bits);
 

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -39,11 +39,8 @@
 #define AT_PROBE_TRIES		3
 #define AT_PROBE_DELAY_MS	200
 #define LOG_PFX	"[esp8266] "
-#define _AT_CMD_DELIM		"\r\n"
-#define _AT_DEFAULT_QP_MS	250
-#define _AT_QP_PRE_INIT_MS	500
-#define _AT_QP_STANDARD_MS	1
-#define _AUTOBAUD_TRIES		3
+#define ESP8266_CMD_DELIM      	"\r\n"
+#define ESP8266_QP_MS	1
 #define _TIMEOUT_LONG_MS	5000
 #define _TIMEOUT_MEDIUM_MS	500
 #define _TIMEOUT_SHORT_MS	50
@@ -150,10 +147,10 @@ bool esp8266_setup(struct Serial *serial, const size_t max_cmd_len)
                 return false;
 
         /* Init our AT engine here */
-        if (!init_at_info(state.ati, state.scb, _AT_DEFAULT_QP_MS,
-                          _AT_CMD_DELIM))
+        if (!at_info_init(state.ati, state.scb))
                 return false;
 
+	at_configure_device(state.ati, ESP8266_QP_MS, ESP8266_CMD_DELIM);
 	at_set_sparse_urc_cb(state.ati, sparse_urc_cb);
 
         return true;
@@ -338,10 +335,6 @@ bool esp8266_init(esp8266_init_cb_t* cb)
 	}
 
 	state.init.cb = cb;
-
-	/* Set normal quiet period */
-        at_configure_device(state.ati, _AT_QP_STANDARD_MS,
-                            _AT_CMD_DELIM);
 
 	/*
 	 * To ensure our device is initialized properly we do the

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -151,8 +151,10 @@ bool esp8266_setup(struct Serial *serial, const size_t max_cmd_len)
 
         /* Init our AT engine here */
         if (!init_at_info(state.ati, state.scb, _AT_DEFAULT_QP_MS,
-                          _AT_CMD_DELIM, sparse_urc_cb))
+                          _AT_CMD_DELIM))
                 return false;
+
+	at_set_sparse_urc_cb(state.ati, sparse_urc_cb);
 
         return true;
 }

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -83,8 +83,7 @@ static void cmd_failure(const char *cmd_name, const char *msg)
  * the standard URC callbacks.  Used for the silly messages like
  * `0,CONNECT` where there is no prefix for the URC like their should be.
  * Messages this callback handles:
- * * <0-4>,CONNECT
- * * <0-4>,CLOSED
+ * * <0-4>,{CONNECT,CLOSED}
  * * WIFI {CONNECTED,DISCONNECT,GOT IP}
  */
 static bool sparse_urc_cb(char* msg)
@@ -100,9 +99,9 @@ static bool sparse_urc_cb(char* msg)
                 return true;
         }
 
-        /* Now look for a message with a comma */
+        /* Now look for a message format <0-4>,MSG */
         char* comma = strchr(msg, ',');
-        if (!comma)
+        if (comma != msg + 1)
                 return false;
 
         *comma = '\0';

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -40,6 +40,7 @@
 #define AT_PROBE_DELAY_MS	200
 #define LOG_PFX	"[esp8266] "
 #define ESP8266_CMD_DELIM      	"\r\n"
+#define ESP8266_DEV_FLAGS	(AT_DEV_CFG_FLAG_RUDE)
 #define ESP8266_QP_MS	1
 #define _TIMEOUT_LONG_MS	5000
 #define _TIMEOUT_MEDIUM_MS	500
@@ -150,7 +151,8 @@ bool esp8266_setup(struct Serial *serial, const size_t max_cmd_len)
         if (!at_info_init(state.ati, state.scb))
                 return false;
 
-	at_configure_device(state.ati, ESP8266_QP_MS, ESP8266_CMD_DELIM);
+	at_configure_device(state.ati, ESP8266_QP_MS, ESP8266_CMD_DELIM,
+			    ESP8266_DEV_FLAGS);
 	at_set_sparse_urc_cb(state.ati, sparse_urc_cb);
 
         return true;

--- a/src/modem/at.c
+++ b/src/modem/at.c
@@ -397,7 +397,8 @@ bool at_info_init(struct at_info *ati, struct serial_buffer *sb)
         memset(ati, 0, sizeof(*ati));
         ati->sb = sb;
 
-	at_configure_device(ati, AT_DEFAULT_QP_MS, AT_DEFAULT_DELIMETER);
+	at_configure_device(ati, AT_DEFAULT_QP_MS, AT_DEFAULT_DELIMETER,
+			    AT_DEV_CFG_FLAG_NONE);
 
         /* Reset the state machine, and now we are ready to run */
         at_reset(ati);
@@ -511,10 +512,11 @@ struct at_urc* at_register_urc(struct at_info *ati, const char *pfx,
  * @param ati The pointer to the at_info struct.
  * @param qp_ms The quiet period in milliseconds.
  * @param delim The command delimeter characters.  Normally this is "\r\n".
+ * @param flags One or more at_dev_cfg_flag items or'd together.
  * @return true if the parameters are acceptable, false otherwise.
  */
 bool at_configure_device(struct at_info *ati, const tiny_millis_t qp_ms,
-                         const char *delim)
+                         const char *delim, const enum at_dev_cfg_flag flags)
 {
         if (!delim || strlen(delim) >= AT_DEV_CVG_DELIM_MAX_LEN) {
                 pr_error("[at] Failed to set delimeter\r\n");
@@ -523,6 +525,7 @@ bool at_configure_device(struct at_info *ati, const tiny_millis_t qp_ms,
 
         ati->dev_cfg.quiet_period_ms = qp_ms;
         strcpy(ati->dev_cfg.delim, delim); /* Sane b/c strlen check above */
+	ati->dev_cfg.flags = flags;
         return true;
 }
 

--- a/src/modem/at.c
+++ b/src/modem/at.c
@@ -25,9 +25,11 @@
 #include "printk.h"
 #include "serial_buffer.h"
 #include "str_util.h"
-
 #include <ctype.h>
 #include <string.h>
+
+#define AT_DEFAULT_QP_MS	250
+#define AT_DEFAULT_DELIMETER	"\r\n"
 
 static const enum log_level dbg_lvl = INFO;
 
@@ -382,13 +384,9 @@ void at_reset(struct at_info *ati)
  * @param ati The at_info structure to initialize.
  * @param sb The serial_buffer to use for tx/rx.  Data is kept in the buffer
  *           and is referenced until the command completes.  Then its gone.
- * @param quiet_period_ms The quiet period to wait between the end of a
- *        command and when to start the next.  Some modems need time to recover
- *        and send URCs.
  * @return true if the parameters were acceptable, false otherwise.
  */
-bool init_at_info(struct at_info *ati, struct serial_buffer *sb,
-                  const tiny_millis_t quiet_period_ms, const char *delim)
+bool at_info_init(struct at_info *ati, struct serial_buffer *sb)
 {
         if (!ati || !sb) {
                 pr_error("[at] Bad init parameter\r\n");
@@ -398,8 +396,8 @@ bool init_at_info(struct at_info *ati, struct serial_buffer *sb,
         /* Clear everything.  We don't know where at_info has been */
         memset(ati, 0, sizeof(*ati));
         ati->sb = sb;
-        if (!at_configure_device(ati, quiet_period_ms, delim))
-                return false;
+
+	at_configure_device(ati, AT_DEFAULT_QP_MS, AT_DEFAULT_DELIMETER);
 
         /* Reset the state machine, and now we are ready to run */
         at_reset(ati);

--- a/src/modem/at_basic.c
+++ b/src/modem/at_basic.c
@@ -37,7 +37,7 @@
  * @param delay_ms Max time to wait.
  */
 bool at_basic_wait_for_msg(struct Serial* serial, const char* msg,
-			   const size_t delay_ms)
+			   const tiny_millis_t delay_ms)
 {
 	const tiny_millis_t term = date_time_uptime_now_plus(delay_ms);
 	const char* ptr = msg;
@@ -62,7 +62,7 @@ bool at_basic_wait_for_msg(struct Serial* serial, const char* msg,
  * @param delay_ms The time to wait for each ping in ms before giving up.
  */
 bool at_basic_ping(struct Serial* serial, const size_t tries,
-		   const size_t delay_ms)
+		   const tiny_millis_t delay_ms)
 {
 	const char cmd[] = "AT\r\n";
 
@@ -89,7 +89,7 @@ bool at_basic_ping(struct Serial* serial, const size_t tries,
  * @return The baud rate that the device responded to. 0 if no response.
  */
 int at_basic_probe(struct Serial* serial, const int bauds[],
-		   const size_t tries, const size_t delay_ms,
+		   const size_t tries, const tiny_millis_t delay_ms,
 		   const size_t msg_bits, const size_t parity,
 		   const size_t stop_bits)
 {

--- a/src/modem/at_basic.c
+++ b/src/modem/at_basic.c
@@ -43,7 +43,10 @@ bool at_basic_wait_for_msg(struct Serial* serial, const char* msg,
 	const char* ptr = msg;
 
 	while (!date_time_is_past(term) && *ptr) {
-		const size_t max_delay_ms = term - getUptime();
+		const tiny_millis_t max_delay_ms = term - getUptime();
+		if (max_delay_ms <= 0)
+			continue;
+
 		char rx_char;
 		if (0 < serial_read_c_wait(serial, &rx_char, max_delay_ms))
 			ptr = rx_char == *ptr ? ptr + 1 : msg;

--- a/src/util/str_util.c
+++ b/src/util/str_util.c
@@ -26,7 +26,9 @@
 #include <string.h>
 
 /**
- * Like strlen, except it ignores serial control characters.
+ * Like strlen, except it ignores serial control characters. We consider
+ * it the end of a serial message if the message ends with "\r\n" or if it
+ * ends with '\0'.
  * @return length of the message, not including any serial control
  * characters.
  */
@@ -34,11 +36,14 @@ size_t serial_msg_strlen(const char *data)
 {
         size_t len = 0;
 
+	/* The for loop check handles the "\0" case */
         for (; *data; ++data, ++len) {
                 switch (*data) {
                 case '\r':
-                case '\n':
-                case '\0':
+			/* Check for the "\r\n" case */
+			if ('\n' != data[1])
+				continue;
+
                         return len;
                 }
         }

--- a/test/AtTest.hh
+++ b/test/AtTest.hh
@@ -30,6 +30,7 @@ class AtTest : public CppUnit::TestFixture
 
         CPPUNIT_TEST( test_init_at_info );
         CPPUNIT_TEST( test_init_at_info_failures );
+	CPPUNIT_TEST( test_set_sparse_urc_cb );
         CPPUNIT_TEST( test_at_put_cmd_full );
         CPPUNIT_TEST( test_at_put_cmd_too_long );
         CPPUNIT_TEST( test_at_put_cmd_ok );
@@ -72,6 +73,7 @@ public:
         void setUp();
         void test_init_at_info();
         void test_init_at_info_failures();
+	void test_set_sparse_urc_cb();
         void test_at_put_cmd_full();
         void test_at_put_cmd_too_long();
         void test_at_put_cmd_ok();

--- a/test/AtTest.hh
+++ b/test/AtTest.hh
@@ -28,8 +28,8 @@ class AtTest : public CppUnit::TestFixture
 {
         CPPUNIT_TEST_SUITE( AtTest );
 
-        CPPUNIT_TEST( test_init_at_info );
-        CPPUNIT_TEST( test_init_at_info_failures );
+        CPPUNIT_TEST( test_at_info_init );
+        CPPUNIT_TEST( test_at_info_init_failures );
 	CPPUNIT_TEST( test_set_sparse_urc_cb );
         CPPUNIT_TEST( test_at_put_cmd_full );
         CPPUNIT_TEST( test_at_put_cmd_too_long );
@@ -63,6 +63,7 @@ class AtTest : public CppUnit::TestFixture
         CPPUNIT_TEST( test_is_timed_out_fail );
         CPPUNIT_TEST( test_is_timed_out_ok );
         CPPUNIT_TEST( test_at_configure_device );
+	CPPUNIT_TEST( test_at_configure_device_returns );
         CPPUNIT_TEST( test_at_ok );
         CPPUNIT_TEST( test_at_parse_rsp_line );
         CPPUNIT_TEST( test_at_parse_rsp_str );
@@ -71,8 +72,8 @@ class AtTest : public CppUnit::TestFixture
 
 public:
         void setUp();
-        void test_init_at_info();
-        void test_init_at_info_failures();
+        void test_at_info_init();
+        void test_at_info_init_failures();
 	void test_set_sparse_urc_cb();
         void test_at_put_cmd_full();
         void test_at_put_cmd_too_long();
@@ -107,6 +108,7 @@ public:
         void test_is_timed_out_fail();
         void test_is_timed_out_ok();
         void test_at_configure_device();
+	void test_at_configure_device_returns();
         void test_at_ok();
         void test_at_parse_rsp_line();
         void test_at_parse_rsp_str();

--- a/test/StrUtilTest.cpp
+++ b/test/StrUtilTest.cpp
@@ -32,8 +32,8 @@ using std::string;
 
 void StrUtilTest::serial_msg_strlen_test()
 {
-        CPPUNIT_ASSERT_EQUAL((size_t) 3, serial_msg_strlen("Foo\r"));
-	CPPUNIT_ASSERT_EQUAL((size_t) 5, serial_msg_strlen("baRRR\n"));
+        CPPUNIT_ASSERT_EQUAL((size_t) 4, serial_msg_strlen("Foo\r"));
+	CPPUNIT_ASSERT_EQUAL((size_t) 5, serial_msg_strlen("baRRR\r\n"));
 	CPPUNIT_ASSERT_EQUAL((size_t) 7, serial_msg_strlen("bazzzz\t"));
 	CPPUNIT_ASSERT_EQUAL((size_t) 0, serial_msg_strlen(""));
 }


### PR DESCRIPTION
We have all heard my grumblings about how the ESP8266 chip is "rude" in that it sends its events during the middle of a normal command (how rude indeed).  This PR includes the patches needed to be able to deal with that.

In the process of adding this support, I hit several other issues, including fixing a hack to work around a different esp8266 issue (no serial EOM message after baud rate change) and had to deal some fallout of my design change.

Regardless the result is almost no dropped incoming messages now, so the app responds much more quickly.