### PR TITLE
Handle the <0-4>,CONNECT FAIL channel action on ESP8266

### DIFF
--- a/include/devices/esp8266.h
+++ b/include/devices/esp8266.h
@@ -73,6 +73,7 @@ enum socket_action {
         SOCKET_ACTION_UNKNOWN,
         SOCKET_ACTION_DISCONNECT,
         SOCKET_ACTION_CONNECT,
+	SOCKET_ACTION_CONNECT_FAIL,
 };
 
 /**

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -188,23 +188,22 @@ static bool channel_action_cb(const char* msg)
  * Callback that gets invoked when we are unable to handle the URC using
  * the standard URC callbacks.  Used for the silly messages like
  * `0,CONNECT` where there is no prefix for the URC like their should be.
- * Messages this callback handles:
- * + IPD - Incoming data.
- * + <0-4>,{CONNECT,CLOSED}
- * + WIFI {CONNECTED,DISCONNECT,GOT IP}
  */
 static bool sparse_urc_cb(char* msg)
 {
+	/* + IPD,... - Incoming data. */
 	if (strncmp(msg, "+IPD,", 5) == 0) {
 		ipd_urc_cb(msg);
 		return true;
 	}
 
+	/* WIFI ... - Device actions */
         if (strncmp(msg, "WIFI ", 5) == 0) {
 		wifi_action_callback(msg);
 		return true;
 	}
 
+	/* <0-4>,... - Socket actions */
 	return channel_action_cb(msg);
 }
 

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -419,6 +419,7 @@ static void socket_state_changed_cb(const size_t chan_id,
 	cmd_set_check(CHECK_DATA);
 	switch (action) {
 	case SOCKET_ACTION_DISCONNECT:
+	case SOCKET_ACTION_CONNECT_FAIL:
 		pr_info_int_msg(LOG_PFX "Socket closed on channel ",
 				chan_id);
 		socket_disconnect_handler(chan_id);


### PR DESCRIPTION
Seems there is another vague channel action, the CONNECT FAIL action.
We didn't handle this before.  When this happens we should close
the connection.  This patch now does that.  When this fails sometimes
it can cause the WiFi chip to get into a bad state.

Issue #861