### PR TITLE
Add strntcpy, convert methods as needed

### DIFF
--- a/include/util/str_util.h
+++ b/include/util/str_util.h
@@ -43,6 +43,8 @@ char* str_util_rstrip_zeros_inline(char *str);
 
 char* str_util_strip_zeros_inline(char *str);
 
+char* strntcpy(char* dest, const char* src, size_t n);
+
 CPP_GUARD_END
 
 #endif /* _STR_UTIL_H_ */

--- a/src/devices/bluetooth.c
+++ b/src/devices/bluetooth.c
@@ -19,16 +19,14 @@
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #include "FreeRTOS.h"
 #include "bluetooth.h"
 #include "loggerConfig.h"
-#include <string.h>
 #include "printk.h"
 #include "task.h"
 #include "taskUtil.h"
-
 #include <stdbool.h>
+#include <string.h>
 
 /*
  * https://www.olimex.com/Products/Components/RF/BLUETOOTH-SERIAL-HC-06/resources/hc06.pdf

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -626,8 +626,8 @@ static bool parse_client_info(char *rsp,
         if (!ssid || !mac)
                 return false;
 
-        strncpy(info->ssid, ssid, ARRAY_LEN(info->ssid));
-        strncpy(info->mac, mac, ARRAY_LEN(info->mac));
+        strntcpy(info->ssid, ssid, ARRAY_LEN(info->ssid));
+        strntcpy(info->mac, mac, ARRAY_LEN(info->mac));
         info->has_ap = true;
 
         return true;

--- a/src/gsm/gsm.c
+++ b/src/gsm/gsm.c
@@ -24,7 +24,7 @@
 #include "macros.h"
 #include "printk.h"
 #include "serial_buffer.h"
-
+#include "str_util.h"
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -92,7 +92,7 @@ bool gsm_get_subscriber_number(struct serial_buffer *sb,
                 goto parse_fail;
 
         *num_end = '\0';
-        strncpy(ci->number, num_start, sizeof(ci->number));
+        strntcpy(ci->number, num_start, sizeof(ci->number));
         return true;
 
 parse_fail:
@@ -148,7 +148,7 @@ bool gsm_get_imei(struct serial_buffer *sb,
                 return false;
         }
 
-        strncpy(cell_info->imei, msgs[0], sizeof(cell_info->imei));
+        strntcpy(cell_info->imei, msgs[0], sizeof(cell_info->imei));
 
         return 1;
 }
@@ -238,6 +238,6 @@ bool gsm_get_network_reg_info(struct serial_buffer *sb,
                 str_beg = "UNKNOWN";
         }
 
-        strncpy(ci->op, str_beg, sizeof(ci->op));
+        strntcpy(ci->op, str_beg, sizeof(ci->op));
         return status;
 }

--- a/src/jsmn/jsmn.c
+++ b/src/jsmn/jsmn.c
@@ -417,6 +417,6 @@ bool jsmn_exists_set_val_string(const jsmntok_t* root, const char* field,
 	if (strip)
 		data = strip_inline(data);
 
-	strncpy(val, data, max_len);
+	strntcpy(val, data, max_len);
 	return true;
 }

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -55,6 +55,7 @@
 #include "printk.h"
 #include "sampleRecord.h"
 #include "serial.h"
+#include "str_util.h"
 #include "task.h"
 #include "taskUtil.h"
 #include "timer.h"
@@ -584,9 +585,9 @@ static const jsmntok_t * setChannelConfig(struct Serial *serial, const jsmntok_t
         unescapeTextField(value);
 
         if (STR_EQ("nm", name))
-            strncpy(channelCfg->label, value, DEFAULT_LABEL_LENGTH);
+            strntcpy(channelCfg->label, value, DEFAULT_LABEL_LENGTH);
         else if (STR_EQ("ut", name))
-            strncpy(channelCfg->units, value, DEFAULT_UNITS_LENGTH);
+            strntcpy(channelCfg->units, value, DEFAULT_UNITS_LENGTH);
         else if (STR_EQ("min", name))
             channelCfg->min = atof(value);
         else if (STR_EQ("max", name))

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -26,6 +26,7 @@
 #include "memory.h"
 #include "modp_numtoa.h"
 #include "printk.h"
+#include "str_util.h"
 #include "timer_config.h"
 #include "units.h"
 #include "virtual_channel.h"
@@ -260,11 +261,11 @@ static void resetCellularConfig(CellularConfig *cfg)
 
 static void resetTelemetryConfig(TelemetryConfig *cfg)
 {
-    memset(cfg, 0, sizeof(TelemetryConfig));
-    cfg->backgroundStreaming = BACKGROUND_STREAMING_ENABLED;
-    strncpy(cfg->telemetryServerHost, DEFAULT_TELEMETRY_SERVER_HOST,
-            sizeof(cfg->telemetryServerHost));
-    cfg->telemetry_port = DEFAULT_TELEMETRY_SERVER_PORT;
+	memset(cfg, 0, sizeof(TelemetryConfig));
+	cfg->backgroundStreaming = BACKGROUND_STREAMING_ENABLED;
+	strntcpy(cfg->telemetryServerHost, DEFAULT_TELEMETRY_SERVER_HOST,
+		 sizeof(cfg->telemetryServerHost));
+	cfg->telemetry_port = DEFAULT_TELEMETRY_SERVER_PORT;
 }
 
 static void resetConnectivityConfig(ConnectivityConfig *cfg)

--- a/src/lua/luaScript.c
+++ b/src/lua/luaScript.c
@@ -19,12 +19,12 @@
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #include "luaScript.h"
 #include "luaTask.h"
 #include "mem_mang.h"
-#include <string.h>
 #include "printk.h"
+#include "str_util.h"
+#include <string.h>
 
 #ifndef RCP_TESTING
 static const volatile ScriptConfig g_scriptConfig  __attribute__((section(".script\n\t#")));
@@ -52,15 +52,15 @@ int flash_default_script()
         lua_task_stop();
 
         ScriptConfig *defaultScriptConfig =
-                (ScriptConfig *) portMalloc(sizeof(ScriptConfig));
+                (ScriptConfig *) calloc(sizeof(ScriptConfig), 1);
         if (defaultScriptConfig == NULL) {
                 pr_error("LUA: Can't flash.  Can't allocate RAM\r\n");
                 return result;
         }
 
         defaultScriptConfig->magicInit = MAGIC_NUMBER_SCRIPT_INIT;
-        strncpy(defaultScriptConfig->script, DEFAULT_SCRIPT,
-                sizeof(DEFAULT_SCRIPT));
+        strntcpy(defaultScriptConfig->script, DEFAULT_SCRIPT,
+		 sizeof(DEFAULT_SCRIPT));
         result = memory_flash_region((void *)&g_scriptConfig,
                                      (void *)defaultScriptConfig,
                                      sizeof (ScriptConfig));

--- a/src/serial/serial_buffer.c
+++ b/src/serial/serial_buffer.c
@@ -138,7 +138,7 @@ size_t serial_buffer_append(struct serial_buffer *sb, const char *buff)
 
         char *ptr = sb->buffer + sb->curr_len;
         const size_t max_len = sb->length - sb->curr_len;
-        strncpy(ptr, buff, max_len);
+        strntcpy(ptr, buff, max_len);
 
         const size_t buff_len = strlen(buff) + 1;
         const size_t cpy_len = MIN(buff_len, max_len);

--- a/src/util/str_util.c
+++ b/src/util/str_util.c
@@ -160,3 +160,22 @@ char* str_util_strip_zeros_inline(char *str)
         str = str_util_lstrip_zeros_inline(str);
         return str_util_rstrip_zeros_inline(str);
 }
+
+/**
+ * Just like strncpy except this method always ensures the resulting string
+ * is null ternimated.  Think of this as safe strncpy.
+ * @param dest The destination pointer
+ * @param src The source pointer
+ * @param n The maximum length of the string.
+ */
+char* strntcpy(char* dest, const char* src, size_t n)
+{
+	if (!n)
+		return dest;
+
+	/* Copy and NULL terminate the string always to avoid overflow */
+	strncpy(dest, src, --n);
+	dest[n] = 0;
+
+	return dest;
+}


### PR DESCRIPTION
@ryandoherty found a string buffer overflow scenario where it was possible for an external source to give a long enough string that would be copied in unterminated which could cause undesired behavior.  This PR fixes that by introducing the `strntcpy` method, which is like strncpy but always guarantees that any copied string is NULL terminated.

Issue #863 