### PR TITLE
Read UTC timestamp from Podium upon connection. #966

### DIFF
--- a/include/devices/bluetooth.h
+++ b/include/devices/bluetooth.h
@@ -25,6 +25,7 @@
 #include "cpp_guard.h"
 #include "devices_common.h"
 #include "stddef.h"
+#include "dateTime.h"
 
 CPP_GUARD_BEGIN
 
@@ -35,7 +36,7 @@ typedef enum {
 } bluetooth_status_t;
 
 bluetooth_status_t bt_get_status();
-int bt_init_connection(DeviceConfig *config);
+int bt_init_connection(DeviceConfig *config, millis_t * connected_at);
 int bt_disconnect(DeviceConfig *config);
 int bt_check_connection_status(DeviceConfig *config);
 

--- a/include/devices/cellular.h
+++ b/include/devices/cellular.h
@@ -127,7 +127,7 @@ telemetry_status_t cellular_get_connection_status();
 enum cellular_net_status cellmodem_get_status(void);
 int32_t cellular_active_time();
 int cellular_disconnect(DeviceConfig *config);
-int cellular_init_connection(DeviceConfig *config);
+int cellular_init_connection(DeviceConfig *config, millis_t * connected_at);
 int cellular_check_connection_status(DeviceConfig *config);
 const char* readsCell(struct serial_buffer *sb, size_t timeout);
 void putsCell(struct serial_buffer *sb, const char *data);

