### PR TITLE
Fix wifi init hang; add better init logging

### DIFF
--- a/include/modem/at_basic.h
+++ b/include/modem/at_basic.h
@@ -37,9 +37,9 @@ bool at_basic_ping(struct Serial* serial, const size_t tries,
 		   const tiny_millis_t delay_ms);
 
 int at_basic_probe(struct Serial* serial, const int bauds[],
-		   const size_t tries, const tiny_millis_t delay,
-		   const size_t msg_bits, const size_t parity,
-		   const size_t stop_bits);
+		   const size_t size, const size_t tries,
+		   const tiny_millis_t delay, const size_t msg_bits,
+		   const size_t parity, const size_t stop_bits);
 
 CPP_GUARD_END
 

--- a/main.c
+++ b/main.c
@@ -105,6 +105,7 @@ void setupTask(void *param)
 #endif
 
         /* Removes this setup task from the scheduler */
+	pr_info("[main] Setup Task complete!\r\n");
         vTaskDelete(NULL);
 }
 

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -1159,8 +1159,9 @@ bool esp8266_set_uart_config_raw(const size_t baud, const size_t bits,
 
 bool esp8266_probe_device(struct Serial* serial, const int fast_baud)
 {
-	const int bauds[] = {ESP8266_SERIAL_DEF_BAUD, fast_baud, 0};
-	return at_basic_probe(serial, bauds, AT_PROBE_TRIES, AT_PROBE_DELAY_MS,
+	const int bauds[] = {fast_baud, ESP8266_SERIAL_DEF_BAUD};
+	return at_basic_probe(serial, bauds, ARRAY_LEN(bauds),
+			      AT_PROBE_TRIES, AT_PROBE_DELAY_MS,
 			      ESP8266_SERIAL_DEF_BITS,
 			      ESP8266_SERIAL_DEF_PARITY,
 			      ESP8266_SERIAL_DEF_STOP);

--- a/src/modem/at_basic.c
+++ b/src/modem/at_basic.c
@@ -80,7 +80,8 @@ bool at_basic_ping(struct Serial* serial, const size_t tries,
  * Probes a Serial port for a device that will respond to the basic
  * AT command.
  * @param Serial The serial device
- * @param bauds A NULL terminated list of baud rates.
+ * @param bauds A list of baud rates to try
+ * @param size The length of the list of baud rates to try.
  * @param tries The number of tries per baud rate before giving up.
  * @param delay_ms The time we wait in ms for a response before giving up.
  * @param msg_bits Serial configuration of # of bits per message
@@ -89,14 +90,14 @@ bool at_basic_ping(struct Serial* serial, const size_t tries,
  * @return The baud rate that the device responded to. 0 if no response.
  */
 int at_basic_probe(struct Serial* serial, const int bauds[],
-		   const size_t tries, const tiny_millis_t delay_ms,
-		   const size_t msg_bits, const size_t parity,
-		   const size_t stop_bits)
+		   const size_t size, const size_t tries,
+		   const tiny_millis_t delay_ms, const size_t msg_bits,
+		   const size_t parity, const size_t stop_bits)
 {
-	for (const int* baud = bauds; bauds && *baud; ++baud) {
-		serial_config(serial, msg_bits, parity, stop_bits, *baud);
+	for (int i = 0; i < size; ++i) {
+		serial_config(serial, msg_bits, parity, stop_bits, bauds[i]);
 		if (at_basic_ping(serial, tries, delay_ms))
-			return *baud;
+			return bauds[i];
 	}
 
 	return 0;


### PR DESCRIPTION
We were encountering an overflow issue in our logic that would cause
the WiFi subsystem to hang and never recover during init if it was
enabled and no wifi device was attached. This patch fixes that and
adds lots more debug to help out with future issues.

I also added a lengh parameter instead of requiring a NULL terminated
list of bauds for the probe command.  I figured this was a saner
approach less prone to failure.

Issue #841