### PR TITLE
enable static OBDII PID delay to slow PID querying 

### DIFF
--- a/include/CAN/OBD2.h
+++ b/include/CAN/OBD2.h
@@ -84,6 +84,13 @@ void update_obd2_channels(CAN_msg *msg, OBD2Config *cfg);
  */
 bool OBD2_get_value_for_pid(uint16_t pid, float *value);
 
+/**
+ * Set a statis OBDII delay between queries, in ms.
+ * Used to throttle OBDII PID requests.
+ * @param the delay to set, in ms
+ */
+void OBD2_set_pid_delay(uint32_t delay);
+
 CPP_GUARD_END
 
 #endif /* OBD2_H_ */

--- a/src/CAN/CAN_task.c
+++ b/src/CAN/CAN_task.c
@@ -42,7 +42,7 @@
 
 #define CAN_TASK_STACK                  128
 #define CAN_TASK_FEATURED_DISABLED_MS   2000
-#define CAN_RX_DELAY                    300
+#define CAN_RX_DELAY                    50
 
 static void CAN_task(void *parameters)
 {

--- a/src/lua/luaLoggerBinding.c
+++ b/src/lua/luaLoggerBinding.c
@@ -786,6 +786,14 @@ static int lua_obd2_read(lua_State *L)
                 return 0;
 }
 
+static int lua_obd2_set_delay(lua_State *L)
+{
+        lua_validate_args_count(L, 1, 1);
+        lua_validate_arg_number(L, 1);
+        OBD2_set_pid_delay(lua_tonumber(L, 1));
+        return 0;
+}
+
 static int lua_logging_start(lua_State *L)
 {
         startLogging();
@@ -1395,6 +1403,7 @@ void registerLuaLoggerBindings(lua_State *L)
         lua_registerlight(L, "rxCAN", lua_rx_can_msg);
         lua_registerlight(L, "setCANfilter", lua_set_can_filter);
         lua_registerlight(L, "readOBD2", lua_obd2_read);
+        lua_registerlight(L, "setOBD2Delay", lua_obd2_set_delay);
 
         lua_registerlight(L, "startLogging", lua_logging_start);
         lua_registerlight(L, "stopLogging", lua_logging_stop);


### PR DESCRIPTION
...for troubleshooting / diagnostic purposes when dealing with ECUs that cannot handle RaceCapture's OBDII query rate. 

 Resolves #1013