### PR TITLE
P/brent/big endian bit mapping

### DIFF
--- a/include/util/byteswap.h
+++ b/include/util/byteswap.h
@@ -61,7 +61,7 @@ uint64_t swap_uint64( uint64_t val );
 /*
  * Byte swap based on specified bit length
  */
-uint32_t swap_uint_length(uint32_t val, size_t bit_length);
+uint64_t swap_uint_length(uint64_t val, size_t bit_length);
 CPP_GUARD_END
 
 #endif /* _BYTESWAP_H_ */

--- a/include/util/byteswap.h
+++ b/include/util/byteswap.h
@@ -23,7 +23,7 @@
 #define _BYTESWAP_H_
 
 #include "cpp_guard.h"
-
+#include <stddef.h>
 #include <stdint.h>
 
 CPP_GUARD_BEGIN
@@ -53,6 +53,15 @@ int32_t swap_int32( int32_t val );
  */
 uint32_t swap_uint32( uint32_t val );
 
+/*
+* Byte swap unsigned 64 bits
+ */
+uint64_t swap_uint64( uint64_t val );
+
+/*
+ * Byte swap based on specified bit length
+ */
+uint32_t swap_uint_length(uint32_t val, size_t bit_length);
 CPP_GUARD_END
 
 #endif /* _BYTESWAP_H_ */

--- a/src/CAN/can_mapping.c
+++ b/src/CAN/can_mapping.c
@@ -35,7 +35,10 @@ float canmapping_extract_value(uint64_t raw_data, const CANMapping *mapping)
                 length *= 8;
                 offset *= 8;
         }
+        /* create the bitmask of the appropriate length */
         uint32_t bitmask = (1UL << length) - 1;
+
+        /* extract the raw value from the 64 bit representation of the CAN message */
         uint32_t raw_value = (raw_data >> (64 - offset - length)) & bitmask;
 
         /* normalize endian */

--- a/src/util/byteswap.c
+++ b/src/util/byteswap.c
@@ -58,18 +58,11 @@ uint64_t swap_uint64(uint64_t val)
              (val & 0x00FF000000000000UL) >> 40 | (val & 0xFF00000000000000UL) >> 56;
 }
 
-uint32_t swap_uint_length(uint32_t val, size_t bit_length)
+uint64_t swap_uint_length(uint64_t val, size_t bit_length)
 {
-    if (bit_length > 8) {
-            if(bit_length <= 16) {
-                    return swap_uint16(val);
-            }
-            else if (bit_length <= 24) {
-                    return swap_uint24(val);
-            }
-            else {
-                    return swap_uint32(val);
-            }
-    }
-    return val;
+    if (bit_length <= 8) return val;
+    if (bit_length <= 16) return swap_uint16(val);
+    if (bit_length <= 24) return swap_uint24(val);
+    if (bit_length <= 32) return swap_uint32(val);
+    return swap_uint64(val);
 }

--- a/src/util/byteswap.c
+++ b/src/util/byteswap.c
@@ -49,3 +49,27 @@ int32_t swap_int32( int32_t val )
     val = ((val << 8) & 0xFF00FF00) | ((val >> 8) & 0xFF00FF );
     return (val << 16) | ((val >> 16) & 0xFFFF);
 }
+
+uint64_t swap_uint64(uint64_t val)
+{
+    return (val & 0x00000000000000FFUL) << 56 | (val & 0x000000000000FF00UL) << 40 |
+             (val & 0x0000000000FF0000UL) << 24 | (val & 0x00000000FF000000UL) << 8 |
+             (val & 0x000000FF00000000UL) >> 8 | (val & 0x0000FF0000000000UL) >> 24 |
+             (val & 0x00FF000000000000UL) >> 40 | (val & 0xFF00000000000000UL) >> 56;
+}
+
+uint32_t swap_uint_length(uint32_t val, size_t bit_length)
+{
+    if (bit_length > 8) {
+            if(bit_length <= 16) {
+                    return swap_uint16(val);
+            }
+            else if (bit_length <= 24) {
+                    return swap_uint24(val);
+            }
+            else {
+                    return swap_uint32(val);
+            }
+    }
+    return val;
+}

