### PR TITLE
Improve stability for Lua script out of memory situation

### DIFF
--- a/include/lua/luaTask.h
+++ b/include/lua/luaTask.h
@@ -50,6 +50,8 @@ bool lua_task_start();
 
 bool lua_task_init(const int priority);
 
+void lua_task_set_max_mem(size_t max_mem);
+
 CPP_GUARD_END
 
 #endif /*LUATASK_H_*/

--- a/platform/mk2/capabilities.h
+++ b/platform/mk2/capabilities.h
@@ -50,7 +50,7 @@
  * LUA allocate before we say no.  This keeps LUA from crashing the system
  * when a memory hog LUA script is running.  Set to 0 for no limit.
  */
-#define LUA_MEM_MAX (1024 * 60)
+#define LUA_MEM_MAX (1024 * 50)
 
 /*
  * These values dictate how the LUA garbage collector will behave.

--- a/platform/mk3/capabilities.h
+++ b/platform/mk3/capabilities.h
@@ -50,7 +50,7 @@
  * LUA allocate before we say no.  This keeps LUA from crashing the system
  * when a memory hog LUA script is running.  Set to 0 for no limit.
  */
-#define LUA_MEM_MAX (1024 * 60)
+#define LUA_MEM_MAX (1024 * 50)
 
 /*
  * These values dictate how the LUA garbage collector will behave.

--- a/platform/rct_mk2/capabilities.h
+++ b/platform/rct_mk2/capabilities.h
@@ -50,7 +50,7 @@
  * LUA allocate before we say no.  This keeps LUA from crashing the system
  * when a memory hog LUA script is running.  Set to 0 for no limit.
  */
-#define LUA_MEM_MAX (1024 * 60)
+#define LUA_MEM_MAX (1024 * 50)
 
 /*
  * These values dictate how the LUA garbage collector will behave.

--- a/src/lua/luaBaseBinding.c
+++ b/src/lua/luaBaseBinding.c
@@ -272,6 +272,14 @@ static int lua_log_get_level(lua_State *L)
         return 1;
 }
 
+static int lua_set_max_mem(lua_State *L)
+{
+        lua_validate_args_count(L, 1, 1);
+        lua_validate_arg_number(L, 1);
+        lua_task_set_max_mem(lua_tointeger(L, 1));
+        return 0;
+}
+
 void registerBaseLuaFunctions(lua_State *L)
 {
         lua_registerlight(L, "getStackSize", lua_get_stack_size);
@@ -282,4 +290,5 @@ void registerBaseLuaFunctions(lua_State *L)
         lua_registerlight(L, "setLogLevel", lua_log_set_level);
         lua_registerlight(L, "getLogLevel", lua_log_get_level);
         lua_registerlight(L, "sleep", lua_sleep);
+        lua_registerlight(L, "setMaxMem", lua_set_max_mem);
 }


### PR DESCRIPTION
reduce default Lua memory back to 50K for stability, and add lua function to set max memory. 

resolves #1011 

Test Script
<pre>
setMaxMem(53000)
setTickRate(30)
x = {}
count = 1
function onTick() 
 x[count] = 'the quick brown fox jumped over the lazy dog the quick brown fox jumped over the lazy dog the quick brown fox jumped over the lazy dog'
 count = count + 1
 println('count ' ..count ..' ' ..collectgarbage("count"))
end
</pre>