### PR TITLE
Discrete CAN mapping capabilities #172

### DIFF
--- a/include/CAN/CAN.h
+++ b/include/CAN/CAN.h
@@ -38,6 +38,8 @@ CPP_GUARD_BEGIN
 
 #define CAN_MSG_SIZE 8
 
+#define DEFAULT_CAN_TIMEOUT 		100
+
 typedef struct _CAN_msg {
     int isExtendedAddress;
     unsigned int addressValue;

--- a/include/CAN/CANMap.h
+++ b/include/CAN/CANMap.h
@@ -18,23 +18,22 @@
  * have received a copy of the GNU General Public License along with
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef OBD2_H_
-#define OBD2_H_
+
+#ifndef CANMAP_H_
+#define CANMAP_H_
 
 #include "cpp_guard.h"
+#include "loggerConfig.h"
 #include "CAN.h"
-#include "stddef.h"
+
+#include <stdint.h>
 
 CPP_GUARD_BEGIN
 
-#define OBD2_PID_DEFAULT_TIMEOUT_MS 300
-
-bool OBD2_request_PID(unsigned char pid, size_t timeout);
-bool OBD2_receive_PID(unsigned char pid, int *value, size_t timeout);
-void OBD2_set_current_PID_value(size_t index, int value);
-int OBD2_get_current_PID_value(int index);
-bool OBD2_process_PID(OBD2Config *oc, CAN_msg *msg, int *value);
+void CANMap_set_current_map_value(size_t index, int value);
+int CANMap_get_current_map_value(int index);
+bool CAN_process_map(CANMapConfig *cMapConf, CAN_msg *msg, int *value);
 
 CPP_GUARD_END
 
-#endif /* OBD2_H_ */
+#endif /* CAN_H_ */

--- a/include/CAN/CAN_Rx_task.h
+++ b/include/CAN/CAN_Rx_task.h
@@ -18,23 +18,18 @@
  * have received a copy of the GNU General Public License along with
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef OBD2_H_
-#define OBD2_H_
+
+#ifndef CAN_RX_TASK_H_
+#define CAN_RX_TASK_H_
 
 #include "cpp_guard.h"
-#include "CAN.h"
-#include "stddef.h"
 
 CPP_GUARD_BEGIN
 
-#define OBD2_PID_DEFAULT_TIMEOUT_MS 300
-
-bool OBD2_request_PID(unsigned char pid, size_t timeout);
-bool OBD2_receive_PID(unsigned char pid, int *value, size_t timeout);
-void OBD2_set_current_PID_value(size_t index, int value);
-int OBD2_get_current_PID_value(int index);
-bool OBD2_process_PID(OBD2Config *oc, CAN_msg *msg, int *value);
+void startCANRxTask(int priority);
+void CANRxTask(void *pvParameters);
 
 CPP_GUARD_END
 
-#endif /* OBD2_H_ */
+
+#endif /* CAN_RX_TASK_H_ */

--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -322,6 +322,27 @@ typedef struct _CANConfig {
 
 #define DEFAULT_CAN_BAUD_RATE 500000
 
+#define CAN_MAP_CHANNELS 100
+
+typedef struct _CANMapChannelConfig {
+    ChannelConfig cfg;
+    unsigned short canChannel; // Bus 0 or 1
+    unsigned short canIdMask;
+    unsigned short canId;
+    unsigned short byteStart;
+    unsigned short byteLength;
+    unsigned short dataMask;
+    signed short multipler;
+    signed short divisor;
+    signed short adder;
+} CANMapChannelConfig;
+
+typedef struct _CANMapConfig {
+    unsigned char enabled;
+    unsigned short enabledChannels;
+    CANMapChannelConfig maps[CAN_MAP_CHANNELS];
+} CANMapConfig;
+
 typedef struct _GPSConfig {
     ChannelConfig latitude;
     ChannelConfig longitude;
@@ -494,6 +515,9 @@ typedef struct _LoggerConfig {
 
     //CAN Configuration
     CANConfig CanConfig;
+
+    //CANMap Config
+    CANMapConfig CANMapConfigs;
 
     //OBD2 Config
     OBD2Config OBD2Configs;

--- a/main.c
+++ b/main.c
@@ -29,6 +29,7 @@
  */
 
 #include "FreeRTOS.h"
+#include "CAN_Rx_task.h"
 #include "OBD2_task.h"
 #include "capabilities.h"
 #include "connectivityTask.h"
@@ -84,6 +85,7 @@ void setupTask(void *param)
         startUSBCommTask(RCP_INPUT_PRIORITY);
 #endif
 
+        startCANRxTask(RCP_INPUT_PRIORITY);
         startOBD2Task(RCP_INPUT_PRIORITY);
         startConnectivityTask(RCP_OUTPUT_PRIORITY);
         startLoggerTaskEx(RCP_LOGGING_PRIORITY);

--- a/platform/mk2/config.mk
+++ b/platform/mk2/config.mk
@@ -78,6 +78,8 @@ $(HAL_SRC)/watchdog_stm32/watchdog_device_stm32.c \
 $(HAL_SRC)/wifi_esp8266/wifi_esp8266_device.c \
 $(RCP_SRC)/ADC/ADC.c \
 $(RCP_SRC)/CAN/CAN.c \
+$(RCP_SRC)/CAN/CANMap.c \
+$(RCP_SRC)/CAN/CAN_Rx_task.c \
 $(RCP_SRC)/GPIO/GPIO.c \
 $(RCP_SRC)/GPIO/gpioTasks.c \
 $(RCP_SRC)/LED/led.c \

--- a/src/CAN/CAN.c
+++ b/src/CAN/CAN.c
@@ -29,7 +29,7 @@ int CAN_init(LoggerConfig *loggerConfig)
 {
     CANConfig *canConfig = &loggerConfig->CanConfig;
 
-    for (size_t i = 0; i < CAN_MAP_CHANNELS; i++)
+    for (size_t i = 0; i < CAN_CHANNELS; i++)
         if (!CAN_init_port(i, canConfig->baud[i]))
             return 0;
 

--- a/src/CAN/CAN.c
+++ b/src/CAN/CAN.c
@@ -29,7 +29,7 @@ int CAN_init(LoggerConfig *loggerConfig)
 {
     CANConfig *canConfig = &loggerConfig->CanConfig;
 
-    for (size_t i = 0; i < CAN_CHANNELS; i++)
+    for (size_t i = 0; i < CAN_MAP_CHANNELS; i++)
         if (!CAN_init_port(i, canConfig->baud[i]))
             return 0;
 

--- a/src/CAN/CANMap.c
+++ b/src/CAN/CANMap.c
@@ -1,0 +1,102 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "CAN.h"
+#include "FreeRTOS.h"
+#include "CANMap.h"
+#include "loggerConfig.h"
+#include "printk.h"
+#include "task.h"
+#include "taskUtil.h"
+
+static int CANMap_current_values[CAN_MAP_CHANNELS];
+
+void CANMap_set_current_map_value(size_t index, int value)
+{
+    if (index < CAN_MAP_CHANNELS) {
+        CANMap_current_values[index] = value;
+    }
+}
+
+int CANMap_get_current_map_value(int index)
+{
+    if (index < CAN_MAP_CHANNELS) {
+        return CANMap_current_values[index];
+    }
+    else {
+        return 0;
+    }
+}
+
+bool CAN_process_map(CANMapConfig *cMapConf, CAN_msg *msg, int *value)
+{
+    bool result = false;
+    *value = 0; // Reset this to 0
+
+    for (size_t i = 0; i < cMapConf->enabledChannels; i++) {
+        CANMapChannelConfig *chanCfg = &cMapConf->maps[i];
+
+        if ((msg->addressValue & chanCfg->canIdMask) == chanCfg->canId) {
+            // We only have enough space for an int (4 bytes)
+            if ((chanCfg->byteStart + chanCfg->byteLength) > 4)
+            {
+                return false;
+            }
+
+            for (size_t i = 0; i < chanCfg->byteLength; i++) {
+                *value = (msg->data[chanCfg->byteStart + i] << (8 * i));
+            }
+
+            if (chanCfg->dataMask) {
+                *value = *value & (int)chanCfg->dataMask;
+            }
+
+            if (chanCfg->multipler) {
+                *value = *value * (int)chanCfg->multipler;
+            }
+
+            if (chanCfg->divisor) {
+                *value = *value / (int)chanCfg->divisor;
+            }
+
+            if (chanCfg->adder) {
+                *value = *value + (int)chanCfg->adder;
+            }
+
+            CANMap_set_current_map_value(i, *value);
+
+            if (TRACE_LEVEL) {
+                pr_trace("read CAN ");
+                pr_trace_int(i);
+                pr_trace(":");
+                pr_trace(chanCfg->cfg.label);
+                pr_trace("=")
+                pr_trace_int(*value);
+                pr_trace("\r\n");
+            }
+
+            result = true;
+        }
+    }       
+
+    return result;
+}

--- a/src/OBD2/OBD2.c
+++ b/src/OBD2/OBD2.c
@@ -72,304 +72,304 @@ static float kPa_to_psig(float kPa)
  */
 static int decode_pid(unsigned char pid, CAN_msg *msg, int *value)
 {
-    int result = 0;
-
-    if (msg->addressValue == STANDARD_PID_RESPONSE &&
-        msg->data[0] >= 3 &&
-        msg->data[1] == CUSTOM_MODE_SHOW_CURRENT_DATA &&
-        msg->data[2] == pid ) {
-
-        result = 1;
-
-        int A = msg->data[3];
-        int B = msg->data[4];
-        int C = msg->data[5];
-        int D = msg->data[6];
-
-        switch(pid) {
-            /* Calculated engine load */
-            case 0x04:
-                *value = A * 100 / 255;
-                break;
-            /* Engine coolant temperature (C) */
-            case 0x05:
-                *value = celcius_to_farenheight(A - 40);
-                break;
-            /* Short term fuel % trim - Bank 1 */
-            /* Short term fuel % trim - Bank 1 */
-            /* Short term fuel % trim - Bank 2 */
-            /* Short term fuel % trim - Bank 2 */
-            case 0x06:
-            case 0x07:
-            case 0x08:
-            case 0x09:
-                *value = (A - 128) * 100 / 128;
-                break;
-            /* Fuel pressure (KPa (gauge)) */
-            case 0x0A:
-                *value  = A * 3;
-                break;
-            /* Intake manifold pressure (KPa absolute) */
-            case 0x0B:
-                *value = A;
-                break;
-            /* RPM */
-            case 0x0C:
-                *value = ((A * 256) + B) / 4;
-                break;
-            /* Vehicle speed (km/ h) */
-            case 0x0D:
-                *value = kph_to_mph(A);
-                break;
-            /* Timing advance (degrees) */
-            case 0x0E:
-                *value = (A - 128) / 2;
-                break;
-            /* Intake air temperature (C) */
-            case 0x0F:
-                *value = celcius_to_farenheight(A - 40);
-                break;
-            /* MAF airflow rate (grams / sec) */
-            case 0x10:
-                *value = ((A * 256) + B) / 100;
-                break;
-            /* Throttle position % */
-            case 0x11:
-                *value = A * 100 / 255;
-                break;
-            /* 
-             * Oxygen sensor voltage - Bank 1, Sensor 1
-             * Oxygen sensor voltage - Bank 1, Sensor 2
-             * Oxygen sensor voltage - Bank 1, Sensor 3
-             * Oxygen sensor voltage - Bank 1, Sensor 4
-             * Oxygen sensor voltage - Bank 2, Sensor 1
-             * Oxygen sensor voltage - Bank 2, Sensor 2
-             * Oxygen sensor voltage - Bank 2, Sensor 3
-             * Oxygen sensor voltage - Bank 2, Sensor 4
-             */
-            case 0x14:
-            case 0x15:
-            case 0x16:
-            case 0x17:
-            case 0x18:
-            case 0x19:
-            case 0x1A:
-            case 0x1B:
-                *value = A / 200;
-                break;
-            /* Run time since engine start */
-            case 0x1F:
-                *value = (A * 256) + B;
-                break;
-            /* Fuel rail Pressure (relative to manifold vacuum) psi */
-            case 0x22:
-                *value = kPa_to_psig(((A * 256) + B) * 0.079);
-                break;
-            /* Fuel rail Pressure (diesel, or gasoline direct inject) psi */
-            case 0x23:
-                *value = kPa_to_psig(((A * 256) + B) * 10);
-                break;
-            /* Commanded evaporative purge % */
-            case 0x2E:
-                *value = A * 100 / 255;
-                break;
-            /* Fuel level input % */
-            case 0x2F:
-                *value = A * 100 / 255;
-                break;
-            /* Number of warm-ups since codes cleared */
-            case 0x30:
-                *value = A;
-                break;
-            /* Distance traveled since codes cleared - Validate km to miles */
-            case 0x31:
-                *value = kph_to_mph((A * 256) + B);
-                break;
-            /* Evap. System Vapor Pressure */
-            case 0x32:
-                *value = ((A * 256) + B) / 4;
-                break;
-            /* Barometric pressure psi */
-            case 0x33:
-                *value = kPa_to_psig(A);
-                break;
-            /* 
-             * O2S1_WR_lambda Current
-             * O2S2_WR_lambda Current
-             * O2S3_WR_lambda Current
-             * O2S4_WR_lambda Current
-             * O2S5_WR_lambda Current
-             * O2S6_WR_lambda Current
-             * O2S7_WR_lambda Current
-             * O2S8_WR_lambda Current
-             */
-            case 0x34:
-            case 0x35:
-            case 0x36:
-            case 0x37:
-            case 0x38:
-            case 0x39:
-            case 0x3A:
-            case 0x3B:
-                *value = ((C * 256) + D) / 256 - 128;
-                break;
-            /* 
-             * Catalyst Temperature Bank 1, Sensor 1
-             * Catalyst Temperature Bank 1, Sensor 2
-             * Catalyst Temperature Bank 2, Sensor 1
-             * Catalyst Temperature Bank 2, Sensor 1
-             */
-            case 0x3C:
-            case 0x3D:
-            case 0x3E:
-            case 0x3F:
-                *value = celcius_to_farenheight((( A * 256) + B) / 10 - 40);
-                break;
-            /* Control module voltage V */
-            case 0x42:
-                *value = ((A * 256) + B) / 1000;
-                break;
-             /* Absolute load value percent */
-            case 0x43:
-                *value = ((A * 256) + B) * 100 / 255;
-                break;
-            /* Fuel/Air commanded equivalence ratio */
-            case 0x44:
-                *value = ((A * 256) + B) / 32768;
-                break;
-            /* Relative throttle position percent */
-            case 0x45:
-                *value = A * 100 / 255;
-                break;
-            /* Ambient air temperature */
-            case 0x46:
-                *value = celcius_to_farenheight(A - 40);
-                break;
-            /* 
-             * Absolute throttle position B percent
-             * Absolute throttle position C percent
-             * Absolute throttle position D percent
-             * Absolute throttle position E percent
-             * Absolute throttle position F percent
-             */
-            case 0x47:
-            case 0x48:
-            case 0x49:
-            case 0x4A:
-            case 0x4B:
-                *value = A * 100 / 255;
-                break;
-            /* 
-             * Time run with MIL on minutes
-             * Time since trouble codes cleared minutes 
-             */
-            case 0x4D:
-            case 0x4E:
-                *value = (A * 256) + B;
-                break;
-            /* 
-             * Fuel Types
-             * 00	Not available
-             * 01	Gasoline
-             * 02	Methanol
-             * 03	Ethanol
-             * 04	Diesel
-             * 05	LPG
-             * 06	CNG
-             * 07	Propane
-             * 08	Electric
-             * 09	Bifuel running Gasoline
-             * 0A	Bifuel running Methanol
-             * 0B	Bifuel running Ethanol
-             * 0C	Bifuel running LPG
-             * 0D	Bifuel running CNG
-             * 0E	Bifuel running Propane
-             */
-            case 0x51:
-                *value = A;
-                break;
-            /* Ethanol fuel percent */
-            case 0x52:
-                *value = A * 100 / 255;
-                break;
-            /* Absolute Evap system Vapor Pressure psi */
-            case 0x53:
-                *value = kPa_to_psig(((A * 256) + B) / 200);
-                break;
-             /* Evap system vapor pressure Pa */
-            case 0x54:
-                *value = ((A * 256) + B) - 32767;
-                break;
-            /* Fuel rail pressure (absolute) psi */
-            case 0x59:
-                *value = kPa_to_psig(((A * 256) + B) * 10);
-                break;
-            /* Relative accelerator pedal position percent */
-            case 0x5A:
-                *value = A * 100 / 255;
-                break;
-            /* Hybrid battery pack remaining life percent */
-            case 0x5B:
-                *value = A * 100 / 255;
-                break;
-            /* Engine oil temp (F) */
-            case 0x5C:
-                *value = celcius_to_farenheight(A - 40);
-                break;
-            /* Fuel injection timing degree */
-            case 0x5D:
-                *value = (((A * 256) + B) - 26880) / 128;
-                break;
-            /* Engine fuel rate l/h */
-            case 0x5E:
-                *value = ((A * 256) + B) * 0.05;
-                break;
-            /* 
-             * Driver's demand engine - percent torque percent
-             * Actual engine - percent torque percent
-             */
-            case 0x61:
-            case 0x62:
-                *value = A - 125;
-                break;
-            /* Engine reference torque - foot lbs */
-            case 0x63:
-                *value = ((A * 256) + B)*0.737562149277;
-                break;
-            /* Engine coolant temperature */
-            case 0x67:
-                *value = celcius_to_farenheight(A - 40);
-                break;
-            /* Intake air temperature sensor */
-            case 0x68:
-                *value = celcius_to_farenheight(A - 40);
-                break;
-            /* Exhaust gas recirculation temperature */
-            case 0x6B:
-                *value = celcius_to_farenheight(A - 40);
-                break;
-            /* Turbocharger compressor inlet pressure psi */
-            case 0x6F:
-                *value = kPa_to_psig(A);
-                break;
-            /* Boost pressure control in psi */
-            case 0x70:
-                *value = kPa_to_psig(A);
-                break;
-            /* Boost pressure control in psi */
-            case 0x74:
-                *value = kPa_to_psig(A);
-                break;
-            default:
-                result = 0;
-                break;
-        }
+    if (msg->data[2] == pid)
+    {
+        return 0;
     }
+
+    int result = 1;
+
+    int A = msg->data[3];
+    int B = msg->data[4];
+    int C = msg->data[5];
+    int D = msg->data[6];
+
+    switch(pid) {
+        /* Calculated engine load */
+        case 0x04:
+            *value = A * 100 / 255;
+            break;
+        /* Engine coolant temperature (C) */
+        case 0x05:
+            *value = celcius_to_farenheight(A - 40);
+            break;
+        /* Short term fuel % trim - Bank 1 */
+        /* Short term fuel % trim - Bank 1 */
+        /* Short term fuel % trim - Bank 2 */
+        /* Short term fuel % trim - Bank 2 */
+        case 0x06:
+        case 0x07:
+        case 0x08:
+        case 0x09:
+            *value = (A - 128) * 100 / 128;
+            break;
+        /* Fuel pressure (KPa (gauge)) */
+        case 0x0A:
+            *value  = A * 3;
+            break;
+        /* Intake manifold pressure (KPa absolute) */
+        case 0x0B:
+            *value = A;
+            break;
+        /* RPM */
+        case 0x0C:
+            *value = ((A * 256) + B) / 4;
+            break;
+        /* Vehicle speed (km/ h) */
+        case 0x0D:
+            *value = kph_to_mph(A);
+            break;
+        /* Timing advance (degrees) */
+        case 0x0E:
+            *value = (A - 128) / 2;
+            break;
+        /* Intake air temperature (C) */
+        case 0x0F:
+            *value = celcius_to_farenheight(A - 40);
+            break;
+        /* MAF airflow rate (grams / sec) */
+        case 0x10:
+            *value = ((A * 256) + B) / 100;
+            break;
+        /* Throttle position % */
+        case 0x11:
+            *value = A * 100 / 255;
+            break;
+        /* 
+        * Oxygen sensor voltage - Bank 1, Sensor 1
+        * Oxygen sensor voltage - Bank 1, Sensor 2
+        * Oxygen sensor voltage - Bank 1, Sensor 3
+        * Oxygen sensor voltage - Bank 1, Sensor 4
+        * Oxygen sensor voltage - Bank 2, Sensor 1
+        * Oxygen sensor voltage - Bank 2, Sensor 2
+        * Oxygen sensor voltage - Bank 2, Sensor 3
+        * Oxygen sensor voltage - Bank 2, Sensor 4
+        */
+        case 0x14:
+        case 0x15:
+        case 0x16:
+        case 0x17:
+        case 0x18:
+        case 0x19:
+        case 0x1A:
+        case 0x1B:
+            *value = A / 200;
+            break;
+        /* Run time since engine start */
+        case 0x1F:
+            *value = (A * 256) + B;
+            break;
+        /* Fuel rail Pressure (relative to manifold vacuum) psi */
+        case 0x22:
+            *value = kPa_to_psig(((A * 256) + B) * 0.079);
+            break;
+        /* Fuel rail Pressure (diesel, or gasoline direct inject) psi */
+        case 0x23:
+            *value = kPa_to_psig(((A * 256) + B) * 10);
+            break;
+        /* Commanded evaporative purge % */
+        case 0x2E:
+            *value = A * 100 / 255;
+            break;
+        /* Fuel level input % */
+        case 0x2F:
+            *value = A * 100 / 255;
+            break;
+        /* Number of warm-ups since codes cleared */
+        case 0x30:
+            *value = A;
+            break;
+        /* Distance traveled since codes cleared - Validate km to miles */
+        case 0x31:
+            *value = kph_to_mph((A * 256) + B);
+            break;
+        /* Evap. System Vapor Pressure */
+        case 0x32:
+            *value = ((A * 256) + B) / 4;
+            break;
+        /* Barometric pressure psi */
+        case 0x33:
+            *value = kPa_to_psig(A);
+            break;
+        /* 
+        * O2S1_WR_lambda Current
+        * O2S2_WR_lambda Current
+        * O2S3_WR_lambda Current
+        * O2S4_WR_lambda Current
+        * O2S5_WR_lambda Current
+        * O2S6_WR_lambda Current
+        * O2S7_WR_lambda Current
+        * O2S8_WR_lambda Current
+        */
+        case 0x34:
+        case 0x35:
+        case 0x36:
+        case 0x37:
+        case 0x38:
+        case 0x39:
+        case 0x3A:
+        case 0x3B:
+            *value = ((C * 256) + D) / 256 - 128;
+            break;
+        /* 
+        * Catalyst Temperature Bank 1, Sensor 1
+        * Catalyst Temperature Bank 1, Sensor 2
+        * Catalyst Temperature Bank 2, Sensor 1
+        * Catalyst Temperature Bank 2, Sensor 1
+        */
+        case 0x3C:
+        case 0x3D:
+        case 0x3E:
+        case 0x3F:
+            *value = celcius_to_farenheight((( A * 256) + B) / 10 - 40);
+            break;
+        /* Control module voltage V */
+        case 0x42:
+            *value = ((A * 256) + B) / 1000;
+            break;
+        /* Absolute load value percent */
+        case 0x43:
+            *value = ((A * 256) + B) * 100 / 255;
+            break;
+        /* Fuel/Air commanded equivalence ratio */
+        case 0x44:
+            *value = ((A * 256) + B) / 32768;
+            break;
+        /* Relative throttle position percent */
+        case 0x45:
+            *value = A * 100 / 255;
+            break;
+        /* Ambient air temperature */
+        case 0x46:
+            *value = celcius_to_farenheight(A - 40);
+            break;
+        /* 
+        * Absolute throttle position B percent
+        * Absolute throttle position C percent
+        * Absolute throttle position D percent
+        * Absolute throttle position E percent
+        * Absolute throttle position F percent
+        */
+        case 0x47:
+        case 0x48:
+        case 0x49:
+        case 0x4A:
+        case 0x4B:
+            *value = A * 100 / 255;
+            break;
+        /* 
+        * Time run with MIL on minutes
+        * Time since trouble codes cleared minutes 
+        */
+        case 0x4D:
+        case 0x4E:
+            *value = (A * 256) + B;
+            break;
+        /* 
+        * Fuel Types
+        * 00	Not available
+        * 01	Gasoline
+        * 02	Methanol
+        * 03	Ethanol
+        * 04	Diesel
+        * 05	LPG
+        * 06	CNG
+        * 07	Propane
+        * 08	Electric
+        * 09	Bifuel running Gasoline
+        * 0A	Bifuel running Methanol
+        * 0B	Bifuel running Ethanol
+        * 0C	Bifuel running LPG
+        * 0D	Bifuel running CNG
+        * 0E	Bifuel running Propane
+        */
+        case 0x51:
+            *value = A;
+            break;
+        /* Ethanol fuel percent */
+        case 0x52:
+            *value = A * 100 / 255;
+            break;
+        /* Absolute Evap system Vapor Pressure psi */
+        case 0x53:
+            *value = kPa_to_psig(((A * 256) + B) / 200);
+            break;
+        /* Evap system vapor pressure Pa */
+        case 0x54:
+            *value = ((A * 256) + B) - 32767;
+            break;
+        /* Fuel rail pressure (absolute) psi */
+        case 0x59:
+            *value = kPa_to_psig(((A * 256) + B) * 10);
+            break;
+        /* Relative accelerator pedal position percent */
+        case 0x5A:
+            *value = A * 100 / 255;
+            break;
+        /* Hybrid battery pack remaining life percent */
+        case 0x5B:
+            *value = A * 100 / 255;
+            break;
+        /* Engine oil temp (F) */
+        case 0x5C:
+            *value = celcius_to_farenheight(A - 40);
+            break;
+        /* Fuel injection timing degree */
+        case 0x5D:
+            *value = (((A * 256) + B) - 26880) / 128;
+            break;
+        /* Engine fuel rate l/h */
+        case 0x5E:
+            *value = ((A * 256) + B) * 0.05;
+            break;
+        /* 
+        * Driver's demand engine - percent torque percent
+        * Actual engine - percent torque percent
+        */
+        case 0x61:
+        case 0x62:
+            *value = A - 125;
+            break;
+        /* Engine reference torque - foot lbs */
+        case 0x63:
+            *value = ((A * 256) + B)*0.737562149277;
+            break;
+        /* Engine coolant temperature */
+        case 0x67:
+            *value = celcius_to_farenheight(A - 40);
+            break;
+        /* Intake air temperature sensor */
+        case 0x68:
+            *value = celcius_to_farenheight(A - 40);
+            break;
+        /* Exhaust gas recirculation temperature */
+        case 0x6B:
+            *value = celcius_to_farenheight(A - 40);
+            break;
+        /* Turbocharger compressor inlet pressure psi */
+        case 0x6F:
+            *value = kPa_to_psig(A);
+            break;
+        /* Boost pressure control in psi */
+        case 0x70:
+            *value = kPa_to_psig(A);
+            break;
+        /* Boost pressure control in psi */
+        case 0x74:
+            *value = kPa_to_psig(A);
+            break;
+        default:
+            result = 0;
+            break;
+    }
+
     return result;
 }
 
-int OBD2_request_PID(unsigned char pid, int *value, size_t timeout)
+bool OBD2_request_PID(unsigned char pid, size_t timeout)
 {
+    bool pid_request_success = false;
+
     CAN_msg msg;
     msg.addressValue = 0x7df;
     msg.data[0] = 2;
@@ -382,26 +382,66 @@ int OBD2_request_PID(unsigned char pid, int *value, size_t timeout)
     msg.data[7] = 0x55;
     msg.dataLength = 8;
     msg.isExtendedAddress = 0;
-    int pid_request_success = 0;
+    
     if (CAN_tx_msg(0, &msg, timeout)) {
-        size_t start_time = xTaskGetTickCount();
-        while (!isTimeoutMs(start_time, OBD2_PID_DEFAULT_TIMEOUT_MS)) {
-            int result = CAN_rx_msg(0, &msg, OBD2_PID_DEFAULT_TIMEOUT_MS);
-            if (result) {
-                result = decode_pid(pid, &msg, value);
+        // Fire and forget
+        pid_request_success = true;
+    }
+
+    return pid_request_success;
+}
+
+bool OBD2_receive_PID(unsigned char pid, int *value, size_t timeout)
+{
+    bool pid_request_success = false;
+
+    CAN_msg msg;
+
+    size_t start_time = xTaskGetTickCount();
+    while (!isTimeoutMs(start_time, OBD2_PID_DEFAULT_TIMEOUT_MS)) {
+        int result = CAN_rx_msg(0, &msg, OBD2_PID_DEFAULT_TIMEOUT_MS);
+        if (result) {
+            decode_pid(pid, &msg, value);
+
+            pid_request_success = true;
+        }
+    }
+
+    return pid_request_success;
+}
+
+bool OBD2_process_PID(OBD2Config *oc, CAN_msg *msg, int *value)
+{
+    unsigned char pid;
+    bool result = false;
+
+    if (msg->addressValue == STANDARD_PID_RESPONSE &&
+                    msg->data[0] >= 3 &&
+                    msg->data[1] == CUSTOM_MODE_SHOW_CURRENT_DATA)
+    {
+        if (oc->enabled && oc->enabledPids > 0) {
+            for (size_t i = 0; i < oc->enabledPids; i++) {
+                PidConfig *pidCfg = &oc->pids[i];
+                pid = pidCfg->pid;
+
+                result = decode_pid(pid, msg, value);
+
                 if (result) {
-                    pid_request_success = 1;
+                    OBD2_set_current_PID_value(i, *value);
+
                     if (DEBUG_LEVEL) {
-                        pr_debug("read OBD2 PID ");
+                        pr_debug("read OBD2 PID: ");
                         pr_debug_int(pid);
                         pr_debug("=")
                         pr_debug_int(*value);
                         pr_debug("\r\n");
                     }
-                    break;
+
+                    break; // We break once we've found a matching PID
                 }
             }
         }
     }
-    return pid_request_success;
+
+    return result;
 }

--- a/src/logger/loggerSampleData.c
+++ b/src/logger/loggerSampleData.c
@@ -22,6 +22,7 @@
 #include "ADC.h"
 #include "FreeRTOS.h"
 #include "GPIO.h"
+#include "CANMap.h"
 #include "OBD2.h"
 #include "PWM.h"
 #include "channel_config.h"
@@ -298,9 +299,17 @@ void init_channel_sample_buffer(LoggerConfig *loggerConfig, struct sample *buff)
     }
 #endif
 
+    CANMapConfig *canMapConfig = &(loggerConfig->CANMapConfigs);
+    const unsigned char canMapEnabled = loggerConfig->CANMapConfigs.enabled;
+    for (size_t i = 0; i < canMapConfig->enabledChannels && canMapEnabled; i++) {
+        chanCfg = &(canMapConfig->maps[i].cfg);
+        sample = processChannelSampleWithIntGetter(sample, chanCfg, i,
+                                                   CANMap_get_current_map_value);
+    }
+
     OBD2Config *obd2Config = &(loggerConfig->OBD2Configs);
-    const unsigned char enabled = loggerConfig->OBD2Configs.enabled;
-    for (size_t i = 0; i < obd2Config->enabledPids && enabled; i++) {
+    const unsigned char obd2Enabled = loggerConfig->OBD2Configs.enabled;
+    for (size_t i = 0; i < obd2Config->enabledPids && obd2Enabled; i++) {
         chanCfg = &(obd2Config->pids[i].cfg);
         sample = processChannelSampleWithIntGetter(sample, chanCfg, i,
                                                    OBD2_get_current_PID_value);

--- a/src/lua/luaLoggerBinding.c
+++ b/src/lua/luaLoggerBinding.c
@@ -52,7 +52,6 @@
 #include "virtual_channel.h"
 
 #define TEMP_BUFFER_LEN 		256
-#define DEFAULT_CAN_TIMEOUT 		100
 #define DEFAULT_SERIAL_TIMEOUT		100
 #define LUA_DEFAULT_SERIAL_PORT 	SERIAL_AUX
 #define LUA_DEFAULT_SERIAL_BAUD 	115200
@@ -754,8 +753,17 @@ static int lua_obd2_read(lua_State *L)
         }
 
         int value;
-        if (!OBD2_request_PID(pid, &value, timeout))
+        if (!OBD2_request_PID(pid, timeout))
+        {
+                if (!OBD2_receive_PID(pid, &value, timeout))
+                {
+                        return 0;
+                }
+        }
+        else
+        {
                 return 0;
+        }
 
         lua_pushnumber(L, value);
         return 1;

--- a/test/CANMapTest.cpp
+++ b/test/CANMapTest.cpp
@@ -1,0 +1,99 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "CANMapTest.hh"
+#include "CAN.h"
+#include "CANMap.h"
+#include "mock_serial.h"
+
+// /* Inclue the code to test here */
+// extern "C" {
+// #include "CAN/CANMap.c"
+// }
+
+using std::string;
+
+CPPUNIT_TEST_SUITE_REGISTRATION( CANMapTest );
+
+void CANMapTest::setAndGetValueTest()
+{
+    CANMap_set_current_map_value(1, 99);
+    CPPUNIT_ASSERT_EQUAL(CANMap_get_current_map_value(1), 99);
+}
+
+void CANMapTest::setOutOfBoundsTest()
+{
+    CANMap_set_current_map_value(101, 99);
+}
+
+void CANMapTest::getOutOfBoundsTest()
+{
+    CPPUNIT_ASSERT_EQUAL(CANMap_get_current_map_value(101), 0);
+}
+
+void CANMapTest::msgProcessTest()
+{
+    CANMapConfig cMapConf;
+        cMapConf.enabled = 1;
+        cMapConf.enabledChannels = 1;
+
+    ChannelConfig chanCfg;
+        strcpy(chanCfg.label, "Test Channel");;
+        strcpy(chanCfg.units, "T");
+        chanCfg.min = 0.0;
+        chanCfg.max = 100.0;
+        chanCfg.sampleRate = 100;
+        chanCfg.precision = 0;
+        chanCfg.flags = 0;
+
+    CANMapChannelConfig mapChanCfg;
+        mapChanCfg.cfg = chanCfg;
+        mapChanCfg.canChannel = 0;
+        mapChanCfg.canIdMask = 0xFF;
+        mapChanCfg.canId = 1;
+        mapChanCfg.byteStart = 0;
+        mapChanCfg.byteLength = 1;
+        mapChanCfg.dataMask = 0xFF;
+        mapChanCfg.multipler = 1;
+        mapChanCfg.divisor = 1;
+        mapChanCfg.adder = 0;
+
+    cMapConf.maps[0] = mapChanCfg;
+
+    CAN_msg msg;
+        msg.isExtendedAddress = 0;
+        msg.addressValue = 1;
+        msg.dataLength = 8;
+        msg.data[0] = 100;
+        msg.data[1] = 0;
+        msg.data[2] = 0;
+        msg.data[3] = 0;
+        msg.data[4] = 0;
+        msg.data[5] = 0;
+        msg.data[6] = 0;
+        msg.data[7] = 0;
+
+    int value = 0;
+
+    CPPUNIT_ASSERT_EQUAL(CAN_process_map(&cMapConf, &msg, &value), true);
+    CPPUNIT_ASSERT_EQUAL(value, 100);
+    CPPUNIT_ASSERT_EQUAL(CANMap_get_current_map_value(0), 100);
+}

--- a/test/CANMapTest.hh
+++ b/test/CANMapTest.hh
@@ -18,23 +18,26 @@
  * have received a copy of the GNU General Public License along with
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef OBD2_H_
-#define OBD2_H_
 
-#include "cpp_guard.h"
-#include "CAN.h"
-#include "stddef.h"
+#ifndef _CANMAPTEST_H_
+#define _CANMAPTEST_H_
 
-CPP_GUARD_BEGIN
+#include <cppunit/extensions/HelperMacros.h>
 
-#define OBD2_PID_DEFAULT_TIMEOUT_MS 300
+class CANMapTest : public CppUnit::TestFixture
+{
+	CPPUNIT_TEST_SUITE( CANMapTest );
+	CPPUNIT_TEST( setAndGetValueTest );
+	CPPUNIT_TEST( setOutOfBoundsTest );
+	CPPUNIT_TEST( getOutOfBoundsTest );
+	CPPUNIT_TEST( msgProcessTest );
+	CPPUNIT_TEST_SUITE_END();
 
-bool OBD2_request_PID(unsigned char pid, size_t timeout);
-bool OBD2_receive_PID(unsigned char pid, int *value, size_t timeout);
-void OBD2_set_current_PID_value(size_t index, int value);
-int OBD2_get_current_PID_value(int index);
-bool OBD2_process_PID(OBD2Config *oc, CAN_msg *msg, int *value);
+public:
+	void setAndGetValueTest();
+	void setOutOfBoundsTest();
+	void getOutOfBoundsTest();
+	void msgProcessTest();
+};
 
-CPP_GUARD_END
-
-#endif /* OBD2_H_ */
+#endif /* _CANMAPTEST_H_ */

--- a/test/CANMockTest.cpp
+++ b/test/CANMockTest.cpp
@@ -1,0 +1,93 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "CANMockTest.hh"
+#include "CAN.h"
+#include "loggerConfig.h"
+#include "macros.h"
+#include <cppunit/extensions/HelperMacros.h>
+
+// extern "C" {
+// #include "logger_mock/CAN_device_mock.c"
+// }
+
+CPPUNIT_TEST_SUITE_REGISTRATION( CANMockTest );
+
+using std::string;
+
+void CANMockTest::rxMsgEmptyQueueTest()
+{
+	CAN_init_port(0, DEFAULT_CAN_BAUD_RATE);
+
+	CAN_msg rxMsg;
+
+	CPPUNIT_ASSERT_EQUAL(CAN_rx_msg(0, &rxMsg, 0), 0);
+}
+
+void CANMockTest::txMsgRxMsgSequentialMsgQueueTest()
+{
+	CAN_init_port(0, DEFAULT_CAN_BAUD_RATE);
+
+	CAN_msg txMsg;
+    txMsg.addressValue = 0x7df;
+    txMsg.data[0] = 2;
+    txMsg.data[1] = 1;
+    txMsg.data[2] = 1; //pid
+    txMsg.data[3] = 0x55;
+    txMsg.data[4] = 0x55;
+    txMsg.data[5] = 0x55;
+    txMsg.data[6] = 0x55;
+    txMsg.data[7] = 0x55;
+    txMsg.dataLength = 8;
+    txMsg.isExtendedAddress = 0;
+
+	CAN_msg rxMsg;
+
+	CPPUNIT_ASSERT(CAN_tx_msg(0, &txMsg, 0) == 1);
+	CPPUNIT_ASSERT(CAN_rx_msg(0, &rxMsg, 0) == 1);
+
+	CPPUNIT_ASSERT(rxMsg.addressValue == txMsg.addressValue);
+}
+
+void CANMockTest::txMsgQueueOverflowTest()
+{
+	CAN_init_port(0, DEFAULT_CAN_BAUD_RATE);
+
+	CAN_msg txMsg;
+    txMsg.addressValue = 0x7df;
+    txMsg.data[0] = 2;
+    txMsg.data[1] = 1;
+    txMsg.data[2] = 1; //pid
+    txMsg.data[3] = 0x55;
+    txMsg.data[4] = 0x55;
+    txMsg.data[5] = 0x55;
+    txMsg.data[6] = 0x55;
+    txMsg.data[7] = 0x55;
+    txMsg.dataLength = 8;
+    txMsg.isExtendedAddress = 0;
+
+	for (int i = 0; i < 10; i++)
+	{
+		CPPUNIT_ASSERT_EQUAL(CAN_tx_msg(0, &txMsg, 0), 1);
+	}
+
+	CPPUNIT_ASSERT_EQUAL(CAN_tx_msg(0, &txMsg, 0), 0);
+}

--- a/test/CANMockTest.hh
+++ b/test/CANMockTest.hh
@@ -18,23 +18,24 @@
  * have received a copy of the GNU General Public License along with
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef OBD2_H_
-#define OBD2_H_
 
-#include "cpp_guard.h"
-#include "CAN.h"
-#include "stddef.h"
+#ifndef _CANMOCKTEST_H_
+#define _CANMOCKTEST_H_
 
-CPP_GUARD_BEGIN
+#include <cppunit/extensions/HelperMacros.h>
 
-#define OBD2_PID_DEFAULT_TIMEOUT_MS 300
+class CANMockTest : public CppUnit::TestFixture
+{
+	CPPUNIT_TEST_SUITE( CANMockTest );
+	CPPUNIT_TEST( rxMsgEmptyQueueTest );
+	CPPUNIT_TEST( txMsgRxMsgSequentialMsgQueueTest );
+	CPPUNIT_TEST( txMsgQueueOverflowTest );
+	CPPUNIT_TEST_SUITE_END();
 
-bool OBD2_request_PID(unsigned char pid, size_t timeout);
-bool OBD2_receive_PID(unsigned char pid, int *value, size_t timeout);
-void OBD2_set_current_PID_value(size_t index, int value);
-int OBD2_get_current_PID_value(int index);
-bool OBD2_process_PID(OBD2Config *oc, CAN_msg *msg, int *value);
+public:
+	void rxMsgEmptyQueueTest();
+	void txMsgRxMsgSequentialMsgQueueTest();
+	void txMsgQueueOverflowTest();
+};
 
-CPP_GUARD_END
-
-#endif /* OBD2_H_ */
+#endif /* _CANMOCKTEST_H_ */

--- a/test/Makefile
+++ b/test/Makefile
@@ -36,6 +36,7 @@ BUILD_DIR=build
 INCLUDES = \
 -I. \
 -I./include \
+-I/usr/local/lib/ \
 -I$(RCP_BASE) \
 -I$(RCP_BASE)/logger \
 -I$(MK2_SRC)/hal/fat_sd_stm32/fatfs \
@@ -137,6 +138,8 @@ $(LAP_STATS_DIR)/LapStatsTest.cpp \
 $(UTIL_DIR)/numtoa_test.cpp \
 AutoLoggerTest.cpp \
 AtTest.cpp \
+CANMockTest.cpp \
+CANMapTest.cpp \
 CellularApiStatusKeysTest.cpp \
 ChannelConfigTest.cpp \
 JsmnTest.cpp \
@@ -180,6 +183,7 @@ $(MOCK_DIR)/timer_device_mock.c \
 $(MOCK_DIR)/watchdog_device_mock.c \
 $(RCP_SRC)/ADC/ADC.c \
 $(RCP_SRC)/CAN/CAN.c \
+$(RCP_SRC)/CAN/CANMap.c \
 $(RCP_SRC)/GPIO/GPIO.c \
 $(RCP_SRC)/LED/led.c \
 $(RCP_SRC)/OBD2/OBD2.c \
@@ -258,7 +262,7 @@ OBJ_SIM = $(addprefix build/, $(addsuffix .o, $(subst $(RCP_BASE)/, rcp_base/, $
 all: test sim
 
 test: $(OBJ_TEST)
-	$(CXX) $(CXXFLAGS) -o $(NAME) $(OBJ_TEST) -lm -lcppunit
+	$(CXX) $(CXXFLAGS) -o $(NAME) $(OBJ_TEST) -lm -L/usr/local/lib/ -lcppunit
 
 sim: $(OBJ_SIM)
 	$(CXX) $(CXXFLAGS) -o $(SIMNAME) $(OBJ_SIM) -lm

--- a/test/logger_mock/CAN_device_mock.c
+++ b/test/logger_mock/CAN_device_mock.c
@@ -19,23 +19,74 @@
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #include "CAN_device.h"
+#include <string.h>
 #include <stdbool.h>
+
+#define CANBUSSES 2
+#define CANQUEUESIZE 10
+
+CAN_msg msgs[CANBUSSES][CANQUEUESIZE];
+static bool queueEmpty = true;
+static int msgRxIndex = 0;
+static int queueCount = 0;
+static int msgTxIndex = 0;
 
 int CAN_device_init(uint8_t channel, uint32_t baud)
 {
+    queueEmpty = true;
+    msgRxIndex = 0;
+    msgTxIndex = 0;
+
     return 1;
 }
 
 int CAN_device_tx_msg(uint8_t channel, CAN_msg *msg, unsigned int timeoutMs)
 {
-    return 1;
+    if (channel < (CANBUSSES - 1) && queueCount < CANQUEUESIZE) {
+        if (msgTxIndex >= CANQUEUESIZE) {
+            msgTxIndex = 0;
+        }
+
+        CAN_msg *txMsg;
+        txMsg = &(msgs[channel][msgTxIndex]);
+        txMsg->isExtendedAddress = msg->isExtendedAddress;
+        txMsg->addressValue = msg->addressValue;
+        txMsg->dataLength = msg->dataLength;
+        memcpy(txMsg->data, msg->data, msg->dataLength);
+
+        ++msgTxIndex;
+        ++queueCount;
+        queueEmpty = false;
+        return 1;
+    }
+    else {
+        return 0;
+    }
 }
 
 int CAN_device_rx_msg(uint8_t channel, CAN_msg *msg, unsigned int timeoutMs)
 {
-    return 1;
+    if (channel < (CANBUSSES - 1) && queueCount > 0) {
+        if (msgRxIndex >= CANQUEUESIZE) {
+            msgRxIndex = 0;
+        }
+
+        *msg = msgs[channel][msgRxIndex];
+        ++msgRxIndex;
+        --queueCount;
+
+        if (queueCount <= 0)
+        {
+            queueCount = 0;
+        }
+
+        return 1;
+    }
+    else
+    {
+        return 0;
+    }
 }
 
 int CAN_device_set_filter(uint8_t channel, uint8_t id, uint8_t extended,


### PR DESCRIPTION
Overhaul to CAN processing.

OBD2 PID responses are now out of sync with PID requests. This free's up the system from blocking the CAN and potentially missing other CAN values.  However, we can still do a blocking OBD2 request using OBD2_request_PID for things like LUA.

The CAN_Rx_Task is now the loop for processing CAN Rx messages. It first check's the message against the OBD2 PID config's and then checks it against the new CANMapConfig.CANMapChannelConfig.  One CAN message can in theory match multiple Channel's.

Changed the CAN_device_mock to use a simple FIFO queue so we can test CAN message processing through unit tests.

Created Unit Tests for: CANMap, CAN_device_mock