### PR TITLE
Deprecate use of serial_destroy; replace with re-opening instead

### DIFF
--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -73,6 +73,8 @@ void serial_destroy(struct Serial *s);
 
 void serial_close(struct Serial* s);
 
+void serial_reopen(struct Serial* s);
+
 bool serial_is_connected(const struct Serial* s);
 
 struct Serial* serial_create(const char *name, const size_t tx_cap,

--- a/src/serial/serial.c
+++ b/src/serial/serial.c
@@ -107,7 +107,8 @@ void serial_close(struct Serial* s)
 /**
  * Re-opens a closed serial object.  This exists because there are inherent
  * race conditions when using serial objects directly and closing/destroying
- * them.  We need
+ * them.  We need an intermediary step like what glibc does with file handles
+ * and streams.  That is tracked by issue #542.
  */
 void serial_reopen(struct Serial* s)
 {

--- a/src/serial/serial.c
+++ b/src/serial/serial.c
@@ -104,6 +104,17 @@ void serial_close(struct Serial* s)
 	unblock_rx_queue(s);
 }
 
+/**
+ * Re-opens a closed serial object.  This exists because there are inherent
+ * race conditions when using serial objects directly and closing/destroying
+ * them.  We need
+ */
+void serial_reopen(struct Serial* s)
+{
+	serial_clear(s);
+	s->closed = false;
+}
+
 
 void serial_destroy(struct Serial *s)
 {


### PR DESCRIPTION
Turns out there are lots of race conditions associated with destroying
Serial devices.  Namely when tasks return from a suspended state they
may try to access a serial device that no longer exists.  This obviously
not good and was causing intermittent crashes on RCT.

This patch works around the issue by never destroying serial devices.
By doing this we will no longer have the segfault issues, but instead
will incur other issues like inproper buffer sizes.  I am willing to
live with that for this release.  Issue #542 tracks a proper fix
(moving to POSIX file handles and streams) which will put an intermediate
buffer inbetween these actions, allowing us to safely destroy the backends
without risk of segfault.

Issue #847