### PR TITLE
extend dynamic range of filter. set min alpha to .0001

### DIFF
--- a/include/filter/filter.h
+++ b/include/filter/filter.h
@@ -35,9 +35,9 @@ typedef struct _Filter {
         int32_t max_samples;
 } Filter;
 
-void init_filter(Filter *filter, float alpha);
+void init_filter(Filter *filter, const float alpha);
 
-int32_t update_filter(Filter *filter, int32_t value);
+int32_t update_filter(Filter *filter, const int32_t value);
 
 CPP_GUARD_END
 

--- a/include/filter/filter.h
+++ b/include/filter/filter.h
@@ -23,17 +23,21 @@
 #define _FILTER_H_
 
 #include "cpp_guard.h"
+#include <stdint.h>
 
 CPP_GUARD_BEGIN
 
 typedef struct _Filter {
-    float alpha;
-    int current_value;
+        float alpha;
+        int32_t total;
+        int32_t current_value;
+        int32_t count;
+        int32_t max_samples;
 } Filter;
 
 void init_filter(Filter *filter, float alpha);
 
-int update_filter(Filter *filter, int value);
+int32_t update_filter(Filter *filter, int32_t value);
 
 CPP_GUARD_END
 

--- a/include/filter/filter.h
+++ b/include/filter/filter.h
@@ -35,9 +35,9 @@ typedef struct _Filter {
         int32_t max_samples;
 } Filter;
 
-void init_filter(Filter *filter, const float alpha);
+void init_filter(Filter *filter, float alpha);
 
-int32_t update_filter(Filter *filter, const int32_t value);
+int32_t update_filter(Filter *filter, int32_t value);
 
 CPP_GUARD_END
 

--- a/src/filter/filter.c
+++ b/src/filter/filter.c
@@ -21,24 +21,24 @@
 
 
 #include "filter.h"
+#include "stdutil.h"
 
 //Implements a fast Exponential Moving Average filter
 #define MIN_ALPHA 0.0001
-void init_filter(Filter *filter, float alpha)
+void init_filter(Filter *filter, const float alpha)
 {
-        filter->max_samples = 1 / (alpha != 0 ? alpha : MIN_ALPHA);
+        filter->max_samples = (int32_t)(1 / MAX(alpha, MIN_ALPHA));
         filter->current_value = 0;
         filter->total = 0;
         filter->count = 0;
 }
 
-int32_t update_filter(Filter *filter, int32_t value)
+int32_t update_filter(Filter *filter, const int32_t value)
 {
         filter->total += value;
         if (filter->count >= filter->max_samples) {
                 filter->total -= filter->current_value;
-        }
-        else {
+        } else {
                 filter->count++;
         }
         filter->current_value = filter->total / filter->count;

--- a/src/filter/filter.c
+++ b/src/filter/filter.c
@@ -22,28 +22,25 @@
 
 #include "filter.h"
 
-//Implements a fast Exponential Moving Average IIR filter
-
-//This macros defines an alpha value between 0 and 1
-#define DSP_EMA_I32_ALPHA(x) ( (unsigned short)(x * 65535) )
-
-static int dsp_ema_i32(int in, int average, unsigned short alpha)
-{
-    long long tmp0; //calcs must be done in 64-bit math to avoid overflow
-    tmp0 = (long long)in * (alpha) + (long long)average * (65536 - alpha);
-    return (int)((tmp0 + 32768) / 65536); //scale back to 32-bit (with rounding)
-}
-
+//Implements a fast Exponential Moving Average filter
+#define MIN_ALPHA 0.0001
 void init_filter(Filter *filter, float alpha)
 {
-    filter->alpha = alpha;
-    filter->current_value = 0;
+        filter->max_samples = 1 / (alpha != 0 ? alpha : MIN_ALPHA);
+        filter->current_value = 0;
+        filter->total = 0;
+        filter->count = 0;
 }
 
-int update_filter(Filter *filter, int value)
+int32_t update_filter(Filter *filter, int32_t value)
 {
-    int current_value = filter->current_value;
-    current_value = dsp_ema_i32(value, current_value, DSP_EMA_I32_ALPHA(filter->alpha));
-    filter->current_value = current_value;
-    return current_value;
+        filter->total += value;
+        if (filter->count >= filter->max_samples) {
+                filter->total -= filter->current_value;
+        }
+        else {
+                filter->count++;
+        }
+        filter->current_value = filter->total / filter->count;
+        return filter->current_value;
 }

--- a/src/filter/filter.c
+++ b/src/filter/filter.c
@@ -21,13 +21,13 @@
 
 
 #include "filter.h"
-#include "stdutil.h"
+#include "math.h"
 
 //Implements a fast Exponential Moving Average filter
 #define MIN_ALPHA 0.0001
 void init_filter(Filter *filter, const float alpha)
 {
-        filter->max_samples = (int32_t)(1 / MAX(alpha, MIN_ALPHA));
+        filter->max_samples = (1 / fmaxf(alpha, MIN_ALPHA));
         filter->current_value = 0;
         filter->total = 0;
         filter->count = 0;


### PR DESCRIPTION
resolves #999. Improves dynamic range of filtering so we can account for scenarios like fuel tank slosh. 

When filtering is set to maximum (alpha = 0.001) time to sweep from min to max scale is about 200 seconds. 