### PR TITLE
Stop LUA if no script; fix log bug

### DIFF
--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -236,7 +236,8 @@ static enum serial_ioctl_status set_telemetry(struct connection* conn,
 
 		if (rate > WIFI_MAX_SAMPLE_RATE) {
 			pr_info_int_msg(LOG_PFX "Telemetry stream rate too "
-					"high.  Reducing to ", rate);
+					"high.  Reducing to ",
+					WIFI_MAX_SAMPLE_RATE);
 			rate = WIFI_MAX_SAMPLE_RATE;
 		}
 


### PR DESCRIPTION
This PR will stop the LUA task if the user provides no script.  This just makes sense.  This also fixes a trivial logging bug.