### PR TITLE
Fix version printing, cleanup version macros and methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@
 # this code. If not, see <http://www.gnu.org/licenses/>.
 #
 
-export MAJOR  := 2
-export MINOR  := 10
-export BUGFIX := 0
+export MAJOR  := $(shell git describe | cut -d \- -f 1 | cut -d . -f 1)
+export MINOR  := $(shell git describe | cut -d \- -f 1 | cut -d . -f 2)
+export BUGFIX := $(shell git describe | cut -d \- -f 1 | cut -d . -f 3)
 export API    := 1
 
 export VERSION := $(shell git describe --dirty --always)

--- a/include/logger/versionInfo.h
+++ b/include/logger/versionInfo.h
@@ -44,7 +44,7 @@ typedef struct _VersionInfo {
 bool version_check_changed(const VersionInfo *versionInfo,
                            const char* log_pfx);
 const VersionInfo* get_current_version_info();
-const char* version_git_description();
+const char* version_full();
 enum release_type version_get_release_type();
 const char* version_release_type_api_key(const enum release_type rt);
 

--- a/platform/mk2/capabilities.h
+++ b/platform/mk2/capabilities.h
@@ -89,9 +89,6 @@
 //system info
 #define DEVICE_NAME    "RCP_MK2"
 #define FRIENDLY_DEVICE_NAME "RaceCapture/Pro MK2"
-#define COMMAND_PROMPT "RaceCapture/Pro MK2"
-#define VERSION_STR MAJOR_REV_STR "." MINOR_REV_STR "." BUGFIX_REV_STR
-#define WELCOME_MSG "Welcome to RaceCapture/Pro MK2 : Firmware Version " VERSION_STR
 
 /* How big is our hardware init stack */
 #define HARDWARE_INIT_STACK_SIZE	256

--- a/platform/rct/capabilities.h
+++ b/platform/rct/capabilities.h
@@ -59,9 +59,6 @@
 //system info
 #define DEVICE_NAME    "RCT"
 #define FRIENDLY_DEVICE_NAME "RaceCapture"
-#define COMMAND_PROMPT "RaceCapture"
-#define VERSION_STR MAJOR_REV_STR "." MINOR_REV_STR "." BUGFIX_REV_STR
-#define WELCOME_MSG "Welcome to RaceCapture : Firmware Version " VERSION_STR
 
 /* LUA Configuration */
 

--- a/src/command/baseCommands.c
+++ b/src/command/baseCommands.c
@@ -117,12 +117,13 @@ void ShowTaskInfo(struct Serial *serial, unsigned int argc, char **argv)
 
 void GetVersion(struct Serial *serial, unsigned int argc, char **argv)
 {
-    putHeader(serial, "Version Info");
-    put_nameString(serial, "major", MAJOR_REV_STR);
-    put_nameString(serial, "minor", MINOR_REV_STR);
-    put_nameString(serial, "bugfix", BUGFIX_REV_STR);
-    put_nameString(serial, "serial", cpu_get_serialnumber());
-    put_crlf(serial);
+	putHeader(serial, "Version Info");
+	put_nameString(serial, "major", MAJOR_REV_STR);
+	put_nameString(serial, "minor", MINOR_REV_STR);
+	put_nameString(serial, "bugfix", BUGFIX_REV_STR);
+	put_nameString(serial, "full", version_full());
+	put_nameString(serial, "serial", cpu_get_serialnumber());
+	put_crlf(serial);
 }
 
 void ResetSystem(struct Serial *serial, unsigned int argc, char **argv)

--- a/src/devices/cellular.c
+++ b/src/devices/cellular.c
@@ -349,7 +349,7 @@ static bool auth_telem_stream(struct serial_buffer *sb,
         json_string(serial, "deviceId", deviceId, 1);
         json_int(serial, "apiVer", API_REV, 1);
         json_string(serial, "device", DEVICE_NAME, 1);
-        json_string(serial, "ver", VERSION_STR, 1);
+        json_string(serial, "ver", version_full(), 1);
         json_string(serial, "sn", cpu_get_serialnumber(), 0);
         json_objEnd(serial, 0);
         json_objEnd(serial, 0);

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -124,7 +124,7 @@ static void rc_version_info(struct Serial *serial, const int more,
         json_int(serial, minor_name, MINOR_REV, 1);
         json_int(serial, bf_name, BUGFIX_REV, 1);
         json_string(serial, "serial", cpu_get_serialnumber(), 1);
-        json_string(serial, "git_info", version_git_description(), 1);
+        json_string(serial, "git_info", version_full(), 1);
         json_string(serial, "release_type", rt_key, more);
 }
 

--- a/src/logger/versionInfo.c
+++ b/src/logger/versionInfo.c
@@ -67,12 +67,13 @@ bool version_check_changed(const VersionInfo *pv,
 }
 
 /**
- * @return The output of `git describe --dirty` on the HEAD of the git
- * tree when this release was built.  This human readable string provides
- * info on where the code has come from along with # of committs and whether
- * or not the tree was dirty at the time of build.
+ * @return The full version string.  This is effectively the output of
+ * `git describe --dirty` on the HEAD of the git tree when this release
+ * was built.  This human readable string provides info on where the code
+ * has come from along with # of committs and whether or not the tree was
+ * dirty at the time of build.
  */
-const char* version_git_description()
+const char* version_full()
 {
         /* The git hash value is defined by the build */
         return RC_BUILD_GIT_DESCRIPTION;

--- a/test/capabilities.h
+++ b/test/capabilities.h
@@ -126,9 +126,6 @@ CPP_GUARD_BEGIN
 //system info
 #define DEVICE_NAME    "RCP_SIM"
 #define FRIENDLY_DEVICE_NAME "RaceCapture/Pro Sim"
-#define COMMAND_PROMPT "RaceCapture/Pro Sim"
-#define VERSION_STR MAJOR_REV_STR "." MINOR_REV_STR "." BUGFIX_REV_STR
-#define WELCOME_MSG "Welcome to RaceCapture/Pro Sim: Firmware Version " VERSION_STR
 
 /* How big is our hardware init stack */
 #define HARDWARE_INIT_STACK_SIZE	192

--- a/test/loggerApi_test.cpp
+++ b/test/loggerApi_test.cpp
@@ -1308,7 +1308,7 @@ void LoggerApiTest::testGetVersion(){
 	CPPUNIT_ASSERT_EQUAL(BUGFIX_REV, (int)(Number)json["ver"]["bugfix"]);
 	CPPUNIT_ASSERT_EQUAL(string(cpu_get_serialnumber()),
 			     (string)(String)json["ver"]["serial"]);
-        CPPUNIT_ASSERT_EQUAL(string(version_git_description()),
+        CPPUNIT_ASSERT_EQUAL(string(version_full()),
 			     (string)(String)json["ver"]["git_info"]);
 
 	const enum release_type rt = version_get_release_type();
@@ -1333,7 +1333,7 @@ void LoggerApiTest::testGetStatus(){
 	CPPUNIT_ASSERT_EQUAL(BUGFIX_REV, (int)(Number)sys_obj["ver_bugfix"]);
 	CPPUNIT_ASSERT_EQUAL(string(cpu_get_serialnumber()),
 			     (string)(String)sys_obj["serial"]);
-	CPPUNIT_ASSERT_EQUAL(string(version_git_description()),
+	CPPUNIT_ASSERT_EQUAL(string(version_full()),
 			     (string)(String)sys_obj["git_info"]);
 
 	const enum release_type rt = version_get_release_type();


### PR DESCRIPTION
Fixes the version printing as reported in issue #886.  Also fixes
the need to update the version info in the Makefile, which is now
derived from the git tag.  We also clean up some macros to remove
some of the less flexible code so we can create the user info as
needed.