### PR TITLE
Enable 32 bit PIDs, and refactor duplicate ChannelConfig (!!)

### DIFF
--- a/include/jsmn/jsmn.h
+++ b/include/jsmn/jsmn.h
@@ -143,8 +143,8 @@ bool jsmn_exists_set_val_float(const jsmntok_t* root, const char* field,
 bool jsmn_exists_set_val_bool(const jsmntok_t* root, const char* field,
                               void* val);
 
-bool jsmn_exists_set_val_uint16(const jsmntok_t* root, const char* field,
-                             uint16_t* val);
+bool jsmn_exists_set_val_uint32(const jsmntok_t* root, const char* field,
+                             uint32_t* val);
 /**
  * Searches for a node based on the specified field name, and if found, set the pointed-to uchar value. Also passes it through a filter function if provided.
  * @param root the node to start searching from.

--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -362,7 +362,6 @@ typedef struct _CANChannelConfig {
 
 
 typedef struct _PidConfig {
-    ChannelConfig cfg;
     CANMapping mapping;
 
     /* flag for passive mode where we only listen for OBDII PID responses */
@@ -371,7 +370,7 @@ typedef struct _PidConfig {
     uint8_t mode;
 
     /* The OBDII PID to query */
-    uint16_t pid;
+    uint32_t pid;
 } PidConfig;
 
 

--- a/platform/rct/capabilities.h
+++ b/platform/rct/capabilities.h
@@ -41,8 +41,8 @@
 #define PWM_CHANNELS	            0
 #define CAN_CHANNELS	            1
 #define CAN_SW_TERMINATION          false
-#define CAN_MAPPINGS                5
-#define OBD2_CHANNELS               5
+#define CAN_MAPPINGS                15
+#define OBD2_CHANNELS               15
 
 //Wireless connections
 #define CONNECTIVITY_CHANNELS	    2

--- a/platform/rct/capabilities.h
+++ b/platform/rct/capabilities.h
@@ -41,8 +41,8 @@
 #define PWM_CHANNELS	            0
 #define CAN_CHANNELS	            1
 #define CAN_SW_TERMINATION          false
-#define CAN_MAPPINGS                15
-#define OBD2_CHANNELS               15
+#define CAN_MAPPINGS                5
+#define OBD2_CHANNELS               5
 
 //Wireless connections
 #define CONNECTIVITY_CHANNELS	    2

--- a/src/OBD2/OBD2.c
+++ b/src/OBD2/OBD2.c
@@ -180,7 +180,7 @@ bool OBD2_init_current_values(OBD2Config *obd2_config)
         size_t max_sample_rate = 0;
         for (size_t i = 0; i < obd2_channel_count; i++) {
                 max_sample_rate = MAX(max_sample_rate,
-                                      decodeSampleRate(obd2_config->pids[i].cfg.sampleRate));
+                                      decodeSampleRate(obd2_config->pids[i].mapping.channel_cfg.sampleRate));
         }
         obd2_state.max_sample_rate = max_sample_rate;
         pr_debug_int_msg(_LOG_PFX " Max OBD2 sample rate: ", obd2_state.max_sample_rate);
