### PR TITLE
Properly encode/decode JSON strings in firmware

### DIFF
--- a/include/jsmn/jsmn.h
+++ b/include/jsmn/jsmn.h
@@ -23,6 +23,7 @@
 #define __JSMN_H_
 
 #include "cpp_guard.h"
+#include "serial.h"
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -137,6 +138,11 @@ bool jsmn_exists_set_val_bool(const jsmntok_t* root, const char* field,
 bool jsmn_exists_set_val_string(const jsmntok_t* root, const char* field,
 				void* val, const size_t max_len,
 				const bool strip);
+
+void jsmn_decode_string(char* dst, const char* src, size_t len);
+
+void jsmn_encode_write_string(struct Serial* serial, const char* str);
+
 
 CPP_GUARD_END
 

--- a/include/logger/loggerApi.h
+++ b/include/logger/loggerApi.h
@@ -171,8 +171,6 @@ void api_sendLogEnd(struct Serial *serial);
 void api_send_sample_record(struct Serial *serial,
                             const struct sample *sample,
                             const unsigned int tick, const int sendMeta);
-//Utility functions
-void unescapeTextField(char *data);
 
 /* Wifi methods */
 int api_get_wifi_cfg(struct Serial *s, const jsmntok_t *json);

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -46,9 +46,9 @@ void initApi()
 
 static void putQuotedStr(struct Serial *serial, const char *str)
 {
-    serial_write_c(serial, '"');
-    serial_write_s(serial, str);
-    serial_write_c(serial, '"');
+	serial_write_c(serial, '"');
+	jsmn_encode_write_string(serial, str);
+	serial_write_c(serial, '"');
 }
 
 static void putKeyAndColon(struct Serial *serial, const char *key)
@@ -96,11 +96,11 @@ void json_uint(struct Serial *serial, const char *name, unsigned int value, int 
 
 void json_escapedString(struct Serial *serial, const char *name, const char *value, int more)
 {
-    putKeyAndColon(serial, name);
-    serial_write_c(serial, '"');
-    put_escapedString(serial, value, strlen(value));
-    serial_write_c(serial, '"');
-    putCommaIfNecessary(serial, more);
+	putKeyAndColon(serial, name);
+	serial_write_c(serial, '"');
+	jsmn_encode_write_string(serial, value);
+	serial_write_c(serial, '"');
+	putCommaIfNecessary(serial, more);
 }
 
 void json_string(struct Serial *serial, const char *name, const char *value, int more)

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -73,41 +73,6 @@ typedef void (*getConfigs_func)(size_t channeId, void ** baseCfg, ChannelConfig 
 typedef const jsmntok_t * (*setExtField_func)(const jsmntok_t *json, const char *name, const char *value, void *cfg);
 typedef int (*reInitConfig_func)(LoggerConfig *config);
 
-
-void unescapeTextField(char *data)
-{
-    char *result = data;
-    while (*data) {
-        if (*data == '\\') {
-            switch(*(data + 1)) {
-            case 'n':
-                *result = '\n';
-                break;
-            case 'r':
-                *result = '\r';
-                break;
-            case '\\':
-                *result = '\\';
-                break;
-            case '"':
-                *result = '\"';
-                break;
-            case '\0': //this should *NOT* happen
-                *result = '\0';
-                return;
-            default: // unknown escape char?
-                *result = ' ';
-                break;
-            }
-            result++;
-            data+=2;
-        } else {
-            *result++ = *data++;
-        }
-    }
-    *result='\0';
-}
-
 static int setUnsignedCharValueIfExists(const jsmntok_t *root, const char * fieldName, unsigned char *target, unsigned char (*filter)(unsigned char))
 {
     const jsmntok_t *valueNode = jsmn_find_get_node_value_prim(root, fieldName);
@@ -582,22 +547,21 @@ static const jsmntok_t * setChannelConfig(struct Serial *serial, const jsmntok_t
 
         char *name = nameTok->data;
         char *value = valueTok->data;
-        unescapeTextField(value);
 
         if (STR_EQ("nm", name))
-            strntcpy(channelCfg->label, value, DEFAULT_LABEL_LENGTH);
+		jsmn_decode_string(channelCfg->label, value, DEFAULT_LABEL_LENGTH);
         else if (STR_EQ("ut", name))
-            strntcpy(channelCfg->units, value, DEFAULT_UNITS_LENGTH);
+		jsmn_decode_string(channelCfg->units, value, DEFAULT_UNITS_LENGTH);
         else if (STR_EQ("min", name))
-            channelCfg->min = atof(value);
+		channelCfg->min = atof(value);
         else if (STR_EQ("max", name))
-            channelCfg->max = atof(value);
+		channelCfg->max = atof(value);
         else if (STR_EQ("sr", name))
-            channelCfg->sampleRate = encodeSampleRate(atoi(value));
+		channelCfg->sampleRate = encodeSampleRate(atoi(value));
         else if (STR_EQ("prec", name))
-            channelCfg->precision = (unsigned char) atoi(value);
+		channelCfg->precision = (unsigned char) atoi(value);
         else if (setExtField != NULL)
-            cfg = setExtField(valueTok, name, value, extCfg);
+		cfg = setExtField(valueTok, name, value, extCfg);
     }
 
     return cfg;

--- a/test/JsmnTest.cpp
+++ b/test/JsmnTest.cpp
@@ -1,0 +1,58 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "JsmnTest.hh"
+#include "macros.h"
+#include "mock_serial.h"
+#include "serial.h"
+#include <cppunit/extensions/HelperMacros.h>
+
+extern "C" {
+#include "jsmn/jsmn.c"
+}
+
+CPPUNIT_TEST_SUITE_REGISTRATION( JsmnTest );
+
+using std::string;
+
+void JsmnTest::decodeStringTest()
+{
+	const char encoded_json[] = "foo\\\"bar\\\\\\/baz\\t\\u1234\\r\\n";
+	const char expected_str[] = "foo\"bar\\/baz\t?\r\n";
+	char actual_str[ARRAY_LEN(expected_str)];
+
+	jsmn_decode_string(actual_str, encoded_json, ARRAY_LEN(actual_str));
+	CPPUNIT_ASSERT_EQUAL(string(expected_str), string(actual_str));
+}
+
+void JsmnTest::encodeWriteStringTest()
+{
+	const char str[] = "foo\"bar\\/baz\t?\r\n";
+	const char expected_json[] = "foo\\\"bar\\\\/baz\\t?\\r\\n";
+
+	setupMockSerial();
+	Serial* serial = getMockSerial();
+
+	jsmn_encode_write_string(serial, str);
+	CPPUNIT_ASSERT_EQUAL(string(expected_json),
+			     string(mock_getTxBuffer()));
+
+}

--- a/test/JsmnTest.hh
+++ b/test/JsmnTest.hh
@@ -1,0 +1,39 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _JSMNTEST_H_
+#define _JSMNTEST_H_
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class JsmnTest : public CppUnit::TestFixture
+{
+	CPPUNIT_TEST_SUITE( JsmnTest );
+	CPPUNIT_TEST( decodeStringTest );
+	CPPUNIT_TEST( encodeWriteStringTest );
+	CPPUNIT_TEST_SUITE_END();
+
+public:
+	void decodeStringTest();
+	void encodeWriteStringTest();
+};
+
+#endif /* _JSMNTEST_H_ */

--- a/test/Makefile
+++ b/test/Makefile
@@ -86,6 +86,7 @@ INCLUDES = \
 -I$(FREE_RTOS_KERNEL_DIR)/include \
 -I$(FREE_RTOS_KERNEL_DIR)/include_testing \
 -I$(UTIL_DIR) \
+-I$(RCP_SRC) \
 -I$(RCP_SRC)/devices \
 -I$(RCP_SRC)/lap_stats \
 -I$(RCP_SRC)/logger \
@@ -138,6 +139,7 @@ AutoLoggerTest.cpp \
 AtTest.cpp \
 CellularApiStatusKeysTest.cpp \
 ChannelConfigTest.cpp \
+JsmnTest.cpp \
 PredictiveTimeTest2.cpp \
 StrUtilTest.cpp \
 date_time_test.cpp \
@@ -199,7 +201,6 @@ $(RCP_SRC)/gps/geopoint.c \
 $(RCP_SRC)/gps/gps.c \
 $(RCP_SRC)/gsm/gsm.c \
 $(RCP_SRC)/imu/imu.c \
-$(RCP_SRC)/jsmn/jsmn.c \
 $(RCP_SRC)/launch_control.c \
 $(RCP_SRC)/logger/fileWriter.c \
 $(RCP_SRC)/logger/connectivityTask.c \
@@ -244,6 +245,7 @@ mock_usb_comm.c \
 
 SIM_C_SRC = \
 $(RCP_SRC)/devices/cellular_api_status_keys.c \
+$(RCP_SRC)/jsmn/jsmn.c \
 $(RCP_SRC)/lap_stats/lap_stats.c \
 $(RCP_SRC)/logger/auto_logger.c \
 $(RCP_SRC)/logger/channel_config.c \

--- a/test/loggerApi_test.cpp
+++ b/test/loggerApi_test.cpp
@@ -178,41 +178,6 @@ void LoggerApiTest::setUp()
         lapstats_config_changed();
 }
 
-
-void LoggerApiTest::tearDown()
-{
-}
-
-void LoggerApiTest::testUnescapeTextField(){
-	{
-		char test[] =  "test1";
-		unescapeTextField(test);
-		CPPUNIT_ASSERT_EQUAL(string("test1"), string(test));
-	}
-
-	{
-		char test[] =  "test\\n1";
-		unescapeTextField(test);
-		CPPUNIT_ASSERT_EQUAL(string("test\n1"), string(test));
-	}
-	{
-		char test[] =  "test\\r1";
-		unescapeTextField(test);
-		CPPUNIT_ASSERT_EQUAL(string("test\r1"), string(test));
-	}
-	{
-		char test[] =  "test\\\\1";
-		unescapeTextField(test);
-		CPPUNIT_ASSERT_EQUAL(string("test\\1"), string(test));
-	}
-	{
-		char test[] =  "test\\\"1";
-		unescapeTextField(test);
-		CPPUNIT_ASSERT_EQUAL(string("test\"1"), string(test));
-	}
-
-}
-
 void LoggerApiTest::populateChannelConfig(ChannelConfig *cfg, const int i, const int splRt) {
    sprintf(cfg->label, "testName_%d", i);
    sprintf(cfg->units, "unit_%d", i);

--- a/test/loggerApi_test.h
+++ b/test/loggerApi_test.h
@@ -39,7 +39,6 @@ using std::istreambuf_iterator;
 class LoggerApiTest : public CppUnit::TestFixture
 {
     CPPUNIT_TEST_SUITE( LoggerApiTest );
-    CPPUNIT_TEST( testUnescapeTextField );
     CPPUNIT_TEST( testSetConnectivityCfg );
     CPPUNIT_TEST( testGetConnectivityCfg );
     CPPUNIT_TEST( testGetAnalogCfg );
@@ -99,7 +98,6 @@ public:
     int findAndReplace(string & source, const string find, const string replace);
     string readFile(string filename);
     void setUp();
-    void tearDown();
 
     void setActiveTrack();
     void setActiveTrackSectors();
@@ -111,7 +109,6 @@ public:
     char * processApiGeneric(string filename);
 
     void assertGenericResponse(char *buffer, const char *messageName, int responseCode);
-    void testUnescapeTextField();
     void testSampleData1();
     void testSampleData2();
     void testHeartBeat();


### PR DESCRIPTION
Turns out we were not properly encoding/decoding JSON strings.
Certain characters are considered illegal in a JSON stream and
thus must be encoded (escaped) so they become legal charaters.
They then must be unencoded on the receiving end so that their
meaning is restored.

This change adds in encode and decode methods, makes use of them
at the appropriate spots and removes broken code that previously
was doing this incorrectly/incompletely.

Note: We don't support unicode encoded charaters.  I just replace
those with a '?' if I see them.

Issue #808