--- a/test/can_obd2/can_mapping_test.cpp
+++ b/test/can_obd2/can_mapping_test.cpp
@@ -24,7 +24,6 @@
 #include <string.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "byteswap.h"
-#include <time.h>
 #include <stdlib.h>
 
 /*
@@ -78,18 +77,18 @@ void CANMappingTest::extract_test_bit_mode(void)
 {
         srand(time(NULL));
 
-        for (size_t random = 0; random <= 1; random++){
+        for (size_t bitpattern = 0; bitpattern <= 1; bitpattern++){
                 for (size_t endian = 0; endian <= 1; endian++){
                         for (uint8_t length = 1; length <= 32; length++ ) {
 
                                 uint64_t test_value;
-                                if (!random) {
+                                if (!bitpattern) {
                                         /* just test a bit pattern of all 1's */
                                         test_value = ((uint64_t)1 << length) - 1;
                                 }
                                 else {
-                                        /* test with a randomly generated number */
-                                        test_value = rand() & (((uint64_t)1 << length) - 1);
+                                        /* test with bit pattern of 101010... */
+                                        test_value = 0x5555555555555555 & (((uint64_t)1 << length) - 1);
                                 }
 
                                 /* shift it all the way to the left */

--- a/test/can_obd2/can_mapping_test.cpp
+++ b/test/can_obd2/can_mapping_test.cpp
@@ -106,6 +106,7 @@ void CANMappingTest::extract_test_bit_mode(void)
                                         mapping.bit_mode = true;
                                         mapping.big_endian = (bool)endian;
 
+                                        /* now shift the value by the offset */
                                         uint64_t offset_test_value = shifted_test_value >> offset;
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__

--- a/test/can_obd2/can_mapping_test.cpp
+++ b/test/can_obd2/can_mapping_test.cpp
@@ -23,6 +23,10 @@
 #include "can_mapping_test.h"
 #include <string.h>
 #include <cppunit/extensions/HelperMacros.h>
+#include "byteswap.h"
+#include <time.h>
+#include <stdlib.h>
+
 /*
  * #define CAN_MAPPING_TEST_DEBUG
  */
