### PR TITLE
query sensors at actual rate if we're logging

### DIFF
--- a/src/logger/loggerTaskEx.c
+++ b/src/logger/loggerTaskEx.c
@@ -210,7 +210,12 @@ void loggerTaskEx(void *params)
 
                 const bool is_logging = logging_is_active();
 
-                if ((is_logging && currentTicks % loggingSampleRate == 0) || (currentTicks % BACKGROUND_SAMPLE_RATE == 0))
+                /**
+                 * Ensure we refresh the internal sensors at either the
+                 * logging rate or at least at background sample rate
+                 */
+                if ((is_logging && currentTicks % loggingSampleRate == 0) ||
+                                (currentTicks % BACKGROUND_SAMPLE_RATE == 0))
                         doBackgroundSampling();
 
                 if (g_loggingShouldRun && !is_logging) {

--- a/src/logger/loggerTaskEx.c
+++ b/src/logger/loggerTaskEx.c
@@ -208,10 +208,11 @@ void loggerTaskEx(void *params)
                 /* Only reset the watchdog when we are configured and ready to rock */
                 watchdog_reset();
 
-                if (currentTicks % BACKGROUND_SAMPLE_RATE == 0)
+                const bool is_logging = logging_is_active();
+
+                if ((is_logging && currentTicks % loggingSampleRate == 0) || (currentTicks % BACKGROUND_SAMPLE_RATE == 0))
                         doBackgroundSampling();
 
-                const bool is_logging = logging_is_active();
                 if (g_loggingShouldRun && !is_logging) {
                         logging_started();
                         const LoggerMessage logStartMsg = getLogStartMessage();


### PR DESCRIPTION
…ng; otherwise do the background rate. resolves #954