### PR TITLE
Get current sample value by name in Lua

### DIFF
--- a/include/logger/loggerTaskEx.h
+++ b/include/logger/loggerTaskEx.h
@@ -30,6 +30,8 @@
 
 CPP_GUARD_BEGIN
 
+struct sample * get_current_sample(void);
+
 void startLogging();
 void stopLogging();
 
@@ -37,6 +39,7 @@ void configChanged();
 
 void startLoggerTaskEx( int priority);
 void loggerTaskEx(void *params);
+
 
 CPP_GUARD_END
 

--- a/include/logger/sampleRecord.h
+++ b/include/logger/sampleRecord.h
@@ -109,6 +109,16 @@ size_t init_sample_buffer(struct sample *s, const size_t count);
  */
 void free_sample_buffer(struct sample *s);
 
+
+/**
+ * Gets a sample value by name for the specified sample.
+ * @param s the sample to fetch a value from
+ * @param name the name of the channel
+ * @param value pointer to the value to set if sample is found
+ * @return true if the sample was found and set
+ */
+bool get_sample_value_by_name(struct sample *s, const char * name, double *value);
+
 /**
  * Creates a LoggerMessage for use in the messaging between threads.
  * @param t The messaget type.

--- a/src/logger/loggerTaskEx.c
+++ b/src/logger/loggerTaskEx.c
@@ -52,11 +52,17 @@
 int g_loggingShouldRun;
 int g_configChanged;
 int g_telemetryBackgroundStreaming;
+struct sample * current_sample = NULL;
 
 xSemaphoreHandle onTick;
 
 /* This should be 0'd out accroding to C standards */
 static struct sample g_sample_buffer[LOGGER_MESSAGE_BUFFER_SIZE] = {0};
+
+struct sample * get_current_sample(void)
+{
+		return current_sample;
+}
 
 static LoggerMessage getLogStartMessage()
 {
@@ -270,6 +276,8 @@ void loggerTaskEx(void *params)
 
                 ++bufferIndex;
                 bufferIndex %= buffer_size;
+
+                current_sample = sample;
         }
 
         panic(PANIC_CAUSE_UNREACHABLE);

--- a/src/logger/sampleRecord.c
+++ b/src/logger/sampleRecord.c
@@ -27,9 +27,11 @@
 #include "mem_mang.h"
 #include "sampleRecord.h"
 #include "taskUtil.h"
-
+#include "macros.h"
 #include <stdbool.h>
+#include "printk.h"
 
+#define LOG_PFX "[sampleRecord] "
 size_t init_sample_buffer(struct sample *s, const size_t count)
 {
         if (s->channel_samples)
@@ -52,6 +54,43 @@ void free_sample_buffer(struct sample *s)
 {
         portFree(s->channel_samples);
         s->channel_samples = NULL;
+}
+
+bool get_sample_value_by_name(struct sample *s, const char * name, double *value)
+{
+    if (!s || !value) return false;
+
+    for (size_t i = 0; i < s->channel_count; i++){
+            ChannelSample *sam = (s->channel_samples + i);
+            if (!STR_EQ(name, sam->cfg->label)) continue;
+
+            if (!sam->populated) return false;
+
+            switch(sam->sampleData) {
+                    case SampleData_Float:
+                    case SampleData_Float_Noarg:
+                            *value = (double)sam->valueFloat;
+                            return true;
+                    case SampleData_Int:
+                    case SampleData_Int_Noarg:
+                            *value = (double)sam->valueInt;
+                            return true;
+                    case SampleData_Double:
+                    case SampleData_Double_Noarg:
+                            *value = sam->valueDouble;
+                            return true;
+                    case SampleData_LongLong:
+                    case SampleData_LongLong_Noarg:
+                            /* risk of overflow here - specifically pertains to the UTC milliseconds channel */
+                            pr_warning_str_msg(LOG_PFX "Data type not supported for channel: ", name);
+                            return false;
+                    default:
+                            pr_warning_int_msg(LOG_PFX "Unknown channel sample type", sam->sampleData);
+                            return false;
+            }
+    }
+    pr_debug_str_msg(LOG_PFX "Unknown channel name: ", name);
+    return false;
 }
 
 /**

--- a/src/logger/sampleRecord.c
+++ b/src/logger/sampleRecord.c
@@ -58,7 +58,7 @@ void free_sample_buffer(struct sample *s)
 
 bool get_sample_value_by_name(struct sample *s, const char * name, double *value)
 {
-    if (!s || !value) return false;
+    if (!s || !value || !name) return false;
 
     for (size_t i = 0; i < s->channel_count; i++){
             ChannelSample *sam = (s->channel_samples + i);

--- a/src/lua/luaLoggerBinding.c
+++ b/src/lua/luaLoggerBinding.c
@@ -896,19 +896,23 @@ static int lua_get_virtual_channel(lua_State *ls)
          * Numbers can be passed in as 123 or "123" in lua.  So handle
          * that case first
          */
-        VirtualChannel *vc;
         if (lua_isnumber(ls, 1)) {
+        		VirtualChannel *vc;
                 vc = get_virtual_channel(lua_tointeger(ls, 1));
+                if (vc) {
+						lua_pushnumber(ls, vc->currentValue);
+						return 1;
+                }
         } else {
-                const int idx = find_virtual_channel(lua_tostring(ls, 1));
-                vc = get_virtual_channel(idx);
-        }
+        		struct sample * s = get_current_sample();
+				double value;
+				if (s && get_sample_value_by_name(s, lua_tostring(ls, 1), &value)){
+						lua_pushnumber(ls, value);
+						return 1;
+        		}
+		}
 
