### PR TITLE
enable auto-detection of 29 bit OBDII. resolves #890

### DIFF
--- a/include/CAN/OBD2.h
+++ b/include/CAN/OBD2.h
@@ -84,14 +84,6 @@ void update_obd2_channels(CAN_msg *msg, OBD2Config *cfg);
  */
 bool OBD2_get_value_for_pid(uint16_t pid, float *value);
 
-/**
- * Sends an OBD2 PID request on the CAN bus.
- * @param pid the OBD2 PID to request
- * @param mode the OBD2 mode to request
- * @param timeout the timeout in ms for sending the OBD2 request
- */
-int OBD2_request_PID(uint16_t pid, uint8_t mode, size_t timeout_ms);
-
 CPP_GUARD_END
 
 #endif /* OBD2_H_ */

--- a/include/CAN/can_mapping.h
+++ b/include/CAN/can_mapping.h
@@ -31,7 +31,7 @@ CPP_GUARD_BEGIN
  * match the can message based on the specified CAN mapping ID and ID mask
  * @param can_msg the CAN message to test
  * @param mapping the can mapping to check against
- * @return true if the CAN message matches the mapping's CAN ID and ID mask
+ * @return true if the CAN message matches the mapping's CAN ID and ID mask, or true if mapping's CAN ID is 0
  */
 bool canmapping_match_id(const CAN_msg *can_msg, const CANMapping *mapping);
 

--- a/include/CAN/can_mapping.h
+++ b/include/CAN/can_mapping.h
@@ -31,7 +31,7 @@ CPP_GUARD_BEGIN
  * match the can message based on the specified CAN mapping ID and ID mask
  * @param can_msg the CAN message to test
  * @param mapping the can mapping to check against
- * @return true if the CAN message matches the mapping's CAN ID and ID mask, or true if mapping's CAN ID is 0
+ * @return true if the CAN message matches the mapping's CAN ID and ID mask. A mapping with CAN ID of 0 is a wildcard and will match any ID in the CAN_msg
  */
 bool canmapping_match_id(const CAN_msg *can_msg, const CANMapping *mapping);
 

--- a/src/CAN/can_mapping.c
+++ b/src/CAN/can_mapping.c
@@ -96,7 +96,7 @@ bool canmapping_match_id(const CAN_msg *can_msg, const CANMapping *mapping)
         if (mapping->can_mask)
                 can_id &= mapping->can_mask;
 
-        return can_id == mapping->can_id;
+        return can_id == mapping->can_id || mapping->can_id == 0;
 }
 
 bool canmapping_map_value(float *value, const CAN_msg *can_msg, const CANMapping *mapping)

--- a/src/CAN/can_mapping.c
+++ b/src/CAN/can_mapping.c
@@ -89,10 +89,12 @@ float canmapping_apply_formula(float value, const CANMapping *mapping)
 bool canmapping_match_id(const CAN_msg *can_msg, const CANMapping *mapping)
 {
         uint32_t can_id  = can_msg->addressValue;
+        if (mapping->can_id == 0) return true;
+
         if (mapping->can_mask)
                 can_id &= mapping->can_mask;
 
-        return can_id == mapping->can_id || mapping->can_id == 0;
+        return can_id == mapping->can_id;
 }
 
 bool canmapping_map_value(float *value, const CAN_msg *can_msg, const CANMapping *mapping)


### PR DESCRIPTION
Enable auto-detection of 29 or 11 bit OBDII protocol.