--- a/include/devices/gps_device.h
+++ b/include/devices/gps_device.h
@@ -37,6 +37,7 @@ typedef enum {
 
 gps_status_t GPS_device_init(uint8_t targetSampleRate, struct Serial *serial);
 gps_msg_result_t GPS_device_get_update(GpsSample *gpsSample, struct Serial *serial);
+void GPS_set_UTC_time(millis_t time);
 CPP_GUARD_END
 
 #endif /* GPS_DEVICE_H_ */

--- a/include/devices/null_device.h
+++ b/include/devices/null_device.h
@@ -25,10 +25,11 @@
 #include "cpp_guard.h"
 #include "stddef.h"
 #include "devices_common.h"
+#include "dateTime.h"
 
 CPP_GUARD_BEGIN
 
-int null_device_init_connection(DeviceConfig *config);
+int null_device_init_connection(DeviceConfig *config, millis_t * connected_at);
 int null_device_check_connection_status(DeviceConfig *config);
 
 CPP_GUARD_END

--- a/include/jsmn/jsmn.h
+++ b/include/jsmn/jsmn.h
@@ -145,6 +145,10 @@ bool jsmn_exists_set_val_bool(const jsmntok_t* root, const char* field,
 
 bool jsmn_exists_set_val_uint32(const jsmntok_t* root, const char* field,
                              uint32_t* val);
+
+bool jsmn_exists_set_val_uint64(const jsmntok_t* root, const char* field,
+                             uint64_t* val);
+
 /**
  * Searches for a node based on the specified field name, and if found, set the pointed-to uchar value. Also passes it through a filter function if provided.
  * @param root the node to start searching from.

--- a/include/logger/connectivityTask.h
+++ b/include/logger/connectivityTask.h
@@ -29,7 +29,7 @@
 #include "sampleRecord.h"
 #include "serial.h"
 #include "task.h"
-
+#include "dateTime.h"
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -39,7 +39,7 @@ typedef struct _ConnParams {
         bool always_streaming;
         char * connectionName;
         int (*disconnect)(DeviceConfig *config);
-        int (*init_connection)(DeviceConfig *config);
+        int (*init_connection)(DeviceConfig *config, millis_t * connected_at);
         int (*check_connection_status)(DeviceConfig *config);
         serial_id_t serial;
         size_t periodicMeta;

--- a/src/devices/bluetooth.c
+++ b/src/devices/bluetooth.c
@@ -217,7 +217,7 @@ int bt_disconnect(DeviceConfig *config)
         return 0; /* NOOP */
 }
 
-int bt_init_connection(DeviceConfig *config)
+int bt_init_connection(DeviceConfig *config,  millis_t * connected_at)
 {
         BluetoothConfig *btConfig =
                 &(getWorkingLoggerConfig()->ConnectivityConfigs.bluetoothConfig);

--- a/src/devices/cellular.c
+++ b/src/devices/cellular.c
@@ -337,7 +337,8 @@ static void print_registration_failure()
 }
 
 static bool auth_telem_stream(struct serial_buffer *sb,
-                              const TelemetryConfig *tc)
+                              const TelemetryConfig *tc,
+                              millis_t * connected_at)
 {
         serial_buffer_reset(sb);
 
@@ -381,6 +382,7 @@ static bool auth_telem_stream(struct serial_buffer *sb,
                         /* Could be success or failure.  Handle both */
                         const char *status = status_val->data;
                         if (0 == strcmp(status, "ok")) {
+                                jsmn_exists_set_val_uint64(toks, "utc", (uint64_t *)connected_at);
                                 pr_info("[cell] Server authenticated\r\n");
                                 return true;
                         }
@@ -404,7 +406,7 @@ static bool auth_telem_stream(struct serial_buffer *sb,
         return false;
 }
 
-int cellular_init_connection(DeviceConfig *config)
+int cellular_init_connection(DeviceConfig *config, millis_t * connected_at)
 {
 	telemetry_info.active_since = 0;
 
@@ -465,7 +467,7 @@ int cellular_init_connection(DeviceConfig *config)
         }
 
         /* Auth against RCL */
-        if (!auth_telem_stream(sb, telemetryConfig)){
+        if (!auth_telem_stream(sb, telemetryConfig, connected_at)){
                 telemetry_info.status = TELEMETRY_STATUS_REJECTED_DEVICE_ID;
                 return DEVICE_INIT_FAIL;
         }

--- a/src/devices/cellular.c
+++ b/src/devices/cellular.c
@@ -45,7 +45,7 @@
 #define PROBE_READ_TIMEOUT_MS	500
 /* Good balance between SIM900 and Ublox sara module */
 #define RESET_MODEM_DELAY_MS	1100
-#define TELEM_AUTH_JSMN_TOKENS	5
+#define TELEM_AUTH_JSMN_TOKENS	8
 #define TELEM_AUTH_RX_TRIES	3
 #define TELEM_AUTH_RX_WAIT_MS	5000
 
@@ -360,7 +360,7 @@ static bool auth_telem_stream(struct serial_buffer *sb,
 
         /* Parse the incoming JSON */
         jsmn_parser parser;
-        jsmntok_t toks[TELEM_AUTH_JSMN_TOKENS];
+        jsmntok_t toks[TELEM_AUTH_JSMN_TOKENS] = {};
 
         for (size_t tries = TELEM_AUTH_RX_TRIES; tries; --tries) {
                 if (!serial_buffer_rx(sb, TELEM_AUTH_RX_WAIT_MS))

--- a/src/devices/cellular.c
+++ b/src/devices/cellular.c
@@ -45,7 +45,7 @@
 #define PROBE_READ_TIMEOUT_MS	500
 /* Good balance between SIM900 and Ublox sara module */
 #define RESET_MODEM_DELAY_MS	1100
-#define TELEM_AUTH_JSMN_TOKENS	8
+#define TELEM_AUTH_JSMN_TOKENS	5
 #define TELEM_AUTH_RX_TRIES	3
 #define TELEM_AUTH_RX_WAIT_MS	5000
 

--- a/src/devices/gps_skytraq_s1216_sup500f8.c
+++ b/src/devices/gps_skytraq_s1216_sup500f8.c
@@ -790,3 +790,8 @@ gps_msg_result_t GPS_device_get_update(GpsSample *gpsSample, struct Serial *seri
 
     return GPS_MSG_SUCCESS;
 }
+
+void GPS_set_UTC_time(millis_t time)
+{
+        /* Do nothing, this driver always sets UTC time on it's own */
+}

--- a/src/devices/null_device.c
+++ b/src/devices/null_device.c
@@ -22,7 +22,7 @@
 
 #include "null_device.h"
 
-int null_device_init_connection(DeviceConfig *config)
+int null_device_init_connection(DeviceConfig *config, millis_t * connected_at)
 {
     return DEVICE_INIT_SUCCESS;
 }

--- a/src/jsmn/jsmn.c
+++ b/src/jsmn/jsmn.c
@@ -403,6 +403,18 @@ bool jsmn_exists_set_val_uint32(const jsmntok_t* root, const char* field,
     return true;
 }
 
+bool jsmn_exists_set_val_uint64(const jsmntok_t* root, const char* field,
+                             uint64_t* val)
+{
+    const jsmntok_t *node = jsmn_find_get_node_value_prim(root, field);
+
+    if (!node)
+        return false;
+
+    *val = strtoull(node->data, NULL, 10);
+    return true;
+}
+
 bool jsmn_exists_set_val_int(const jsmntok_t* root, const char* field,
                              void* val)
 {

--- a/src/logger/connectivityTask.c
+++ b/src/logger/connectivityTask.c
@@ -298,14 +298,17 @@ void connectivityTask(void *params)
     bool logging_enabled = false;
 
     while (1) {
+        millis_t connected_at = 0;
         bool should_stream = logging_enabled ||
                              logger_config->ConnectivityConfigs.telemetryConfig.backgroundStreaming ||
                              connParams->always_streaming;
 
-        while (should_stream && connParams->init_connection(&deviceConfig) != DEVICE_INIT_SUCCESS) {
+        while (should_stream && connParams->init_connection(&deviceConfig, &connected_at) != DEVICE_INIT_SUCCESS) {
             pr_info("conn: not connected. retrying\r\n");
             vTaskDelay(INIT_DELAY);
         }
+
+        pr_info_int_msg("Connected at ", connected_at);
 
         serial_flush(serial);
         rxCount = 0;

--- a/src/logger/connectivityTask.c
+++ b/src/logger/connectivityTask.c
@@ -43,6 +43,7 @@
 #include "task.h"
 #include "taskUtil.h"
 #include "usart.h"
+#include "gps_device.h"
 
 
 #if (CONNECTIVITY_CHANNELS == 1)
@@ -307,8 +308,8 @@ void connectivityTask(void *params)
             pr_info("conn: not connected. retrying\r\n");
             vTaskDelay(INIT_DELAY);
         }
-
-        pr_info_int_msg("Connected at ", connected_at);
+        if (connected_at > 0)
+                GPS_set_UTC_time(connected_at);
 
         serial_flush(serial);
         rxCount = 0;

--- a/src/logger/sampleRecord.c
+++ b/src/logger/sampleRecord.c
@@ -89,7 +89,7 @@ bool get_sample_value_by_name(const struct sample *s, const char * name, double 
                             return false;
             }
     }
-    pr_debug_str_msg(LOG_PFX "Unknown channel name: ", name);
+    pr_trace_str_msg(LOG_PFX "Unknown channel name: ", name);
     return false;
 }
 

--- a/test/mock_gps_device.c
+++ b/test/mock_gps_device.c
@@ -33,3 +33,8 @@ gps_msg_result_t GPS_device_get_update(GpsSample *gpsSample, struct Serial *seri
 {
     return GPS_MSG_SUCCESS;
 }
+
+void GPS_set_UTC_time(millis_t time)
+{
+        /* Do nothing, this driver always sets UTC time on it's own */
+}


### PR DESCRIPTION
Podium will supply current UTC, and we will set it to the GPS driver as needed.  Not all GPS drivers will honor the UTC - e.g. the skytraq module driver ignores it, but PodiumConnect's virtual GPS driver will accept and use it. 