### PR TITLE
Update metadata while telemetry buffering

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+= 2.17.4=
+* Telemetry: Fix issue with telemetry failing if buffering is enabled + virtual channels present
+
 = 2.17.2=
 * Telemetry: Ensure telemetry stream starts correctly if no SD card is installed
 

--- a/include/logger/connectivityTask.h
+++ b/include/logger/connectivityTask.h
@@ -93,6 +93,7 @@ typedef struct _BufferingTaskParams {
 typedef struct _BufferedLoggerMessage {
         size_t ticks;
         struct sample *sample;
+        bool needs_meta;
 } BufferedLoggerMessage;
 
 typedef struct _CellularState {

--- a/include/logger/sampleRecord.h
+++ b/include/logger/sampleRecord.h
@@ -88,9 +88,10 @@ struct sample {
 };
 
 typedef struct _LoggerMessage {
-        enum LoggerMessageType type;
         size_t ticks;
         struct sample *sample;
+        enum LoggerMessageType type;
+        bool needs_meta;
 } LoggerMessage;
 
 /**
@@ -126,9 +127,11 @@ bool get_sample_value_by_name(const struct sample *s, const char * name, double 
  * @param t The messaget type.
  * @param ticks The logger tick value.
  * @param s The associated sample object (if any).
+ * @param needs_meta true if metadata changed
  */
 LoggerMessage create_logger_message(const enum LoggerMessageType t,
-                                    const size_t ticks, struct sample *s);
+                                    const size_t ticks, struct sample *s,
+                                    const bool needs_meta);
 
 /**
  * Receives and validates a LoggerMessage from the provided queue.  If the

--- a/src/logger/loggerTaskEx.c
+++ b/src/logger/loggerTaskEx.c
@@ -51,7 +51,7 @@
 #define BACKGROUND_SAMPLE_RATE	SAMPLE_50Hz
 
 int g_loggingShouldRun;
-int g_config_changed;
+bool g_config_changed;
 int g_telemetryBackgroundStreaming;
 struct sample * current_sample = NULL;
 

--- a/src/logger/loggerTaskEx.c
+++ b/src/logger/loggerTaskEx.c
@@ -51,7 +51,7 @@
 #define BACKGROUND_SAMPLE_RATE	SAMPLE_50Hz
 
 int g_loggingShouldRun;
-int g_configChanged;
+int g_config_changed;
 int g_telemetryBackgroundStreaming;
 struct sample * current_sample = NULL;
 
@@ -67,12 +67,12 @@ struct sample * get_current_sample(void)
 
 static LoggerMessage getLogStartMessage()
 {
-        return create_logger_message(LoggerMessageType_Start, 0, NULL);
+        return create_logger_message(LoggerMessageType_Start, 0, NULL, false);
 }
 
 static LoggerMessage getLogStopMessage()
 {
-        return create_logger_message(LoggerMessageType_Stop, 0, NULL);
+        return create_logger_message(LoggerMessageType_Stop, 0, NULL, false);
 }
 
 /**
@@ -86,7 +86,7 @@ void vApplicationTickHook(void)
 
 void configChanged()
 {
-        g_configChanged = 1;
+        g_config_changed = true;
 }
 
 void startLogging()
@@ -181,7 +181,7 @@ void loggerTaskEx(void *params)
         vSemaphoreCreateBinary(onTick);
         logging_set_status(LOGGING_STATUS_IDLE);
         logging_set_logging_start(0);
-        g_configChanged = 1;
+        g_config_changed = true;
 
 #if CAMERA_CONTROL
         camera_control_init(&loggerConfig->camera_control_cfg);
@@ -195,7 +195,7 @@ void loggerTaskEx(void *params)
                 xSemaphoreTake(onTick, portMAX_DELAY);
                 ++currentTicks;
 
-                if (g_configChanged) {
+                if (g_config_changed) {
                         buffer_size = init_sample_ring_buffer(loggerConfig);
                         if (!buffer_size) {
                                 pr_error("Failed to allocate any buffers!\r\n");
@@ -217,7 +217,6 @@ void loggerTaskEx(void *params)
                         resetLapCount();
                         lapstats_reset_distance();
                         currentTicks = 0;
-                        g_configChanged = 0;
                 }
 
                 /* Only reset the watchdog when we are configured and ready to rock */
@@ -263,7 +262,7 @@ void loggerTaskEx(void *params)
 
                 /* If here, create the LoggerMessage to send with the sample */
                 const LoggerMessage msg = create_logger_message(
-                                                  LoggerMessageType_Sample, currentTicks, sample);
+                                                  LoggerMessageType_Sample, currentTicks, sample, g_config_changed);
 
                 /*
                  * We only log to file if the user has manually pushed the
@@ -293,6 +292,7 @@ void loggerTaskEx(void *params)
                 bufferIndex %= buffer_size;
 
                 current_sample = sample;
+                g_config_changed = false;
         }
 
         panic(PANIC_CAUSE_UNREACHABLE);

--- a/src/logger/sampleRecord.c
+++ b/src/logger/sampleRecord.c
@@ -135,13 +135,15 @@ xQueueHandle create_logger_message_queue()
 }
 
 LoggerMessage create_logger_message(const enum LoggerMessageType t,
-                                    const size_t ticks, struct sample *s)
+                                    const size_t ticks, struct sample *s,
+                                    bool needs_meta)
 {
         LoggerMessage msg;
 
         msg.type = t;
         msg.ticks = ticks;
         msg.sample = s;
+        msg.needs_meta = needs_meta;
 
         return msg;
 }

--- a/test/sampleRecord_test.cpp
+++ b/test/sampleRecord_test.cpp
@@ -437,7 +437,7 @@ void SampleRecordTest::testIsValidLoggerMessage()
         struct sample s;
 
         /* Test the non sample case.  This always passes */
-        lm = create_logger_message(LoggerMessageType_Start, 0, NULL);
+        lm = create_logger_message(LoggerMessageType_Start, 0, NULL, false);
         lm.ticks = 42;
         s.ticks = 42;
         CPPUNIT_ASSERT_EQUAL(true, is_sample_data_valid(&lm));
@@ -445,7 +445,7 @@ void SampleRecordTest::testIsValidLoggerMessage()
         CPPUNIT_ASSERT_EQUAL(true,  is_sample_data_valid(&lm));
 
         /* Test the sample case. */
-        lm = create_logger_message(LoggerMessageType_Sample, 0,&s);
+        lm = create_logger_message(LoggerMessageType_Sample, 0, &s, false);
         lm.ticks = 42;
         s.ticks = 42;
         CPPUNIT_ASSERT_EQUAL(true, is_sample_data_valid(&lm));


### PR DESCRIPTION
Trigger an update to metadata during buffering if virtual channels are added; address race condition only present with the new telemetry buffering. 

Resolves #1050