### PR TITLE
P/brent/calc gear

### DIFF
--- a/src/lua/luaLoggerBinding.c
+++ b/src/lua/luaLoggerBinding.c
@@ -1130,6 +1130,7 @@ static int lua_sx_set_display(lua_State *L)
         if (lua_gettop(L) > 1 && lua_isnumber(L, 2)) {
                 lua_validate_arg_number(L, 2);
                 uint8_t value = lua_tointeger(L, 2);
+                /* digit index offset by ascii 0 (48) */
                 lua_pushinteger(L, shiftx_set_display(digit_index, 48 + value));
         }
         else {

--- a/src/lua/luaLoggerBinding.c
+++ b/src/lua/luaLoggerBinding.c
@@ -1048,8 +1048,8 @@ static int lua_calc_gear(lua_State *L)
         if (final_drive_ratio == 0)
                 return luaL_error(L, "Final Drive ratio must be > 0");
 
-        /* cant calculate gear if speed is 0 */
-        if (speed == 0)
+        /* cant calculate gear if speed below threshold */
+        if (speed < 10)
                 return 0;
 
         /* Calculate ratio based on cm per minute */

--- a/src/lua/luaLoggerBinding.c
+++ b/src/lua/luaLoggerBinding.c
@@ -991,7 +991,7 @@ static int lua_calc_gear(lua_State *L)
          *
          * calcGear(speedChannelName, rpmChannelName, tireDiamCm, finalGearRatio, gear1Ratio, gear2Ratio, gear3Ratio, gear4Ratio, gear5Ratio, gear6Ratio)
          *
-         * Use specified Speed and RPM channel name. Speed channel must be in kph.
+         * Use specified Speed and RPM channel name.
          *
          */
         lua_validate_args_count(L, 3, 10);
@@ -1004,7 +1004,7 @@ static int lua_calc_gear(lua_State *L)
         char * units;
         size_t params_start = 1;
 
-        /* check if first 2 parameters are strings; if so, assume those are "Speed" and "RPM" channels */
+        /* check if first 2 parameters are numbers; if so, use built in channels */
         if (lua_isnumber(L, 1) && lua_isnumber(L, 2)) {
                 lua_validate_args_count(L, 3, 8);
 

--- a/src/lua/luaLoggerBinding.c
+++ b/src/lua/luaLoggerBinding.c
@@ -1012,21 +1012,24 @@ static int lua_calc_gear(lua_State *L)
                 speed = getGPSSpeed();
 
                 /* Ensure RPM is available in the current sample. If not, bail out*/
-                if (!(s && get_sample_value_by_name(s, "RPM", &value, &units))) return 0;
+                if (!(s && get_sample_value_by_name(s, "RPM", &value, &units)))
+                        return 0;
                 rpm = value;
         }
         else {
                 /* For Speed and RPM, check if sample is currently available and if
                  * channel exists in current sample. If not, bail out
                  */
-                if (!(s && get_sample_value_by_name(s, lua_tostring(L, 1), &value, &units))) return 0;
+                if (!(s && get_sample_value_by_name(s, lua_tostring(L, 1), &value, &units)))
+                        return 0;
                 speed = value;
                 if (strcasecmp("kph", units) != 0) {
                         /* if units are not kph, assume mph and convert */
                         speed *= 1.60934;
                 }
 
-                if (!(s && get_sample_value_by_name(s, lua_tostring(L, 2), &value, &units))) return 0;
+                if (!(s && get_sample_value_by_name(s, lua_tostring(L, 2), &value, &units)))
+                        return 0;
                 rpm = value;
                 params_start += 2;
         }
@@ -1035,9 +1038,19 @@ static int lua_calc_gear(lua_State *L)
         float tire_diameter_cm = (float)lua_tonumber(L, params_start);
         params_start++;
 
+        if (tire_diameter_cm == 0)
+                return luaL_error(L, "Tire Diameter must be > 0");
+
         lua_validate_arg_number(L, params_start);
         float final_drive_ratio = (float)lua_tonumber(L, params_start);
         params_start++;
+
+        if (final_drive_ratio == 0)
+                return luaL_error(L, "Final Drive ratio must be > 0");
+
+        /* cant calculate gear if speed is 0 */
+        if (speed == 0)
+                return 0;
 
         /* Calculate ratio based on cm per minute */
         float rpm_speed_ratio = (rpm / speed)/(final_drive_ratio * 1666.67 / (tire_diameter_cm * 3.14159));


### PR DESCRIPTION
Add Lua helper function to make gear calculation easier to use and save Lua memory. resolves #1008 

Supports two different ways to call calcGear:

calcGear(tireDiamCm, finalGearRatio, gear1Ratio, gear2Ratio, gear3Ratio, gear4Ratio, gear5Ratio, gear6Ratio)
Default using the built-in GPS speed channel and "RPM" channel.

calcGear(speedChannelName, rpmChannelName, tireDiamCm, finalGearRatio, gear1Ratio, gear2Ratio, gear3Ratio, gear4Ratio, gear5Ratio, gear6Ratio)
Use specified Speed and RPM channel name.

Usage looks like this:

<pre>
setTickRate(50)

gearId = addChannel("Gear", 10, 0, 0, 6)

function onTick_discrete_channels()
  speed = getChannel("SpeedX")
  rpm = getChannel("RPM")
  local gear = calcGear("SpeedX", "RPM", 62.7, 3.45, 4.23, 2.52, 1.66, 1.22, 1.0, 0.8)
  setChannel(gearId, gear)
  sxSetDisplay(0, gear)
end

function onTick_default_channels()
  local gear = calcGear(62.7, 3.45, 4.23, 2.52, 1.66, 1.22, 1.0, 0.8)
  setChannel(gearId, gear)
  sxSetDisplay(0, gear)
end

function onTick()
--  onTick_default_channels()
  onTick_discrete_channels()

end
</pre>

