### PR TITLE
undo PR #960, resolves #979

### DIFF
--- a/include/util/byteswap.h
+++ b/include/util/byteswap.h
@@ -59,9 +59,9 @@ uint32_t swap_uint32( uint32_t val );
 uint64_t swap_uint64( uint64_t val );
 
 /*
- * decode a little endian encoded variable bit length stream
+ * Byte swap based on specified bit length
  */
-uint64_t decode_little_endian_bitmode(uint64_t val, size_t bit_length);
+uint64_t swap_uint_length(uint64_t val, size_t bit_length);
 CPP_GUARD_END
 
 #endif /* _BYTESWAP_H_ */

--- a/src/CAN/can_mapping.c
+++ b/src/CAN/can_mapping.c
@@ -91,10 +91,16 @@ bool canmapping_match_id(const CAN_msg *can_msg, const CANMapping *mapping)
         uint32_t can_id  = can_msg->addressValue;
         if (mapping->can_id == 0) return true;
 
+        /* apply mask to CAN ID, if specified (non zero) */
         if (mapping->can_mask)
                 can_id &= mapping->can_mask;
 
-        return can_id == mapping->can_id;
+        /* If no match, give up. */
+        if (can_id != mapping->can_id)
+                return false;
+
+        /* Match the sub ID index with the first data byte, if specified (>= 0) */
+        return (mapping->sub_id < 0 || mapping->sub_id == can_msg->data[0]);
 }
 
 bool canmapping_map_value(float *value, const CAN_msg *can_msg, const CANMapping *mapping)

--- a/src/CAN/can_mapping.c
+++ b/src/CAN/can_mapping.c
@@ -22,8 +22,6 @@
 #include "byteswap.h"
 #include "units_conversion.h"
 #include "panic.h"
-#include <stdlib.h>
-
 
 float canmapping_extract_value(uint64_t raw_data, const CANMapping *mapping)
 {
@@ -45,7 +43,7 @@ float canmapping_extract_value(uint64_t raw_data, const CANMapping *mapping)
 
         /* normalize endian */
         if (!mapping->big_endian) {
-                raw_value = decode_little_endian_bitmode(raw_value, length);
+                raw_value = swap_uint_length(raw_value, length);
         }
 
         /* convert type */
@@ -93,16 +91,10 @@ bool canmapping_match_id(const CAN_msg *can_msg, const CANMapping *mapping)
         uint32_t can_id  = can_msg->addressValue;
         if (mapping->can_id == 0) return true;
 
-        /* apply mask to CAN ID, if specified (non zero) */
         if (mapping->can_mask)
                 can_id &= mapping->can_mask;
 
-        /* If no match, give up. */
-        if (can_id != mapping->can_id)
-                return false;
-
-        /* Match the sub ID index with the first data byte, if specified (>= 0) */
-        return (mapping->sub_id < 0 || mapping->sub_id == can_msg->data[0]);
+        return can_id == mapping->can_id;
 }
 
 bool canmapping_map_value(float *value, const CAN_msg *can_msg, const CANMapping *mapping)

--- a/src/util/byteswap.c
+++ b/src/util/byteswap.c
@@ -59,36 +59,13 @@ uint64_t swap_uint64(uint64_t val)
              (val & 0x00FF000000000000UL) >> 40 | (val & 0xFF00000000000000UL) >> 56;
 }
 
-uint64_t decode_little_endian_bitmode(uint64_t val, size_t bit_length)
-/*
- * Convert a variable bit length little endian encoded stream, accounting for byte-level
- * endian granularity, also accounting for remaining bits
- *
- * example conversion:
- * incoming 12 bit stream:  LLLLLLLL HHHHxxxx
- * converts to: xxxxHHHH LLLLLLLL
- *
- * @param val incoming value
- * @param bit_length number of bits to swap
- * @return byte swapped value
- */
+uint64_t swap_uint_length(uint64_t val, size_t bit_length)
 {
-        if (bit_length <= 8) return val & ((1 << bit_length) - 1);
-        if (bit_length <= 16){
-                const size_t partial_bit_length = bit_length - 8;
-                const uint8_t partial_bit_mask = (1 << partial_bit_length) - 1;
-                return ((val & partial_bit_mask) << 8) + ((val >> partial_bit_length) & 0xFF);
-        }
-        if (bit_length <= 24) {
-                const size_t partial_bit_length = bit_length - 16;
-                const uint8_t partial_bit_mask = (1 << partial_bit_length) - 1;
-                return ((val & partial_bit_mask) << 16) + swap_uint16(val >> partial_bit_length);
-        }
-        if (bit_length <= 32) {
-                const size_t partial_bit_length = bit_length - 24;
-                const uint8_t partial_bit_mask = (1 << partial_bit_length) - 1;
-                return ((val & partial_bit_mask) << 24) + swap_uint24(val >> partial_bit_length);
-        }
-        panic(PANIC_CAUSE_UNREACHABLE);
-        return 0; /* to make compiler happy */
+    if (bit_length <= 8) return val;
+    if (bit_length <= 16) return swap_uint16(val);
+    if (bit_length <= 24) return swap_uint24(val);
+    if (bit_length <= 32) return swap_uint32(val);
+    if (bit_length <= 64) return swap_uint64(val);
+    panic(PANIC_CAUSE_UNREACHABLE);
+    return 0; /* to make compiler happy */
 }

