### PR TITLE
Strip IMEI content when read from serial line

### DIFF
--- a/src/gsm/gsm.c
+++ b/src/gsm/gsm.c
@@ -148,7 +148,8 @@ bool gsm_get_imei(struct serial_buffer *sb,
                 return false;
         }
 
-        strntcpy(cell_info->imei, msgs[0], sizeof(cell_info->imei));
+	strntcpy(cell_info->imei, msgs[0], sizeof(cell_info->imei));
+	rstrip_inline(cell_info->imei);
 
         return 1;
 }


### PR DESCRIPTION
Else the \r\n characters remain in there and that brakes the mind of
our app.

Issue #872