### PR TITLE
A Few Important Misc Fixes for RCT

### DIFF
--- a/platform/rct/hal/ADC_stm32/ADC_device_stm32.c
+++ b/platform/rct/hal/ADC_stm32/ADC_device_stm32.c
@@ -83,10 +83,13 @@ int ADC_device_init(void)
         /* Calibration procedure */
         ADC_VoltageRegulatorCmd(ADC3, ENABLE);
 
-	/* Disable ADC3 and its associated DMA before we calibrate */
-	ADC_DMACmd(ADC3, DISABLE);
-	ADC_Cmd(ADC3, DISABLE);
-	while(SET == ADC_GetDisableCmdStatus(ADC3));
+	/* Disable ADC3 and its associated DMA before we calibrate if enabled. */
+	if (ADC3->CR & ADC_CR_ADEN) {
+		ADC_StopConversion(ADC3);
+		while(SET == ADC_GetStartConversionStatus(ADC3));
+		ADC_Cmd(ADC3, DISABLE);
+		while(SET == ADC_GetDisableCmdStatus(ADC3));
+	}
 
         /*
          * Wait at least 10us before starting calibration or enabling.

--- a/platform/rct/hal/ADC_stm32/ADC_device_stm32.c
+++ b/platform/rct/hal/ADC_stm32/ADC_device_stm32.c
@@ -83,6 +83,11 @@ int ADC_device_init(void)
         /* Calibration procedure */
         ADC_VoltageRegulatorCmd(ADC3, ENABLE);
 
+	/* Disable ADC3 and its associated DMA before we calibrate */
+	ADC_DMACmd(ADC3, DISABLE);
+	ADC_Cmd(ADC3, DISABLE);
+	while(SET == ADC_GetDisableCmdStatus(ADC3));
+
         /*
          * Wait at least 10us before starting calibration or enabling.
          * Since there is no interrupt to tell me this is ready we just

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -561,9 +561,9 @@ static const jsmntok_t * setChannelConfig(struct Serial *serial, const jsmntok_t
         unescapeTextField(value);
 
         if (STR_EQ("nm", name))
-            memcpy(channelCfg->label, value, DEFAULT_LABEL_LENGTH);
+            strncpy(channelCfg->label, value, DEFAULT_LABEL_LENGTH);
         else if (STR_EQ("ut", name))
-            memcpy(channelCfg->units, value, DEFAULT_UNITS_LENGTH);
+            strncpy(channelCfg->units, value, DEFAULT_UNITS_LENGTH);
         else if (STR_EQ("min", name))
             channelCfg->min = atof(value);
         else if (STR_EQ("max", name))

--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -148,7 +148,7 @@ static bool send_event(struct wifi_event* event, const char* event_name,
 	if (sent)
 		return true;
 
-	pr_warning_str_msg(LOG_PFX "Event overflow: ", event_name);
+	pr_debug_str_msg(LOG_PFX "Event overflow: ", event_name);
 	return false;
 }
 
@@ -493,7 +493,7 @@ static void process_sample(struct wifi_sample_data* data)
 
         if (ticks != sample->ticks) {
                 /* Then the sample has changed underneath us */
-                pr_warning(LOG_PFX "Stale sample.  Dropping \r\n");
+                pr_debug(LOG_PFX "Stale sample.  Dropping \r\n");
                 return;
         }
 


### PR DESCRIPTION
The following fixes are in this PR:

* Fix ADC calibration crash:  Turns out we need to disable ADC before calibrating it.  Else it is liable to destabilize the system.
* Improve handling of no serial EOF on IPD command
* Use strncpy instead of memcpy on our config to avoid reading data from potentially out of bounds memory regions
* Demote a couple of noisy log messages