### PR TITLE
Improve Status API Reporting

### DIFF
--- a/include/drivers/esp8266_drv.h
+++ b/include/drivers/esp8266_drv.h
@@ -57,6 +57,8 @@ const struct esp8266_ipv4_info* get_ap_ipv4_info();
 
 bool esp8266_drv_client_connected();
 
+bool esp8266_drv_is_initialized();
+
 CPP_GUARD_END
 
 #endif /* _ESP8266_DRV_H_ */

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -1477,3 +1477,12 @@ bool esp8266_drv_client_connected()
         const struct esp8266_client_info *ci = &esp8266_state.client.info;
         return cfg && ci->has_ap && STR_EQ(ci->ssid, cfg->ssid);
 }
+
+/**
+ * Tells us if the driver is in an initialized and ready state.
+ * @return true if it is, false otherwise.
+ */
+bool esp8266_drv_is_initialized()
+{
+	return esp8266_state.device.init_state == INIT_STATE_READY;
+}

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -237,14 +237,20 @@ static void get_imu_status(struct Serial *serial, const bool more)
 
 static void get_wifi_status(struct Serial* serial, const bool more)
 {
+        const LoggerConfig *lc = getWorkingLoggerConfig();
+
         const struct wifi_ap_cfg* ap_cfg = esp8266_drv_get_ap_config();
         const struct wifi_client_cfg* clt_cfg = esp8266_drv_get_client_config();
 
         const bool ap_active = ap_cfg && ap_cfg->active;
         const bool client_active = clt_cfg && clt_cfg->active;
         const bool client_connected = esp8266_drv_client_connected();
+	const bool device_active = lc->ConnectivityConfigs.wifi.active;
+	const bool device_init = esp8266_drv_is_initialized();
 
         json_objStartString(serial, "wifi");
+	json_bool(serial, "active", device_active, true);
+	json_bool(serial, "initialized", device_init, true);
 
         json_objStartString(serial, "ap");
         json_bool(serial, "active", ap_active, false);


### PR DESCRIPTION
Adds additional WiFi status parameters ("active" and "initialized") and removes BT and Logging reporting when these are not available on the target system.  Tested on both RCT and MK2

Issues: #829 #821 