### PR TITLE
Remove hack around multi-dest UDP port on esp8266 chip

### DIFF
--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -1453,18 +1453,16 @@ struct Serial* esp8266_drv_connect(const enum protocol proto,
                                                      port, -1, connect_cb);
                 break;
         case PROTOCOL_UDP:
-                ;
-                int src_port = 0;
-                enum esp8266_udp_mode udp_mode = ESP8266_UDP_MODE_NONE;
-                if (0 == strcmp(addr, IPV4_BROADCAST_ADDRESS_STR)) {
-                        src_port = port;
-                        udp_mode = ESP8266_UDP_MODE_PEER_CHANGE_WHENEVER;
-                }
+	{
+                const int src_port = 0;
+                const enum esp8266_udp_mode udp_mode = ESP8266_UDP_MODE_NONE;
                 connect_result = esp8266_connect_udp(cso->chan_id, addr,
                                                      port, src_port,
                                                      udp_mode, connect_cb);
                 break;
+	}
         }
+
         if (!connect_result) {
                 pr_warning(LOG_PFX "Failed to issue connect command\r\n");
                 goto done;


### PR DESCRIPTION
We had a hack in place on the UDP connection that would set both the
UDP source port and would control a special UDP mode on the esp8266
chip.  Based on the documentation it would seem that this was
necessary to enable the broadcasting of a beacon packet.  Turns out
that this was in incorrect assumption.  That combined with setting the
source port to be the same as the destination port lead to some issues
if more than one RCP/RCT was on the same network (the stateless UDP
connection would see other packets and this would lead to issues).

The fix is simple, remove the use of these flags and specific setting
of the souce UDP port.  This should default to the UDP connection
using an ephemeral port which should be chosen at random and should be
out of the range of port 7223, thus solving the issue of reading other
packets.  This also simplifies the code a wee bit, which is always a
good thing.