@@ -72,85 +76,127 @@ void CANMappingTest::formula_test(void)
 
 void CANMappingTest::extract_test_bit_mode(void)
 {
-    for (uint8_t length = 1; length <= 32; length++ ) {
-            uint64_t test_value = ((uint64_t)1 << length) - 1;
-            for (uint8_t offset = 0; offset < (CAN_MSG_SIZE * 8) - length + 1; offset++) {
-                    CAN_msg msg;
-                    CANMapping mapping;
-                    memset(&mapping, 0, sizeof(mapping));
-                    memset(&msg, 0, sizeof(CAN_msg));
-                    mapping.offset = offset;
-                    mapping.length = length;
-                    mapping.type = CANMappingType_unsigned;
-                    mapping.bit_mode = true;
-                    msg.data64 = test_value << offset;
+        srand(time(NULL));
 
-                    float value = canmapping_extract_value(msg.data64, &mapping);
+        for (size_t random = 0; random <= 1; random++){
+                for (size_t endian = 0; endian <= 1; endian++){
+                        for (uint8_t length = 1; length <= 32; length++ ) {
 
+                                uint64_t test_value;
+                                if (!random) {
+                                        /* just test a bit pattern of all 1's */
+                                        test_value = ((uint64_t)1 << length) - 1;
+                                }
+                                else {
+                                        /* test with a randomly generated number */
+                                        test_value = rand() & (((uint64_t)1 << length) - 1);
+                                }
+
+                                /* shift it all the way to the left */
+                                uint64_t shifted_test_value = test_value << (64-length);
+
+                                for (uint8_t offset = 0; offset < (CAN_MSG_SIZE * 8) - length + 1; offset++) {
+                                        CAN_msg msg;
+                                        CANMapping mapping;
+                                        memset(&mapping, 0, sizeof(mapping));
+                                        memset(&msg, 0, sizeof(CAN_msg));
+                                        mapping.offset = offset;
+                                        mapping.length = length;
+                                        mapping.type = CANMappingType_unsigned;
+                                        mapping.bit_mode = true;
+                                        mapping.big_endian = (bool)endian;
+
+                                        uint64_t offset_test_value = shifted_test_value >> offset;
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+                                        /* account for platform's endian-ness */
+                                        offset_test_value= swap_uint64(offset_test_value);
+#endif
+                                        msg.data64 = offset_test_value;
+
+                                        float value = canmapping_extract_value(msg.data64, &mapping);
+
+                                        /* prepare the comparison value */
+                                        uint64_t compare_value = test_value;
+                                        if (!mapping.big_endian) {
+                                                compare_value = swap_uint_length(test_value, length);
+                                        }
 #ifdef CAN_MAPPING_TEST_DEBUG
-                    printf("bitmode test: value / offset / length / return %lu %d %d %f\r\n" ,
-                           test_value, offset, length, value);
-                    printf("CAN data: ");
-                    for (size_t di = 0; di < CAN_MSG_SIZE; di++){
-                    		uint8_t d = msg.data[di];
-                            printf("%02x ", d);
-                    }
-                    printf("\r\n");
+                                        printf("bitmode test: endian=%u / test_value=%lu / offset=%d / length=%d / return = %f\r\n" ,
+                                               mapping.big_endian, compare_value, offset, length, value);
+                                        printf("CAN data: ");
+                                        for (size_t di = 0; di < CAN_MSG_SIZE; di++){
+                                                uint8_t d = msg.data[di];
+                                                printf("%02x ", d);
+                                        }
+                                        printf("\r\n");
 
-                    for (size_t di = 0; di < CAN_MSG_SIZE; di++){
-                    		uint8_t d = msg.data[di];
-                            static char b[9];
-							b[0] = '\0';
-							for (int z = 128; z > 0; z >>= 1)
-							{
-								strcat(b, ((d & z) == z) ? "1" : "0");
-							}
-                            printf("%s ", b);
-                    }
-                    printf("\r\n");
-
+                                        for (size_t di = 0; di < CAN_MSG_SIZE; di++){
+                                                uint8_t d = msg.data[di];
+                                                static char b[9];
+                                                b[0] = '\0';
+                                                for (int z = 128; z > 0; z >>= 1)
+                                                {
+                                                    strcat(b, ((d & z) == z) ? "1" : "0");
+                                                }
+                                                printf("%s ", b);
+                                        }
+                                        printf("\r\n");
 #endif
 
-                    CPPUNIT_ASSERT_EQUAL((float)test_value, value);
-            }
-    }
+                                        CPPUNIT_ASSERT_EQUAL((float)compare_value, value);
+                                }
+                        }
+                }
+        }
 }
