### PR TITLE
Reset WiFi if too many errors occur

### DIFF
--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -213,7 +213,7 @@ static void cmd_completed(const bool success)
 		--esp8266_state.cmd.failures;
 
 	if (esp8266_state.cmd.failures >= CMD_MAX_FAILURES) {
-		pr_info(LOG_PFX "Too many failures.  Resetting...\r\n");
+		pr_warning(LOG_PFX "Too many failures.  Resetting...\r\n");
 		esp8266_state.device.init_state = INIT_STATE_RESET_HARD;
 		cmd_set_check(CHECK_WIFI_DEVICE);
 	}


### PR DESCRIPTION
Adds an error tracking mechanism to the driver so that if too many
commands fail, then we reset the wifi hardware.  Currently this value
is hardcoded to 3 failures.

Issue #584