### PR TITLE
updates to track autodetection semantics

### DIFF
--- a/src/lap_stats/lap_stats.c
+++ b/src/lap_stats/lap_stats.c
@@ -651,11 +651,13 @@ static void lapstats_setup(const GpsSnapshot *gps_snapshot)
         const Track *track = NULL;
         track_status_t track_status;
         if (auto_detect_track) {
-                track_status = TRACK_STATUS_AUTO_DETECTED;
-                track = auto_configure_track(NULL, gp);
+                const Track *default_track = (get_tracks()->count == 0) ? &trackConfig->track : NULL;
+                track = auto_configure_track(default_track, gp);
+                track_status = default_track->trackId ? TRACK_STATUS_AUTO_DETECTED : TRACK_STATUS_WAITING_TO_CONFIG;
                 if (track)
                         pr_info_int_msg("track: detected track ",
                                         track->trackId);
+
         } else {
                 track_status = TRACK_STATUS_FIXED_CONFIG;
                 track = &trackConfig->track;

--- a/src/lap_stats/lap_stats.c
+++ b/src/lap_stats/lap_stats.c
@@ -657,14 +657,12 @@ static void lapstats_setup(const GpsSnapshot *gps_snapshot)
                 if (track != &trackConfig->track) {
                         pr_info_int_msg(_LOG_PFX "Auto-detected track from db ",
                                         track->trackId);
-                }
-                else {
+                } else {
                         bool track_db_exists = (get_tracks()->count > 0);
                         if (track_db_exists) {
                                 track_status = TRACK_STATUS_FIXED_CONFIG;
                                 pr_info_int_msg(_LOG_PFX "Could not find track in db, falling back to fixed config ", track->trackId);
-                        }
-                        else {
+                        } else {
                                 pr_info_int_msg(_LOG_PFX "Using track config ", track->trackId);
                         }
                 }

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -240,8 +240,7 @@ static void resetTrackConfig(TrackConfig *cfg)
 {
 	memset(cfg, 0, sizeof(TrackConfig));
 	cfg->radius = DEFAULT_TRACK_TARGET_RADIUS;
-	/* True if we support a track DB, false otherwise */
-	cfg->auto_detect = !!MAX_TRACKS;
+	cfg->auto_detect = true;
 }
 
 static void resetBluetoothConfig(BluetoothConfig *cfg)


### PR DESCRIPTION
This PR affects RCT:
* always report configured track ID if we have no track database
* normalizes default configuration.
* Allows auto configure flag to have a useful meaning in RCT, where currently it's a flag that's present but ignored.

This is to match updates to app to enhance track auto-detection, in PR: https://github.com/autosportlabs/RaceCapture_App/pull/1278

Resolves #878

