### PR TITLE
Bug Fix: getAnalog with a linear mapped value doesn't apply linearOffset

### DIFF
--- a/src/lua/luaLoggerBinding.c
+++ b/src/lua/luaLoggerBinding.c
@@ -228,7 +228,7 @@ static int lua_get_analog(lua_State *L)
                         analogValue = adcRaw;
                         break;
                 case SCALING_MODE_LINEAR:
-                        analogValue = (ac->linearScaling * (float) adcRaw);
+                        analogValue = (ac->linearScaling * (float) adcRaw) + ac->linearOffset;
                         break;
                 case SCALING_MODE_MAP:
                         analogValue = get_mapped_value((float) adcRaw,


### PR DESCRIPTION
Tested on a RCP Mk2.  Didn't see any unit tests for testing Lua functions.