### PR TITLE
raise OBDII stack to match RCP to prevent heap smash 

### DIFF
--- a/src/OBD2/OBD2_task.c
+++ b/src/OBD2/OBD2_task.c
@@ -34,7 +34,7 @@
 #include "taskUtil.h"
 #include "capabilities.h"
 
-#define OBD2_TASK_STACK 	configMINIMAL_STACK_SIZE
+#define OBD2_TASK_STACK 	128
 #define OBD2_FEATURE_DISABLED_DELAY_MS 2000
 
 void startOBD2Task(int priority)


### PR DESCRIPTION
resolved #895 