### PR TITLE
Memory savings and OBDII / CAN channels expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ signal gain in wooded areas).
 
 ### Toolchain Setup
 Do the following to setup the MK2 toolchain:
-* Download [the official MK2
-  toolchain](https://launchpad.net/gcc-arm-embedded/4.7/4.7-2013-q3-update/)
+* Download [the official
+  toolchain](https://launchpad.net/gcc-arm-embedded/+milestone/4.9-2014-q4-major)
 * Extract the tarball to a directory of your choice
 * Add the 'bin' directory from within the newly extracted directory to
   your system PATH.
@@ -74,9 +74,11 @@ Do the following to setup the MK2 toolchain:
   asl_f4_loader application.  This package does all the post-processing on
   MK2 firmware and provides a firmware loading utility.
 
-### Compiling MK2 Firmware
-From the root of the project, simply run `make mk2`.  For a package run
-`make mk2-package`.
+### Compiling Firmware
+From the root of the project, simply run `make`.  This will build all platforms.
+To build a specific platform, run `make <platform>` where platform = mk2, mk3 or rct
+ For a package run
+`make <platform>-package`.
 
 When building from the command line, a debug version of the firmware is
 built by default. To disable debug and enable standard optimization,

--- a/make/asl_cflags.mk
+++ b/make/asl_cflags.mk
@@ -20,7 +20,7 @@
 ASL_CFLAGS :=
 
 # Basic flags
-ASL_CFLAGS += -Os -std=gnu99
+ASL_CFLAGS += -Os -std=gnu99 -Wno-missing-braces
 
 #
 # Only specify ASL_DEBUG on devel builds. Reason being that when

--- a/platform/mk2/capabilities.h
+++ b/platform/mk2/capabilities.h
@@ -78,7 +78,7 @@
 #define CAN_CHANNELS			2
 #define CAN_SW_TERMINATION      false
 #define CAN_MAPPINGS            100
-#define OBD2_CHANNELS           10
+#define OBD2_CHANNELS           20
 //Wireless Channels
 #define CONNECTIVITY_CHANNELS	2
 

--- a/platform/mk3/capabilities.h
+++ b/platform/mk3/capabilities.h
@@ -78,7 +78,7 @@
 #define CAN_CHANNELS			2
 #define CAN_SW_TERMINATION      true
 #define CAN_MAPPINGS            100
-#define OBD2_CHANNELS           10
+#define OBD2_CHANNELS           20
 
 //Wireless connections
 #define CONNECTIVITY_CHANNELS	2

--- a/platform/rct/Makefile
+++ b/platform/rct/Makefile
@@ -273,7 +273,7 @@ CPU_FLAGS := \
 -mthumb \
 -mfloat-abi=soft \
 
-CFLAGS := -DUSE_STDPERIPH_DRIVER -DSTM32F30X -MD -c
+CFLAGS := -DUSE_STDPERIPH_DRIVER -DSTM32F30X -MD -c 
 CFLAGS += $(CPU_FLAGS)
 CFLAGS += $(ASL_CFLAGS)
 CFLAGS += $(BOARD_DEFINES)
@@ -281,7 +281,7 @@ CFLAGS += $(addprefix -I,$(inc-y))
 
 LDFLAGS := $(CPU_FLAGS)
 LDFLAGS += -TProject/STM32_FLASH.ld
-LDFLAGS += -Wl,-cref,-u,Reset_Handler,-Map=main.map
+LDFLAGS += -Wl,-cref,-u,Reset_Handler,-Map=main.map --specs=nano.specs
 LDFLAGS += -Wl,--gc-sections,-static
 LDFLAGS += $(FREERTOS_LD_FLAGS)
 

--- a/platform/rct/Project/STM32_FLASH.ld
+++ b/platform/rct/Project/STM32_FLASH.ld
@@ -36,8 +36,8 @@ ENTRY(Reset_Handler)
 _estack = 0x20000000 + 40K;    /* end of 40K RAM */
 
 /* Generate a link error if heap and stack don't fit into RAM */
-_Min_Heap_Size = 0x200;      /* required amount of heap  */
-_Min_Stack_Size = 0x400; 	/* required amount of stack */
+_Min_Heap_Size = 0x100;      /* required amount of heap  */
+_Min_Stack_Size = 0x100; 	/* required amount of stack */
 
 /* Specify the memory areas */
 MEMORY

--- a/platform/rct/capabilities.h
+++ b/platform/rct/capabilities.h
@@ -41,8 +41,8 @@
 #define PWM_CHANNELS	            0
 #define CAN_CHANNELS	            1
 #define CAN_SW_TERMINATION          false
-#define CAN_MAPPINGS                5
-#define OBD2_CHANNELS               5
+#define CAN_MAPPINGS                10
+#define OBD2_CHANNELS               10
 
 //Wireless connections
 #define CONNECTIVITY_CHANNELS	    2

--- a/platform/rct/hal/imu_stm32/imu_device_stm32.c
+++ b/platform/rct/hal/imu_stm32/imu_device_stm32.c
@@ -39,7 +39,7 @@
 #define IMU_TASK_PRIORITY	(tskIDLE_PRIORITY + 2)
 #define IS_9150_ADDR            0x68
 
-static struct is9150_all_sensor_data sensor_data[2];
+static struct is9150_all_sensor_data sensor_data[2] = {0};
 static struct is9150_all_sensor_data *read_buf = &sensor_data[0];
 static struct is9150_all_sensor_data *fill_buf = &sensor_data[1];
 static enum imu_init_status init_status;

--- a/src/devices/esp8266.c
+++ b/src/devices/esp8266.c
@@ -50,7 +50,7 @@
 
 /* STIEG: Temp until we write *_create methods for serial_buff and at_info */
 struct serial_buffer _serial_cmd_buff;
-struct at_info _ati;
+struct at_info _ati = {0};
 
 /**
  * Internal state of our driver.

--- a/src/devices/gps_skytraq_s1216_sup500f8.c
+++ b/src/devices/gps_skytraq_s1216_sup500f8.c
@@ -654,7 +654,7 @@ static gps_cmd_result_t configureUpdateRate(GpsMessage * gpsMsg,
     return result;
 }
 
-static GpsMessage gpsMsg;
+static GpsMessage gpsMsg = {0};
 
 static uint8_t getTargetUpdateRate(uint8_t sampleRate)
 {

--- a/src/drivers/esp8266_drv.c
+++ b/src/drivers/esp8266_drv.c
@@ -155,7 +155,7 @@ static struct {
                 tiny_millis_t backoff;
                 xTimerHandle timer;
         } led;
-} esp8266_state;
+} esp8266_state ={0};
 
 static void led_timer_cb( xTimerHandle xTimer )
 {

--- a/src/gps/gps.c
+++ b/src/gps/gps.c
@@ -27,7 +27,7 @@
 #define GPS_LOCK_FLASH_COUNT 5
 #define GPS_NOFIX_FLASH_COUNT 25
 
-static GpsSnapshot g_gpsSnapshot;
+static GpsSnapshot g_gpsSnapshot ={0};
 gps_status_t gps_status = GPS_STATUS_NOT_INIT;
 static int g_flashCount;
 static millis_t g_timeFirstFix;

--- a/src/imu/imu.c
+++ b/src/imu/imu.c
@@ -28,7 +28,7 @@
 #include "printk.h"
 
 //Channel Filters
-static Filter g_imu_filter[CONFIG_IMU_CHANNELS];
+static Filter g_imu_filter[CONFIG_IMU_CHANNELS] = {0};
 
 static void init_filters(LoggerConfig *loggerConfig)
 {

--- a/src/lap_stats/lap_stats.c
+++ b/src/lap_stats/lap_stats.c
@@ -78,8 +78,8 @@ static int g_lapCount;
 static float g_distance;
 
 // Our GeoTriggers so we don't unintentionally trigger on start/finish
-static struct GeoTrigger g_start_geo_trigger;
-static struct GeoTrigger g_finish_geo_trigger;
+static struct GeoTrigger g_start_geo_trigger = {0};
+static struct GeoTrigger g_finish_geo_trigger = {0};
 
 static void reset_elapsed_time()
 {

--- a/src/logger/loggerSampleData.c
+++ b/src/logger/loggerSampleData.c
@@ -52,7 +52,7 @@ struct sample_cb_registry {
         logger_sample_cb_t* cb;
         void* data;
         int rate;
-} sample_cb_registry[SAMPLE_CB_REGISTRY_SIZE];
+} sample_cb_registry[SAMPLE_CB_REGISTRY_SIZE] = {0};
 
 static ChannelSample* processChannelSampleWithFloatGetter(ChannelSample *s,
         ChannelConfig *cfg,

--- a/src/logger/loggerTaskEx.c
+++ b/src/logger/loggerTaskEx.c
@@ -56,7 +56,7 @@ int g_telemetryBackgroundStreaming;
 xSemaphoreHandle onTick;
 
 /* This should be 0'd out accroding to C standards */
-static struct sample g_sample_buffer[LOGGER_MESSAGE_BUFFER_SIZE];
+static struct sample g_sample_buffer[LOGGER_MESSAGE_BUFFER_SIZE] = {0};
 
 static LoggerMessage getLogStartMessage()
 {


### PR DESCRIPTION
* switch to gcc 4.9 with newlib nano for memory savings. 
* move select things from un-initialized BSS to initialized DATA segments by providing a compiler hint by initializing the selected structs to {0}
* increase OBDII and CAN channels for RCT, increase OBDII channels for RCP. 

Note, memory savings wasn't needed for RCP OBDII channels increase, just bundled it together. 

Resolves #936 #904 