### PR TITLE
Fix Too Many Connections Crash; Increase Heap Size

### DIFF
--- a/platform/rct/FreeRTOS/Source/portable/MemMang/heap_4.c
+++ b/platform/rct/FreeRTOS/Source/portable/MemMang/heap_4.c
@@ -94,7 +94,6 @@ task.h is included from an application file. */
 #define heapADJUSTED_HEAP_SIZE	( configTOTAL_HEAP_SIZE - portBYTE_ALIGNMENT )
 
 /* Allocate the memory for the heap. */
-extern size_t _CONFIG_HEAP_SIZE;
 static unsigned char ucHeap[ configTOTAL_HEAP_SIZE ] __attribute__((section(".heap\n\t#")));
 
 /* Define the linked list structure.  This is used to link free blocks in order

--- a/platform/rct/FreeRTOS/Source/portable/MemMang/heap_4.c
+++ b/platform/rct/FreeRTOS/Source/portable/MemMang/heap_4.c
@@ -94,7 +94,8 @@ task.h is included from an application file. */
 #define heapADJUSTED_HEAP_SIZE	( configTOTAL_HEAP_SIZE - portBYTE_ALIGNMENT )
 
 /* Allocate the memory for the heap. */
-static unsigned char ucHeap[ configTOTAL_HEAP_SIZE ];
+extern size_t _CONFIG_HEAP_SIZE;
+static unsigned char ucHeap[ configTOTAL_HEAP_SIZE ] __attribute__((section(".heap\n\t#")));
 
 /* Define the linked list structure.  This is used to link free blocks in order
 of their memory address. */

--- a/platform/rct/Project/FreeRTOSConfig.h
+++ b/platform/rct/Project/FreeRTOSConfig.h
@@ -90,7 +90,7 @@ extern uint32_t SystemCoreClock;
 #define configTICK_RATE_HZ				((portTickType) 1000)
 #define configMAX_PRIORITIES				((unsigned portBASE_TYPE) 5)
 #define configMINIMAL_STACK_SIZE			((unsigned short) 64)
-#define configTOTAL_HEAP_SIZE				((size_t) (25 * 1024))
+#define configTOTAL_HEAP_SIZE				((size_t) (36 * 1024))
 #define configMAX_TASK_NAME_LEN				(16)
 #define configUSE_TRACE_FACILITY			1
 #define configUSE_STATS_FORMATTING_FUNCTIONS 		1

--- a/platform/rct/Project/STM32_FLASH.ld
+++ b/platform/rct/Project/STM32_FLASH.ld
@@ -43,19 +43,23 @@ _Min_Stack_Size = 0x400; 	/* required amount of stack */
 MEMORY
 {
   BOOTLDR   (rx)    : ORIGIN = 0x08000000, LENGTH = 16K
-  FLASH     (rx)    : ORIGIN = 0x08004000, LENGTH = 256K - 48K
+  FLASH	    (rx)    : ORIGIN = 0x08004000, LENGTH = 256K - 48K
 
   CONFIG    (rx)    : ORIGIN = 0x08038000, LENGTH = 16K
   TRACKS    (rx)    : ORIGIN = 0x0803C000, LENGTH = 16K
 
+  /* BSS segment of STM32f3.  8K in size */
+  BSS       (rxw)   : ORIGIN = 0x10000000, LENGTH = 8K
+
+  /* SRAM segment of STM32f3. 40K in size */
   HANDSHAKE (rwx)   : ORIGIN = 0x20000000, LENGTH = 8
-  RAM       (xrw)   : ORIGIN = 0x20000008, LENGTH = 40K - 8
-  CCM_RAM   (rxw)   : ORIGIN = 0x10000000, LENGTH = 8K
+  DATA      (rwx)   : ORIGIN = 0x20000008, LENGTH = 4K - 8
+  HEAP      (rwx)   : ORIGIN = 0x20001000, LENGTH = 36K
 }
 
