### PR TITLE
handle cases when cellular module falls into a bad state. 

### DIFF
--- a/src/devices/sara_u280.c
+++ b/src/devices/sara_u280.c
@@ -45,7 +45,6 @@
 #define STOP_DM_RX_EVENTS	10
 #define STOP_DM_RX_TIMEOUT_MS	1000
 #define SARA_U280_SUBSCRIBER_NUMBER_RETRIES 3
-#define FAILED_READ_BACKOFF_MS 100
 
 static bool sara_u280_get_subscriber_number(struct serial_buffer *sb,
                                             struct cellular_info *ci)
@@ -56,8 +55,6 @@ static bool sara_u280_get_subscriber_number(struct serial_buffer *sb,
         bool status = false;
         for (size_t i = 0; i < SARA_U280_SUBSCRIBER_NUMBER_RETRIES && !status; ++i)
                 status = gsm_get_subscriber_number(sb, ci);
-                if (!status)
-                        delayMs(FAILED_READ_BACKOFF_MS);
 
         if (!status)
                 pr_warning("[cell] Phone number not available\r\n");

--- a/src/gsm/gsm.c
+++ b/src/gsm/gsm.c
@@ -79,24 +79,24 @@ bool gsm_get_subscriber_number(struct serial_buffer *sb,
 
         if (!status) {
                 pr_debug("[gsm] Failed to read phone number\r\n");
-                return false;
+                goto read_fail;
         }
 
         char *num_start = strstr(msgs[0], ",\"");
         if (!num_start)
-                goto parse_fail;
+                goto read_fail;
 
         num_start += 2;
         char *num_end = strstr(num_start, "\"");
         if (!num_end)
-                goto parse_fail;
+                goto read_fail;
 
         *num_end = '\0';
         strntcpy(ci->number, num_start, sizeof(ci->number));
         return true;
 
-parse_fail:
-        pr_warning("[gsm] Failed to parse phone number\r\n");
+read_fail:
+        strcpy(ci->number, "Not available");
         return false;
 }
 

--- a/src/gsm/gsm.c
+++ b/src/gsm/gsm.c
@@ -92,11 +92,11 @@ bool gsm_get_subscriber_number(struct serial_buffer *sb,
                 goto read_fail;
 
         *num_end = '\0';
-        strntcpy(ci->number, num_start, sizeof(ci->number));
+        strncpy(ci->number, num_start, sizeof(ci->number));
         return true;
 
 read_fail:
-        strcpy(ci->number, "Not available");
+        strncpy(ci->number, "Not available", sizeof(ci->number));
         return false;
 }
 


### PR DESCRIPTION
Resolves #973. 

It appears the SARA U2 can crash or fall into a bad state, where responses to messages show up as garbage characters, instead of OK or ERROR, or expected data. It's possible that the cell module is rebooting into a default baud rate.

Often this happens while we're waiting to get on the network, which can cause a long wait until the network registration times out. We should detect these bad responses and reset the module accordingly.

 This seems to happen especially after AT+CNUM fails / stops responding - so also made this more robust; also it seems that the phone number is not always available on the SIM card.  So, set the 'Not available' message if no number is available on the SIM. 