--- a/test/can_obd2/can_mapping_test.cpp
+++ b/test/can_obd2/can_mapping_test.cpp
@@ -30,6 +30,7 @@
  * #define CAN_MAPPING_TEST_DEBUG
  */
 
+
 CPPUNIT_TEST_SUITE_REGISTRATION( CANMappingTest );
 
 
@@ -79,7 +80,7 @@ void CANMappingTest::extract_test_bit_mode(void)
 
         for (size_t bitpattern = 0; bitpattern <= 1; bitpattern++){
                 for (size_t endian = 0; endian <= 1; endian++){
-                        for (uint8_t length = 1; length <= 32; length++ ) {
+                        for (uint8_t length = 0; length <= 32; length++ ) {
 
                                 uint64_t test_value;
                                 if (!bitpattern) {
@@ -87,12 +88,26 @@ void CANMappingTest::extract_test_bit_mode(void)
                                         test_value = ((uint64_t)1 << length) - 1;
                                 }
                                 else {
-                                        /* test with bit pattern of 101010... */
-                                        test_value = 0x5555555555555555 & (((uint64_t)1 << length) - 1);
+                                        /* test with bit pattern ... */
+                                        test_value = 0xAA55AA55AA55AA55 & (((uint64_t)1 << length) - 1);
+                                }
+
+                                uint64_t encoded_value = test_value;
+                                if (endian == 0) {
+                                        /* perform byte oriented endian flip that accounts for variable bit length */
+                                        if (length > 8 && length <=16) {
+                                                encoded_value = ((encoded_value & 0xFF) << (length - 8)) + (encoded_value >> 8);
+                                        }
+                                        if (length > 16 && length <=24) {
+                                                encoded_value = (swap_uint16(encoded_value) << (length - 16)) + (encoded_value >> 16);
+                                        }
+                                        if (length > 24 && length <=32) {
+                                                encoded_value = (swap_uint24(encoded_value) << (length - 24)) + (encoded_value >> 24);
+                                        }
                                 }
 
                                 /* shift it all the way to the left */
-                                uint64_t shifted_test_value = test_value << (64-length);
+                                uint64_t shifted_test_value = encoded_value << (64-length);
 
                                 for (uint8_t offset = 0; offset < (CAN_MSG_SIZE * 8) - length + 1; offset++) {
                                         CAN_msg msg;
@@ -110,20 +125,16 @@ void CANMappingTest::extract_test_bit_mode(void)
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
                                         /* account for platform's endian-ness */
-                                        offset_test_value= swap_uint64(offset_test_value);
+                                        offset_test_value = swap_uint64(offset_test_value);
 #endif
                                         msg.data64 = offset_test_value;
 
                                         float value = canmapping_extract_value(msg.data64, &mapping);
 
                                         /* prepare the comparison value */
-                                        uint64_t compare_value = test_value;
-                                        if (!mapping.big_endian) {
-                                                compare_value = swap_uint_length(test_value, length);
-                                        }
 #ifdef CAN_MAPPING_TEST_DEBUG
                                         printf("bitmode test: endian=%u / test_value=%lu / offset=%d / length=%d / return = %f\r\n" ,
-                                               mapping.big_endian, compare_value, offset, length, value);
+                                               mapping.big_endian, test_value, offset, length, value);
                                         printf("CAN data: ");
                                         for (size_t di = 0; di < CAN_MSG_SIZE; di++){
                                                 uint8_t d = msg.data[di];
@@ -144,7 +155,7 @@ void CANMappingTest::extract_test_bit_mode(void)
                                         printf("\r\n");
 #endif
 
-                                        CPPUNIT_ASSERT_EQUAL((float)compare_value, value);
+                                        CPPUNIT_ASSERT_EQUAL((float)test_value, value);
                                 }
                         }
                 }
@@ -347,6 +358,7 @@ void CANMappingTest::id_match_test(void)
                 msg.addressValue = 0xFF;
                 mapping.can_id = 0xFF;
                 mapping.can_mask = 0;
+                mapping.sub_id = -1;
                 CPPUNIT_ASSERT_EQUAL(true, canmapping_match_id(&msg, &mapping));
                 mapping.can_mask = 0xFF;
                 CPPUNIT_ASSERT_EQUAL(true, canmapping_match_id(&msg, &mapping));
@@ -410,6 +422,7 @@ void CANMappingTest::mapping_test(void)
         mapping.adder = adder;
 
         mapping.can_id = 0x1122;
+        mapping.sub_id = -1;
         mapping.can_mask = 0;
 
         bool result;

--- a/test/can_obd2/can_mapping_test.cpp
+++ b/test/can_obd2/can_mapping_test.cpp
@@ -80,7 +80,7 @@ void CANMappingTest::extract_test_bit_mode(void)
 
         for (size_t bitpattern = 0; bitpattern <= 1; bitpattern++){
                 for (size_t endian = 0; endian <= 1; endian++){
-                        for (uint8_t length = 0; length <= 32; length++ ) {
+                        for (uint8_t length = 1; length <= 32; length++ ) {
 
                                 uint64_t test_value;
                                 if (!bitpattern) {
@@ -88,26 +88,12 @@ void CANMappingTest::extract_test_bit_mode(void)
                                         test_value = ((uint64_t)1 << length) - 1;
                                 }
                                 else {
-                                        /* test with bit pattern ... */
-                                        test_value = 0xAA55AA55AA55AA55 & (((uint64_t)1 << length) - 1);
-                                }
-
-                                uint64_t encoded_value = test_value;
-                                if (endian == 0) {
-                                        /* perform byte oriented endian flip that accounts for variable bit length */
-                                        if (length > 8 && length <=16) {
-                                                encoded_value = ((encoded_value & 0xFF) << (length - 8)) + (encoded_value >> 8);
-                                        }
-                                        if (length > 16 && length <=24) {
-                                                encoded_value = (swap_uint16(encoded_value) << (length - 16)) + (encoded_value >> 16);
-                                        }
-                                        if (length > 24 && length <=32) {
-                                                encoded_value = (swap_uint24(encoded_value) << (length - 24)) + (encoded_value >> 24);
-                                        }
+                                        /* test with bit pattern of 101010... */
+                                        test_value = 0x5555555555555555 & (((uint64_t)1 << length) - 1);
                                 }
 
                                 /* shift it all the way to the left */
-                                uint64_t shifted_test_value = encoded_value << (64-length);
+                                uint64_t shifted_test_value = test_value << (64-length);
 
                                 for (uint8_t offset = 0; offset < (CAN_MSG_SIZE * 8) - length + 1; offset++) {
                                         CAN_msg msg;
@@ -125,16 +111,20 @@ void CANMappingTest::extract_test_bit_mode(void)
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
                                         /* account for platform's endian-ness */
-                                        offset_test_value = swap_uint64(offset_test_value);
+                                        offset_test_value= swap_uint64(offset_test_value);
 #endif
                                         msg.data64 = offset_test_value;
 
                                         float value = canmapping_extract_value(msg.data64, &mapping);
 
                                         /* prepare the comparison value */
+                                        uint64_t compare_value = test_value;
+                                        if (!mapping.big_endian) {
+                                                compare_value = swap_uint_length(test_value, length);
+                                        }
 #ifdef CAN_MAPPING_TEST_DEBUG
                                         printf("bitmode test: endian=%u / test_value=%lu / offset=%d / length=%d / return = %f\r\n" ,
-                                               mapping.big_endian, test_value, offset, length, value);
+                                               mapping.big_endian, compare_value, offset, length, value);
                                         printf("CAN data: ");
                                         for (size_t di = 0; di < CAN_MSG_SIZE; di++){
                                                 uint8_t d = msg.data[di];
@@ -155,7 +145,7 @@ void CANMappingTest::extract_test_bit_mode(void)
                                         printf("\r\n");
 #endif
 
-                                        CPPUNIT_ASSERT_EQUAL((float)test_value, value);
+                                        CPPUNIT_ASSERT_EQUAL((float)compare_value, value);
                                 }
                         }
                 }


### PR DESCRIPTION
Undo changes to little endian bit mode mapping, b/c it regresses E46 CAN bus mapping. Obviously there's more work to do here, and existing E46 support is most important to support. 

