### PR TITLE
Reduce MK2 Wifi Max Sample rate down to 10Hz

### DIFF
--- a/platform/mk2/capabilities.h
+++ b/platform/mk2/capabilities.h
@@ -18,7 +18,7 @@
 
 /* Wifi Specific Info */
 #define WIFI_MAX_BAUD		230400
-#define WIFI_MAX_SAMPLE_RATE	50
+#define WIFI_MAX_SAMPLE_RATE	10
 #define WIFI_ENABLED_DEFAULT	false
 
 /* Rx Max Message length */


### PR DESCRIPTION
We have 1/4 the bandwidth for wifi on this device when compared to
RCT.  This is due to hardware limitations.  As a result we need to
set stricter limits for this device to ensure it remains operational
under load.

This reduces WiFi sample baud rate to 10Hz.  After doing this our
reliability over WiFi was much improved.