### PR TITLE
Optimize scheduling of OBDII PIDs of different sample rates #870

### DIFF
--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -274,11 +274,22 @@ typedef struct _PWMConfig {
 
 #define OBD2_CHANNELS 20
 
+typedef enum _OBD2TimeOuts
+{
+    Hz0_2 = 1 << 0, // 5 seconds
+    Hz0_5 = 1 << 1, // 2 seconds
+    Hz1_0 = 1 << 2, // 1 seconds
+    Hz2_5 = 1 << 3, // .5 seconds
+    Hz10_0 = 1 << 4, // .1 seconds
+    Hz25_0 = 1 << 5, // .04 seconds
+    Hz50_0 = 1 << 6, // .02 seconds
+    Hz100_0 = 1 << 7 // .01 seconds
+} OBD2TimeOuts;
+
 typedef struct _PidConfig {
     ChannelConfig cfg;
     unsigned short pid;
 } PidConfig;
-
 
 typedef struct _OBD2Config {
     unsigned char enabled;

--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -279,7 +279,7 @@ typedef enum _OBD2TimeOuts
     Hz0_2 = 1 << 0, // 5 seconds
     Hz0_5 = 1 << 1, // 2 seconds
     Hz1_0 = 1 << 2, // 1 seconds
-    Hz2_5 = 1 << 3, // .5 seconds
+    Hz2_0 = 1 << 3, // .5 seconds
     Hz10_0 = 1 << 4, // .1 seconds
     Hz25_0 = 1 << 5, // .04 seconds
     Hz50_0 = 1 << 6, // .02 seconds

--- a/src/OBD2/OBD2_task.c
+++ b/src/OBD2/OBD2_task.c
@@ -37,6 +37,7 @@
 #define OBD2_TASK_STACK 	configMINIMAL_STACK_SIZE
 #define OBD2_FEATURE_DISABLED_DELAY_MS 2000
 
+
 void startOBD2Task(int priority)
 {
         /* Make all task names 16 chars including NULL char*/
@@ -45,29 +46,69 @@ void startOBD2Task(int priority)
                     priority, NULL );
 }
 
+OBD2TimeOuts mapSampleRates(short sampleRate)
+{
+    if (sampleRate > 25) {
+        return Hz50_0;
+    } else if (sampleRate > 10) {
+        return Hz25_0;
+    } else if (sampleRate > 5) {
+        return Hz10_0;
+    } else if (sampleRate > 1) {
+        return Hz2_5;
+    }
+    return Hz100_0;
+}
+
 void OBD2Task(void *pvParameters)
 {
     pr_info("Start OBD2 task\r\n");
     size_t max_obd2_samplerate = msToTicks((TICK_RATE_HZ / MAX_OBD2_SAMPLE_RATE));
     LoggerConfig *config = getWorkingLoggerConfig();
     OBD2Config *oc = &config->OBD2Configs;
+
+    uint32_t currTime = getUptime();
+    uint32_t currtimeOuts = 0;
+    tiny_millis_t lastTime5000ms = currTime + 5000;
+    tiny_millis_t lastTime2000ms = currTime + 2000;
+    tiny_millis_t lastTime1000ms = currTime + 1000;
+    tiny_millis_t lastTime500ms = currTime + 500;
+    tiny_millis_t lastTime100ms = currTime + 100;
+    tiny_millis_t lastTime40ms = currTime + 40;
+    tiny_millis_t lastTime20ms = currTime + 20;
+    tiny_millis_t lastTime1ms = currTime + 1;
+
     while(1) {
-        while(oc->enabled && oc->enabledPids > 0) {
+        while (oc->enabled && oc->enabledPids > 0) {
+            currTime = getUptime();
+            currtimeOuts = (currTime > lastTime5000ms ? Hz0_2 : 0)
+                + (currTime > lastTime2000ms ? Hz0_5 : 0)
+                + (currTime > lastTime1000ms ? Hz1_0 : 0)
+                + (currTime > lastTime500ms ? Hz2_5 : 0)
+                + (currTime > lastTime100ms ? Hz10_0 : 0)
+                + (currTime > lastTime40ms ? Hz25_0 : 0)
+                + (currTime > lastTime20ms ? Hz50_0 : 0)
+                + (currTime > lastTime1ms ? Hz100_0 : 0);
+
             for (size_t i = 0; i < oc->enabledPids; i++) {
                 PidConfig *pidCfg = &oc->pids[i];
-                int value;
-                unsigned char pid = pidCfg->pid;
-                if (OBD2_request_PID(pid, &value, OBD2_PID_DEFAULT_TIMEOUT_MS)) {
-                    OBD2_set_current_PID_value(i, value);
-                    if (TRACE_LEVEL) {
-                        pr_trace("read OBD2 PID ");
-                        pr_trace_int(pid);
-                        pr_trace("=")
-                        pr_trace_int(value);
-                        pr_trace("\r\n");
+
+                if (currtimeOuts & mapSampleRates(pidCfg->cfg.sampleRate))
+                {
+                    int value;
+                    unsigned char pid = pidCfg->pid;
+                    if (OBD2_request_PID(pid, &value, OBD2_PID_DEFAULT_TIMEOUT_MS)) {
+                        OBD2_set_current_PID_value(i, value);
+                        if (TRACE_LEVEL) {
+                            pr_trace("read OBD2 PID ");
+                            pr_trace_int(pid);
+                            pr_trace("=")
+                            pr_trace_int(value);
+                            pr_trace("\r\n");
+                        }
+                    } else {
+                        pr_warning_int_msg("OBD2: PID read fail: ", pid);
                     }
-                } else {
-                    pr_warning_int_msg("OBD2: PID read fail: ", pid);
                 }
                 delayTicks(max_obd2_samplerate);
             }

--- a/src/OBD2/OBD2_task.c
+++ b/src/OBD2/OBD2_task.c
@@ -55,9 +55,9 @@ OBD2TimeOuts mapSampleRates(short sampleRate)
     } else if (sampleRate > 5) {
         return Hz10_0;
     } else if (sampleRate > 1) {
-        return Hz2_5;
+        return Hz2_0;
     }
-    return Hz100_0;
+    return Hz1_0;
 }
 
 void OBD2Task(void *pvParameters)
@@ -78,11 +78,11 @@ void OBD2Task(void *pvParameters)
             currtimeOuts = (currTime > lastTime + 5000 ? Hz0_2 : 0)
                 + (currTime > lastTime + 2000 ? Hz0_5 : 0)
                 + (currTime > lastTime + 1000 ? Hz1_0 : 0)
-                + (currTime > lastTime + 500 ? Hz2_5 : 0)
+                + (currTime > lastTime + 500 ? Hz2_0 : 0)
                 + (currTime > lastTime + 100 ? Hz10_0 : 0)
                 + (currTime > lastTime + 40 ? Hz25_0 : 0)
                 + (currTime > lastTime + 20 ? Hz50_0 : 0)
-                + (currTime > lastTime + 1 ? Hz100_0 : 0);
+                + (currTime > lastTime + 10 ? Hz100_0 : 0);
             lastTime = currTime;
 
             for (size_t i = 0; i < oc->enabledPids; i++) {


### PR DESCRIPTION
Work on Issue 870: Optimize scheduling of OBDII PIDs of different sample rates
On each OBD2 loop, fetch the current milliseconds, create a bitmap of timeouts. Perform an AND on the timeout bitmask against the OBD2Config.Pid[].cfg.sampleRate