### PR TITLE
Fix the RCT Battery Voltage Issue

### DIFF
--- a/bin/asl_flash
+++ b/bin/asl_flash
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+IMAGE=$1
+if [ ! -r "$IMAGE" ]; then
+    echo "Image \"$IMAGE\" not readable" >&2
+    exit 1
+fi
+
+DEV=$(find /dev -name 'ttyACM*' | head -n 1)
+if [ -z "$DEV" ]; then
+    echo "Device not found" >&2
+    exit 1
+fi
+echo "Device found at \"$DEV\"."
+
+if pkill minicom; then
+    echo "Minicom was open.  Closed it and will sleep for a bit..."
+    sleep 2
+fi
+
+echo "Entering Bootloader mode..."
+stty --file=$DEV 115200
+echo -en "q\r\n {\"sysReset\":{\"loader\":1}}\r\n" >$DEV
+sleep 2
+
+echo "Starting flash procedure"
+echo | asl_f4_loader -f $IMAGE
+
+echo "Done"
+exit 0

--- a/platform/rct/hal/ADC_stm32/ADC_device_stm32.c
+++ b/platform/rct/hal/ADC_stm32/ADC_device_stm32.c
@@ -28,6 +28,7 @@
 #include "taskUtil.h"
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 /*
  * RC/T
@@ -38,10 +39,12 @@
 #define SCALING_BATTERYV		0.00465f
 #define TOTAL_ADC_CHANNELS		1
 
-volatile unsigned short ADC_Val[TOTAL_ADC_CHANNELS];
+volatile unsigned short *ADC_Val;
 
 int ADC_device_init(void)
 {
+	ADC_Val = calloc(TOTAL_ADC_CHANNELS, sizeof(*ADC_Val));
+
         /* Configure the ADC clock */
         RCC_ADCCLKConfig(RCC_ADC34PLLCLK_Div2);
 


### PR DESCRIPTION
DMA can't be written to memory that lives in the CCM area of the chip.  Our .bss section lives in this portion of the chip.  Thus had to adjust how the memory was allocated.  Now it works.

I also added a helpful script for flashing.

Fixes Issue #868 