### PR TITLE
Increase stack sizes for button and wifi tasks

### DIFF
--- a/src/GPIO/gpioTasks.c
+++ b/src/GPIO/gpioTasks.c
@@ -32,7 +32,7 @@
 #include "GPIO.h"
 
 #define DEBOUNCE_DELAY_PERIOD		30
-#define GPIO_TASK_STACK_SIZE		50
+#define GPIO_TASK_STACK_SIZE		64
 
 xSemaphoreHandle xOnPushbutton;
 

--- a/src/tasks/wifi.c
+++ b/src/tasks/wifi.c
@@ -63,7 +63,7 @@
 /* How long to wait before giving up on the message */
 #define READ_TIMEOUT_MS		250
 /* How much stack does this task deserve */
-#define STACK_SIZE		256
+#define STACK_SIZE		288
 /* Make all task names 16 chars including NULL char */
 #define THREAD_NAME		"WiFi Task      "
 /* How many events can be pending before we overflow */


### PR DESCRIPTION
Both were below the 32 value for their high water mark.  This adds
enough to ensure they are above that threshold.  I added more to the
wifi task because I once saw a stack smash that is probably related
to a couple of interupts firing and that lacking sufficient space.