-_heap_address = ORIGIN(RAM);
+_heap_address = ORIGIN(HEAP);
 _flash_start = ORIGIN(FLASH) - ORIGIN(BOOTLDR);
-_CONFIG_HEAP_SIZE = LENGTH(RAM);
+_CONFIG_HEAP_SIZE = LENGTH(HEAP);
 
 /* Define output sections */
 SECTIONS
@@ -141,7 +145,7 @@ SECTIONS
 
     . = ALIGN(4);
     _edata = .;        /* define a global symbol at data end */
-  } >RAM
+  } >DATA
 
   /* Uninitialized data section */
   . = ALIGN(4);
@@ -157,7 +161,7 @@ SECTIONS
     . = ALIGN(4);
     _ebss = .;         /* define a global symbol at bss end */
     __bss_end__ = _ebss;
-  } >RAM
+  } >BSS
 
   PROVIDE ( end = _ebss );
   PROVIDE ( _end = _ebss );
@@ -169,7 +173,14 @@ SECTIONS
     . = . + _Min_Heap_Size;
     . = . + _Min_Stack_Size;
     . = ALIGN(4);
-  } >RAM
+  } >DATA
+
+  heap :
+   {
+    . = ALIGN(4);
+    KEEP (*(.heap))
+   } >HEAP
+
 
   /* Remove information from the standard libraries */
   /DISCARD/ :

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -49,6 +49,7 @@
 #define CHECK_DONE_SLEEP_MS	3600000
 #define CLIENT_BACKOFF_MS	3000
 #define INIT_FAIL_SLEEP_MS	10000
+#define INVALID_CHANNEL_ID	-1
 #define LED_PERIOD_MS		25
 #define LOG_PFX			"[ESP8266 Driver] "
 #define MAX_CHANNELS		5
@@ -326,7 +327,7 @@ static int channel_find_serial(struct Serial *serial)
                         return i;
         }
 
-        return -1;
+        return INVALID_CHANNEL_ID;
 }
 
 static int channel_get_next_available()
@@ -1421,7 +1422,7 @@ struct Serial* esp8266_drv_connect(const enum protocol proto,
         pr_info_int_msg(LOG_PFX "Connected on comm channel ", cso->chan_id);
 
 done:
-	cso->chan_id = -1;
+	cso->chan_id = INVALID_CHANNEL_ID;
         xSemaphoreGive(cso->op_semaphore);
         return serial;
 }
@@ -1481,7 +1482,7 @@ bool esp8266_drv_close(struct Serial* serial)
         }
 
 done:
-	cso->chan_id = -1;
+	cso->chan_id = INVALID_CHANNEL_ID;
         xSemaphoreGive(cso->op_semaphore);
         return status;
 }

--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -372,7 +372,7 @@ static void check_connections()
 				LOG_PFX "Closing external connection: ",
 				serial_get_name(serial));
 			set_telemetry(conn, 0);
-			serial_destroy(serial);
+			serial_close(serial);
 			reset_connection(conn);
 			continue;
 		}
@@ -403,16 +403,19 @@ static void process_new_connection(struct Serial *s)
 		 */
 		pr_info_str_msg(LOG_PFX "New external connection: ",
 				serial_get_name(s));
+		pr_debug_int_msg(LOG_PFX "External conn slot: ", i);
 		serial_set_ioctl_cb(s, wifi_serial_ioctl);
+
+		reset_connection(conn);
 		conn->serial = s;
-		conn->ls_handle = -1;
+
 		return;
 	}
 
 	/* If here, no slot found.  Close the Serial port */
 	pr_warning(LOG_PFX "Max external connections reached. Closing\r\n");
+	serial_close(s);
 	esp8266_drv_close(s);
-	serial_destroy(s);
 }
 
 /* *** All methods that are used to handle sending beacons *** */


### PR DESCRIPTION
This PR gets our heap and extra 11K in RAM by moving the .bss segment into CCM and re-organizing some of our RAM layout.  It also fixes a regression caused by the Rude AT support and fixes a crash seen when too many connections were opened to the RCT device.