### PR TITLE
Adjust WiFi client to better handle connect/disconnect actions

### DIFF
--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -53,11 +53,18 @@ enum dev_init_state {
 	DEV_INIT_STATE_READY	 =  1,
 };
 
+enum client_action {
+	CLIENT_ACTION_UNKNOWN,
+	CLIENT_ACTION_CONNECT,
+	CLIENT_ACTION_DISCONNECT,
+	CLIENT_ACTION_GOT_IP,
+};
+
 /**
  * Called whenever the device informs us that the state of the
  * wifi client has changed.
  */
-typedef void client_state_changed_cb_t(const char* msg);
+typedef void client_state_changed_cb_t(const enum client_action action);
 
 /**
  * An action taken by the ESP8266 on a socket.

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -133,15 +133,19 @@ static void wifi_action_callback(const char* msg)
 	/* Look at our 5th character to determin our action */
 	switch (msg[5]) {
 	case 'C':
+		/* WIFI CONNECT */
 		action = CLIENT_ACTION_CONNECT;
 		break;
 	case 'D':
+		/* WIFI DISCONNECT */
 		action = CLIENT_ACTION_DISCONNECT;
 		break;
 	case 'G':
+		/* WIFI GOT IP */
 		action = CLIENT_ACTION_GOT_IP;
 		break;
 	default:
+		pr_warning_str_msg(LOG_PFX "Unknown Wifi Action: ", msg);
 		action = CLIENT_ACTION_UNKNOWN;
 		break;
 	}

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -123,6 +123,32 @@ static void ipd_urc_cb(char *msg)
 		state.hooks.data_received_cb(chan_id, len, data);
 }
 
+static void wifi_action_callback(const char* msg)
+{
+	/* Check for the hook */
+	if (!state.hooks.client_state_changed_cb)
+		return;
+
+	enum client_action action;
+	/* Look at our 5th character to determin our action */
+	switch (msg[5]) {
+	case 'C':
+		action = CLIENT_ACTION_CONNECT;
+		break;
+	case 'D':
+		action = CLIENT_ACTION_DISCONNECT;
+		break;
+	case 'G':
+		action = CLIENT_ACTION_GOT_IP;
+		break;
+	default:
+		action = CLIENT_ACTION_UNKNOWN;
+		break;
+	}
+
+	state.hooks.client_state_changed_cb(action);
+}
+
 /**
  * Callback that gets invoked when we are unable to handle the URC using
  * the standard URC callbacks.  Used for the silly messages like
@@ -139,14 +165,10 @@ static bool sparse_urc_cb(char* msg)
 		return true;
 	}
 
-        if (STR_EQ(msg, "WIFI CONNECTED\r\n")  ||
-            STR_EQ(msg, "WIFI DISCONNECT\r\n") ||
-            STR_EQ(msg, "WIFI GOT IP\r\n")) {
-                if (state.hooks.client_state_changed_cb)
-                        state.hooks.client_state_changed_cb(msg);
-
-                return true;
-        }
+        if (strncmp(msg, "WIFI ", 5) == 0) {
+		wifi_action_callback(msg);
+		return true;
+	}
 
         /* Now look for a message format <0-4>,MSG */
         char* comma = strchr(msg, ',');


### PR DESCRIPTION
The behavior of the WiFi client on the ESP8266 was not entirely
clear and thus I ended up coding it incorrectly.  This change addresses
that so that we use the auto-connect features that are built into the
ESP8266 chip and better handle the callbacks that we get from it.

Issue #822