+
 void CANMappingTest::extract_test(void)
 {
         /*
          * This test sweeps through every offset and data lengths of 1-4 bytes,
          * testing the ability to extract values from anywhere in the message.
          */
-        uint32_t test_value = 0;
-        for (uint8_t length = 1; length <= 4; length++ ) {
-                /* make a test pattern like 0x01020304 */
-                test_value = (test_value << 8) + length;
-                for (uint8_t offset = 0; offset < CAN_MSG_SIZE - length + 1; offset++) {
-                        CAN_msg msg;
-                        CANMapping mapping;
-                        memset(&mapping, 0, sizeof(mapping));
-                        memset(&msg, 0, sizeof(CAN_msg));
-                        mapping.offset = offset;
-                        mapping.length = length;
-                        mapping.type = CANMappingType_unsigned;
-
-                        /* populate byte values starting at offset */
-                        for (size_t l = 0; l < length; l++) {
-                                msg.data[offset + l] = (test_value >> l * 8) & 0xff;
+        for (size_t endian = 0; endian <= 1; endian++){
+                uint32_t test_value = 0;
+                for (uint8_t length = 1; length <= 4; length++ ) {
+                        /* make a test pattern like 0x01020304 */
+                        test_value = (test_value << 8) + length;
+                        uint32_t can_value = test_value;
+                        if (!endian) {
+                                can_value = swap_uint_length(can_value, length * 8);
                         }
-                        float value = canmapping_extract_value(msg.data64, &mapping);
+
+                        for (uint8_t offset = 0; offset < CAN_MSG_SIZE - length + 1; offset++) {
+                                CAN_msg msg;
+                                CANMapping mapping;
+                                memset(&mapping, 0, sizeof(mapping));
+                                memset(&msg, 0, sizeof(CAN_msg));
+                                mapping.offset = offset;
+                                mapping.length = length;
+                                mapping.type = CANMappingType_unsigned;
+                                mapping.big_endian = (bool)endian;
+
+
+                                /* populate byte values starting at offset */
+                                for (size_t l = 0; l < length; l++) {
+                                        msg.data[offset + length - l - 1] = (can_value >> l * 8) & 0xff;
+                                }
+                                float value = canmapping_extract_value(msg.data64, &mapping);
 
 #ifdef CAN_MAPPING_TEST_DEBUG
-                        printf("test value / offset / length / return %d %d %d %f\r\n" ,
-                               test_value, offset, length, value);
-                        printf("CAN data: ");
-                        for (size_t di = 0; di < CAN_MSG_SIZE; di++){
-                                printf("%2x ", msg.data[di]);
-                        }
-                        printf("\r\n");
+                                printf("endian=%d / test value=%d / offset=%d / length=%d / return=%f\r\n" ,
+                                       endian, test_value, offset, length, value);
+                                printf("CAN data: ");
+                                for (size_t di = 0; di < CAN_MSG_SIZE; di++){
+                                        printf("%2x ", msg.data[di]);
+                                }
+                                printf("\r\n");
 #endif
 
-                        CPPUNIT_ASSERT_EQUAL((float)test_value, value);
+
+                               CPPUNIT_ASSERT_EQUAL((float)test_value, value);
+                        }
                 }
         }
 }
@@ -345,6 +391,7 @@ void CANMappingTest::mapping_test(void)
         msg.data[4] = 5;
         msg.data[5] = 6;
         msg.data[6] = 7;
+        msg.data[7] = 8;
         msg.addressValue = 0x1122;
 
         /* set up mapping */


### PR DESCRIPTION
So, We were doing can mapping for bit-mode big-endian incorrectly. 

Bits in a CAN message must be defined left to right, starting with the msb bit of byte 0. 

Arbitrary length values must be extracted from this 8 byte / 64 bit block before endian is converted. 

Below is the output of unit tests for a 9 bit extraction, to illustrate the desired effect. 
enable the #define CAN_MAPPING_TEST_DEBUG  in can_mapping_test.cpp to see the output. 




bitmode test: endian=1 / test_value=511 / offset=0 / length=9 / return = 511.000000
CAN data: ff 80 00 00 00 00 00 00 
11111111 10000000 00000000 00000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=1 / length=9 / return = 511.000000
CAN data: 7f c0 00 00 00 00 00 00 
01111111 11000000 00000000 00000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=2 / length=9 / return = 511.000000
CAN data: 3f e0 00 00 00 00 00 00 
00111111 11100000 00000000 00000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=3 / length=9 / return = 511.000000
CAN data: 1f f0 00 00 00 00 00 00 
00011111 11110000 00000000 00000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=4 / length=9 / return = 511.000000
CAN data: 0f f8 00 00 00 00 00 00 
00001111 11111000 00000000 00000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=5 / length=9 / return = 511.000000
CAN data: 07 fc 00 00 00 00 00 00 
00000111 11111100 00000000 00000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=6 / length=9 / return = 511.000000
CAN data: 03 fe 00 00 00 00 00 00 
00000011 11111110 00000000 00000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=7 / length=9 / return = 511.000000
CAN data: 01 ff 00 00 00 00 00 00 
00000001 11111111 00000000 00000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=8 / length=9 / return = 511.000000
CAN data: 00 ff 80 00 00 00 00 00 
00000000 11111111 10000000 00000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=9 / length=9 / return = 511.000000
CAN data: 00 7f c0 00 00 00 00 00 
00000000 01111111 11000000 00000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=10 / length=9 / return = 511.000000
CAN data: 00 3f e0 00 00 00 00 00 
00000000 00111111 11100000 00000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=11 / length=9 / return = 511.000000
CAN data: 00 1f f0 00 00 00 00 00 
00000000 00011111 11110000 00000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=12 / length=9 / return = 511.000000
CAN data: 00 0f f8 00 00 00 00 00 
00000000 00001111 11111000 00000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=13 / length=9 / return = 511.000000
CAN data: 00 07 fc 00 00 00 00 00 
00000000 00000111 11111100 00000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=14 / length=9 / return = 511.000000
CAN data: 00 03 fe 00 00 00 00 00 
00000000 00000011 11111110 00000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=15 / length=9 / return = 511.000000
CAN data: 00 01 ff 00 00 00 00 00 
00000000 00000001 11111111 00000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=16 / length=9 / return = 511.000000
CAN data: 00 00 ff 80 00 00 00 00 
00000000 00000000 11111111 10000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=17 / length=9 / return = 511.000000
CAN data: 00 00 7f c0 00 00 00 00 
00000000 00000000 01111111 11000000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=18 / length=9 / return = 511.000000
CAN data: 00 00 3f e0 00 00 00 00 
00000000 00000000 00111111 11100000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=19 / length=9 / return = 511.000000
CAN data: 00 00 1f f0 00 00 00 00 
00000000 00000000 00011111 11110000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=20 / length=9 / return = 511.000000
CAN data: 00 00 0f f8 00 00 00 00 
00000000 00000000 00001111 11111000 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=21 / length=9 / return = 511.000000
CAN data: 00 00 07 fc 00 00 00 00 
00000000 00000000 00000111 11111100 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=22 / length=9 / return = 511.000000
CAN data: 00 00 03 fe 00 00 00 00 
00000000 00000000 00000011 11111110 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=23 / length=9 / return = 511.000000
CAN data: 00 00 01 ff 00 00 00 00 
00000000 00000000 00000001 11111111 00000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=24 / length=9 / return = 511.000000
CAN data: 00 00 00 ff 80 00 00 00 
00000000 00000000 00000000 11111111 10000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=25 / length=9 / return = 511.000000
CAN data: 00 00 00 7f c0 00 00 00 
00000000 00000000 00000000 01111111 11000000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=26 / length=9 / return = 511.000000
CAN data: 00 00 00 3f e0 00 00 00 
00000000 00000000 00000000 00111111 11100000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=27 / length=9 / return = 511.000000
CAN data: 00 00 00 1f f0 00 00 00 
00000000 00000000 00000000 00011111 11110000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=28 / length=9 / return = 511.000000
CAN data: 00 00 00 0f f8 00 00 00 
00000000 00000000 00000000 00001111 11111000 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=29 / length=9 / return = 511.000000
CAN data: 00 00 00 07 fc 00 00 00 
00000000 00000000 00000000 00000111 11111100 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=30 / length=9 / return = 511.000000
CAN data: 00 00 00 03 fe 00 00 00 
00000000 00000000 00000000 00000011 11111110 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=31 / length=9 / return = 511.000000
CAN data: 00 00 00 01 ff 00 00 00 
00000000 00000000 00000000 00000001 11111111 00000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=32 / length=9 / return = 511.000000
CAN data: 00 00 00 00 ff 80 00 00 
00000000 00000000 00000000 00000000 11111111 10000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=33 / length=9 / return = 511.000000
CAN data: 00 00 00 00 7f c0 00 00 
00000000 00000000 00000000 00000000 01111111 11000000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=34 / length=9 / return = 511.000000
CAN data: 00 00 00 00 3f e0 00 00 
00000000 00000000 00000000 00000000 00111111 11100000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=35 / length=9 / return = 511.000000
CAN data: 00 00 00 00 1f f0 00 00 
00000000 00000000 00000000 00000000 00011111 11110000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=36 / length=9 / return = 511.000000
CAN data: 00 00 00 00 0f f8 00 00 
00000000 00000000 00000000 00000000 00001111 11111000 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=37 / length=9 / return = 511.000000
CAN data: 00 00 00 00 07 fc 00 00 
00000000 00000000 00000000 00000000 00000111 11111100 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=38 / length=9 / return = 511.000000
CAN data: 00 00 00 00 03 fe 00 00 
00000000 00000000 00000000 00000000 00000011 11111110 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=39 / length=9 / return = 511.000000
CAN data: 00 00 00 00 01 ff 00 00 
00000000 00000000 00000000 00000000 00000001 11111111 00000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=40 / length=9 / return = 511.000000
CAN data: 00 00 00 00 00 ff 80 00 
00000000 00000000 00000000 00000000 00000000 11111111 10000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=41 / length=9 / return = 511.000000
CAN data: 00 00 00 00 00 7f c0 00 
00000000 00000000 00000000 00000000 00000000 01111111 11000000 00000000 
bitmode test: endian=1 / test_value=511 / offset=42 / length=9 / return = 511.000000
CAN data: 00 00 00 00 00 3f e0 00 
00000000 00000000 00000000 00000000 00000000 00111111 11100000 00000000 
bitmode test: endian=1 / test_value=511 / offset=43 / length=9 / return = 511.000000
CAN data: 00 00 00 00 00 1f f0 00 
00000000 00000000 00000000 00000000 00000000 00011111 11110000 00000000 
bitmode test: endian=1 / test_value=511 / offset=44 / length=9 / return = 511.000000
CAN data: 00 00 00 00 00 0f f8 00 
00000000 00000000 00000000 00000000 00000000 00001111 11111000 00000000 
bitmode test: endian=1 / test_value=511 / offset=45 / length=9 / return = 511.000000
CAN data: 00 00 00 00 00 07 fc 00 
00000000 00000000 00000000 00000000 00000000 00000111 11111100 00000000 
bitmode test: endian=1 / test_value=511 / offset=46 / length=9 / return = 511.000000
CAN data: 00 00 00 00 00 03 fe 00 
00000000 00000000 00000000 00000000 00000000 00000011 11111110 00000000 
bitmode test: endian=1 / test_value=511 / offset=47 / length=9 / return = 511.000000
CAN data: 00 00 00 00 00 01 ff 00 
00000000 00000000 00000000 00000000 00000000 00000001 11111111 00000000 
bitmode test: endian=1 / test_value=511 / offset=48 / length=9 / return = 511.000000
CAN data: 00 00 00 00 00 00 ff 80 
00000000 00000000 00000000 00000000 00000000 00000000 11111111 10000000 
bitmode test: endian=1 / test_value=511 / offset=49 / length=9 / return = 511.000000
CAN data: 00 00 00 00 00 00 7f c0 
00000000 00000000 00000000 00000000 00000000 00000000 01111111 11000000 
bitmode test: endian=1 / test_value=511 / offset=50 / length=9 / return = 511.000000
CAN data: 00 00 00 00 00 00 3f e0 
00000000 00000000 00000000 00000000 00000000 00000000 00111111 11100000 
bitmode test: endian=1 / test_value=511 / offset=51 / length=9 / return = 511.000000
CAN data: 00 00 00 00 00 00 1f f0 
00000000 00000000 00000000 00000000 00000000 00000000 00011111 11110000 
bitmode test: endian=1 / test_value=511 / offset=52 / length=9 / return = 511.000000
CAN data: 00 00 00 00 00 00 0f f8 
00000000 00000000 00000000 00000000 00000000 00000000 00001111 11111000 
bitmode test: endian=1 / test_value=511 / offset=53 / length=9 / return = 511.000000
CAN data: 00 00 00 00 00 00 07 fc 
00000000 00000000 00000000 00000000 00000000 00000000 00000111 11111100 
bitmode test: endian=1 / test_value=511 / offset=54 / length=9 / return = 511.000000
CAN data: 00 00 00 00 00 00 03 fe 
00000000 00000000 00000000 00000000 00000000 00000000 00000011 11111110 
bitmode test: endian=1 / test_value=511 / offset=55 / length=9 / return = 511.000000
CAN data: 00 00 00 00 00 00 01 ff 
00000000 00000000 00000000 00000000 00000000 00000000 00000001 11111111 