@@ -308,7 +308,7 @@ void sequence_next_obd2_query(OBD2Config * obd2_config, uint16_t enabled_obd2_pi
                         continue;
 
                 uint16_t timeout = state->sequencer_count;
-                uint16_t sample_rate = decodeSampleRate(obd2_config->pids[i].cfg.sampleRate);
+                uint16_t sample_rate = decodeSampleRate(obd2_config->pids[i].mapping.channel_cfg.sampleRate);
                 timeout += sample_rate;
 
                 /**

--- a/src/OBD2/OBD2.c
+++ b/src/OBD2/OBD2.c
@@ -140,27 +140,31 @@ static int OBD2_request_PID(uint32_t pid, uint8_t mode, bool is_29_bit, size_t t
 {
         CAN_msg msg;
         msg.addressValue = is_29_bit ? OBD2_29BIT_PID_REQUEST : OBD2_11BIT_PID_REQUEST;
-        if (mode == OBD2_MODE_ENHANCED_DATA) {
-                /* extract into a 32 bit PID as needed, big endian format */
-                if (pid > 0xFFFF) {
+        if (mode != OBD2_MODE_SHOW_CURRENT_DATA) {
+                /* treat everything that's not a standard current data request
+                 * as an enchanced data request mode
+                 */
+                if (pid > 0xFFFF) { /* extract into a 32 bit PID as needed, big endian format */
                         msg.data[0] = 5;
                         msg.data[2] = (pid >> 24);
                         msg.data[3] = (pid >> 16) & 0xFF;
                         msg.data[4] = (pid >> 8) & 0xFF;
                         msg.data[5] = pid & 0xFF;
                 }
-                else {
+                else { /*otherwise treat as 16 bit PID */
                         msg.data[0] = 3;
-                        msg.data[2] = (pid >> 8) & 0xFF;
+                        msg.data[2] = pid >> 8;
                         msg.data[3] = pid & 0xFF;
                         msg.data[4] = 0x55;
                         msg.data[5] = 0x55;
                 }
         }
-        else{
+        else{ /* request current data, 8 bit PID */
                 msg.data[0] = 2;
                 msg.data[2] = pid;
                 msg.data[3] = 0x55;
+                msg.data[4] = 0x55;
+                msg.data[5] = 0x55;
         }
         msg.data[1] = mode;
         msg.data[6] = 0x55;

--- a/src/jsmn/jsmn.c
+++ b/src/jsmn/jsmn.c
@@ -391,8 +391,8 @@ bool jsmn_exists_set_val_uint8(const jsmntok_t *root, const char * field,
     return (valueNode != NULL);
 }
 
-bool jsmn_exists_set_val_uint16(const jsmntok_t* root, const char* field,
-                             uint16_t* val)
+bool jsmn_exists_set_val_uint32(const jsmntok_t* root, const char* field,
+                             uint32_t* val)
 {
     const jsmntok_t *node = jsmn_find_get_node_value_prim(root, field);
 

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -1481,7 +1481,7 @@ int api_getObd2Config(struct Serial *serial, const jsmntok_t *json)
     for (int i = 0; i < enabledPids; i++) {
         PidConfig *pidCfg = &obd2Cfg->pids[i];
         json_objStart(serial);
-        json_channelConfig(serial, &(pidCfg->cfg), 1);
+        json_channelConfig(serial, &(pidCfg->mapping.channel_cfg), 1);
         json_put_can_mapping(serial, &(pidCfg->mapping), 1);
         json_int(serial,"pid",pidCfg->pid, 1);
         json_int(serial, "mode", pidCfg->mode, 1);
@@ -1530,9 +1530,9 @@ int api_setObd2Config(struct Serial *serial, const jsmntok_t *json)
             PidConfig *pid_cfg = obd2Cfg->pids + index;
             set_can_mapping(pids_tok, &(pid_cfg->mapping));
             jsmn_exists_set_val_bool(pids_tok, "pass", &pid_cfg->passive);
-            jsmn_exists_set_val_uint16(pids_tok, "pid", &pid_cfg->pid);
+            jsmn_exists_set_val_uint32(pids_tok, "pid", &pid_cfg->pid);
             jsmn_exists_set_val_uint8(pids_tok, "mode", &pid_cfg->mode, NULL);
-            pids_tok = setChannelConfig(serial, pids_tok, &(pid_cfg->cfg), NULL, NULL);
+            pids_tok = setChannelConfig(serial, pids_tok, &(pid_cfg->mapping.channel_cfg), NULL, NULL);
         }
         /* update the number of PIDs enabled in the list as needed */
         if (index > obd2Cfg->enabledPids || is_last)

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -224,7 +224,7 @@ static void resetOBD2Config(OBD2Config *cfg)
     for (int i = 0; i < OBD2_CHANNELS; ++i) {
         PidConfig *c = &cfg->pids[i];
         memset(c, 0, sizeof(PidConfig));
-        sPrintStrInt(c->cfg.label, "OBD2 Pid ", i + 1);
+        sPrintStrInt(c->mapping.channel_cfg.label, "OBD2 Pid ", i + 1);
     }
 
     /* TODO BAP - hacked in some defaults */
@@ -522,7 +522,7 @@ unsigned int getHighestSampleRate(LoggerConfig *config)
             const size_t enabled_channels = obd2_config->enabledPids;
             bool enabled = obd2_config->enabled;
             for (size_t i = 0; i < enabled_channels && enabled; i++) {
-					sr = config->OBD2Configs.pids[i].cfg.sampleRate;
+					sr = config->OBD2Configs.pids[i].mapping.channel_cfg.sampleRate;
 					s = getHigherSampleRate(sr, s);
             }
     }
@@ -634,7 +634,7 @@ size_t get_enabled_channel_count(LoggerConfig *loggerConfig)
             const size_t enabled_channels = obd2_config->enabledPids;
             bool enabled = obd2_config->enabled;
             for (size_t i=0; i < enabled_channels && enabled; i++) {
-                if (loggerConfig->OBD2Configs.pids[i].cfg.sampleRate != SAMPLE_DISABLED)
+                if (loggerConfig->OBD2Configs.pids[i].mapping.channel_cfg.sampleRate != SAMPLE_DISABLED)
                     ++channels;
             }
     }

--- a/src/logger/loggerSampleData.c
+++ b/src/logger/loggerSampleData.c
@@ -304,7 +304,7 @@ void init_channel_sample_buffer(LoggerConfig *loggerConfig, struct sample *buff)
     OBD2Config *obd2Config = &(loggerConfig->OBD2Configs);
     const unsigned char enabled = loggerConfig->OBD2Configs.enabled;
     for (size_t i = 0; i < obd2Config->enabledPids && enabled; i++) {
-        chanCfg = &(obd2Config->pids[i].cfg);
+        chanCfg = &(obd2Config->pids[i].mapping.channel_cfg);
         sample = processChannelSampleWithFloatGetter(sample, chanCfg, i,
                                                    OBD2_get_current_channel_value);
     }

--- a/test/loggerApi_test.cpp
+++ b/test/loggerApi_test.cpp
@@ -1234,13 +1234,13 @@ void LoggerApiTest::testGetObd2ConfigFile(string filename){
         obd2Config->enabled = 1;
         obd2Config->enabledPids = 2;
 
-        ChannelConfig *cfg1 = &obd2Config->pids[0].cfg;
+        ChannelConfig *cfg1 = &obd2Config->pids[0].mapping.channel_cfg;
         populateChannelConfig(cfg1, 1, 1);
         obd2Config->pids[0].pid = 0x05;
         obd2Config->pids[0].mode = 0x55;
         obd2Config->pids[0].passive = true;
 
-        ChannelConfig *cfg2 = &obd2Config->pids[1].cfg;
+        ChannelConfig *cfg2 = &obd2Config->pids[1].mapping.channel_cfg;
         populateChannelConfig(cfg2, 2, 50);
         obd2Config->pids[1].pid = 0x06;
         obd2Config->pids[1].mode = 0x66;
@@ -1252,14 +1252,14 @@ void LoggerApiTest::testGetObd2ConfigFile(string filename){
 
         Object json_pid0 = (Object)json["obd2Cfg"]["pids"][0];
         PidConfig *pid_cfg0 = &obd2Config->pids[0];
-        check_channel_config(json_pid0, &pid_cfg0->cfg);
+        check_channel_config(json_pid0, &pid_cfg0->mapping.channel_cfg);
         CPPUNIT_ASSERT_EQUAL((int)pid_cfg0->pid, (int)(Number)json_pid0["pid"]);
         CPPUNIT_ASSERT_EQUAL((int)pid_cfg0->mode, (int)(Number)json_pid0["mode"]);
         CPPUNIT_ASSERT_EQUAL((bool)pid_cfg0->passive, (bool)(Boolean)json_pid0["pass"]);
 
         Object json_pid1 = (Object)json["obd2Cfg"]["pids"][1];
         PidConfig *pid_cfg1 = &obd2Config->pids[1];
-        check_channel_config(json_pid1, &pid_cfg1->cfg);
+        check_channel_config(json_pid1, &pid_cfg1->mapping.channel_cfg);
         CPPUNIT_ASSERT_EQUAL((int)pid_cfg1->pid, (int)(Number)json_pid1["pid"]);
         CPPUNIT_ASSERT_EQUAL((int)pid_cfg1->mode, (int)(Number)json_pid1["mode"]);
         CPPUNIT_ASSERT_EQUAL((bool)pid_cfg1->passive, (bool)(Boolean)json_pid1["pass"]);
@@ -1287,7 +1287,7 @@ void LoggerApiTest::testSetObd2ConfigFile(string filename){
         for (size_t i=0; i < json_pids.Size(); i++) {
                 PidConfig *pid_cfg = &obd2Config->pids[i];
                 Object json_pid = (Object)json_pids[i];
-                check_channel_config(json_pid, &pid_cfg->cfg);
+                check_channel_config(json_pid, &pid_cfg->mapping.channel_cfg);
                 check_can_mapping_config(json_pid, &pid_cfg->mapping);
 
                 CPPUNIT_ASSERT_EQUAL((int)(Number)json_pid["pid"], (int)pid_cfg->pid);
@@ -1317,11 +1317,11 @@ void LoggerApiTest::testSetObd2ConfigFile_fromIndex(){
 	//when setting PIDs from an index, index + length of PID array becomes the total number of enabled PIDs
 	CPPUNIT_ASSERT_EQUAL(4, (int)obd2Config->enabledPids);
 
-    check_channel_config(obd2_json1["setObd2Cfg"]["pids"][0], &obd2Config->pids[0].cfg);
-    check_channel_config(obd2_json1["setObd2Cfg"]["pids"][1], &obd2Config->pids[1].cfg);
+    check_channel_config(obd2_json1["setObd2Cfg"]["pids"][0], &obd2Config->pids[0].mapping.channel_cfg);
+    check_channel_config(obd2_json1["setObd2Cfg"]["pids"][1], &obd2Config->pids[1].mapping.channel_cfg);
 
-	check_channel_config(obd2_json2["setObd2Cfg"]["pids"][0], &obd2Config->pids[2].cfg);
-	check_channel_config(obd2_json2["setObd2Cfg"]["pids"][1], &obd2Config->pids[3].cfg);
+	check_channel_config(obd2_json2["setObd2Cfg"]["pids"][0], &obd2Config->pids[2].mapping.channel_cfg);
+	check_channel_config(obd2_json2["setObd2Cfg"]["pids"][1], &obd2Config->pids[3].mapping.channel_cfg);
 }
 
 void LoggerApiTest::testSetObd2ConfigFile_invalid(){

--- a/test/loggerConfig_test.cpp
+++ b/test/loggerConfig_test.cpp
@@ -147,8 +147,8 @@ void LoggerConfigTest::testLoggerInitObd2Config() {
    CPPUNIT_ASSERT(c->enabled == 0);
 
    for (int i = 0; i < OBD2_CHANNELS; ++i) {
-      CPPUNIT_ASSERT(strlen(c->pids[i].cfg.label));
-      CPPUNIT_ASSERT(c->pids[i].cfg.sampleRate == 0);
+      CPPUNIT_ASSERT(strlen(c->pids[i].mapping.channel_cfg.label));
+      CPPUNIT_ASSERT(c->pids[i].mapping.channel_cfg.sampleRate == 0);
    }
 }
 


### PR DESCRIPTION
This enables 32 bit PIDs and also includes a refactoring for some major memory savings. 

Turns out for each OBDII channel we had an extra ChannelConfig defined in the PidConfig, but not used. 

Refactor to use the ChannelConfig that's in the CANMapping object. 

Resolves #924 and helps memory situation to resolve #936 