-        if (!vc)
-                return luaL_error(ls, "Virtual channel not found!");
-
-        lua_pushnumber(ls, vc->currentValue);
-        return 1;
+		return luaL_error(ls, "Channel not found!");
 }
 
 static int lua_set_virt_channel_value(lua_State *L)

--- a/test/sampleRecord_test.cpp
+++ b/test/sampleRecord_test.cpp
@@ -441,3 +441,28 @@ void SampleRecordTest::testLoggerMessageAlwaysHasTime() {
 
         CPPUNIT_ASSERT_EQUAL(true, tick < 1000);
 }
+
+void SampleRecordTest::test_get_sample_value_by_name()
+{
+		lc->ADCConfigs[7].scalingMode = SCALING_MODE_RAW;
+		ADC_mock_set_value(7, 123);
+		ADC_sample_all();
+
+        increment_tick();
+        CPPUNIT_ASSERT_EQUAL(1, (int) (xTaskGetTickCount()));
+
+        populate_sample_buffer(&s, 0);
+
+
+		double value;
+		bool result = get_sample_value_by_name(&s, "Speed", &value);
+		CPPUNIT_ASSERT_EQUAL(true, result);
+		CPPUNIT_ASSERT_EQUAL((double)0, value);
+
+		result = get_sample_value_by_name(&s, "Battery", &value);
+		CPPUNIT_ASSERT_EQUAL(true, result);
+		CPPUNIT_ASSERT_EQUAL((double)123 * 0.0048828125f, value);
+
+		result = get_sample_value_by_name(&s, "FooBar", &value);
+		CPPUNIT_ASSERT_EQUAL(false, result);
+}

--- a/test/sampleRecord_test.h
+++ b/test/sampleRecord_test.h
@@ -31,6 +31,7 @@ class SampleRecordTest : public CppUnit::TestFixture
     CPPUNIT_TEST( testPopulateSampleRecord );
     CPPUNIT_TEST( testIsValidLoggerMessage );
     CPPUNIT_TEST( testLoggerMessageAlwaysHasTime );
+    CPPUNIT_TEST( test_get_sample_value_by_name );
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -41,6 +42,7 @@ public:
     void testPopulateSampleRecord();
     void testIsValidLoggerMessage();
     void testLoggerMessageAlwaysHasTime();
+    void test_get_sample_value_by_name();
 
 private:
 


### PR DESCRIPTION
Resolves #939 

Extend the current get_channel_value to get the current value for any channel, if parameter is passed as a string. 

