### PR TITLE
implement reverse telemetry / set virtual channel resolves #1077

### DIFF
--- a/include/logger/loggerApi.h
+++ b/include/logger/loggerApi.h
@@ -68,6 +68,14 @@ CPP_GUARD_BEGIN
 	API_METHOD("setWifiCfg", api_set_wifi_cfg)			\
 	API_METHOD("sysReset", api_systemReset)				\
 
+
+#if VIRTUAL_CHANNEL_SUPPORT == 1
+#define VIRTUAL_CHANNEL_METHODS                 \
+    API_METHOD("setVChan", api_set_virtual_channel_value)
+#else
+#define VIRTUAL_CHANNEL_METHODS
+#endif
+
 #if GPS_HARDWARE_SUPPORT
 #define GPS_API_METHODS                         \
     API_METHOD("getGpsCfg", api_getGpsConfig)   \
@@ -246,6 +254,10 @@ int api_set_auto_logger_cfg(struct Serial *serial, const jsmntok_t *json);
 #if CAMERA_CONTROL
 int api_get_camera_control_cfg(struct Serial *serial, const jsmntok_t *json);
 int api_set_camera_control_cfg(struct Serial *serial, const jsmntok_t *json);
+#endif
+
+#if VIRTUAL_CHANNEL_SUPPORT
+int api_set_virtual_channel_value(struct Serial *serial, const jsmntok_t *json);
 #endif
 
 CPP_GUARD_END

--- a/include/logger/loggerApi.h
+++ b/include/logger/loggerApi.h
@@ -257,7 +257,7 @@ int api_get_camera_control_cfg(struct Serial *serial, const jsmntok_t *json);
 int api_set_camera_control_cfg(struct Serial *serial, const jsmntok_t *json);
 #endif
 
-#if VIRTUAL_CHANNEL_SUPPORT
+#if VIRTUAL_CHANNEL_SUPPORT == 1
 int api_set_virtual_channel_value(struct Serial *serial, const jsmntok_t *json);
 #endif
 

--- a/include/logger/loggerApi.h
+++ b/include/logger/loggerApi.h
@@ -159,6 +159,7 @@ CPP_GUARD_BEGIN
 #endif
 
 #define API_METHODS                             \
+        VIRTUAL_CHANNEL_METHODS                 \
         AUTOLOGGING_METHODS                     \
         CAMERA_CONTROL_METHODS                  \
         BASE_API_METHODS                        \

--- a/include/virtual_channel/virtual_channel.h
+++ b/include/virtual_channel/virtual_channel.h
@@ -37,7 +37,11 @@ typedef struct _VirtualChannel {
 } VirtualChannel;
 
 #define INVALID_VIRTUAL_CHANNEL -1
+#define DEFAULT_VIRTUAL_CHANNEL_MINVAL 0
+#define DEFAULT_VIRTUAL_CHANNEL_MAXVAL 0
+#define DEFAULT_VIRTUAL_CHANNEL_PRECISION 2
 
+void init_virtual_channels(void);
 int find_virtual_channel(const char * channel_name);
 int create_virtual_channel(const ChannelConfig chCfg);
 VirtualChannel * get_virtual_channel(size_t id);

--- a/main.c
+++ b/main.c
@@ -50,6 +50,7 @@
 #include "wifi.h"
 #include "watchdog.h"
 #include "versionInfo.h"
+#include "virtual_channel.h"
 #include <app_info.h>
 #include <stdbool.h>
 
@@ -73,6 +74,9 @@ static const struct app_info_block info_block = {
 
 void setupTask(void *param)
 {
+#if VIRTUAL_CHANNEL_SUPPORT == 1
+        init_virtual_channels();
+#endif
         initialize_tracks();
         initialize_logger_config();
 

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -239,7 +239,6 @@ static int execute_api(struct Serial * serial, const jsmntok_t *json)
 
 int process_api(struct Serial *serial, char *buffer, size_t bufferSize)
 {
-        pr_info_str_msg("process api ", buffer);
         jsmn_init(&g_jsonParser);
         memset(g_json_tok, 0, sizeof(jsmntok_t) * JSON_TOKENS);
 

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -239,6 +239,7 @@ static int execute_api(struct Serial * serial, const jsmntok_t *json)
 
 int process_api(struct Serial *serial, char *buffer, size_t bufferSize)
 {
+        pr_info_str_msg("process api ", buffer);
         jsmn_init(&g_jsonParser);
         memset(g_json_tok, 0, sizeof(jsmntok_t) * JSON_TOKENS);
 

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -2218,7 +2218,7 @@ int api_set_camera_control_cfg(struct Serial *serial, const jsmntok_t *json)
 }
 #endif
 
-#if VIRTUAL_CHANNEL_SUPPORT
+#if VIRTUAL_CHANNEL_SUPPORT == 1
 
 int api_set_virtual_channel_value(struct Serial *serial, const jsmntok_t *json)
 {
@@ -2260,10 +2260,11 @@ int api_set_virtual_channel_value(struct Serial *serial, const jsmntok_t *json)
                 channel_id = create_virtual_channel(cc);
         }
 
-        if (channel_id == INVALID_VIRTUAL_CHANNEL)
+        if (channel_id == INVALID_VIRTUAL_CHANNEL) {
                 pr_error_str_msg("Could not make virtual channel ", channel_name);
                 //could not make a virutal channel
                 return API_ERROR_SEVERE;
+        }
 
         set_virtual_channel_value(channel_id, channel_value);
         return API_SUCCESS;

--- a/src/virtual_channel/virtual_channel.c
+++ b/src/virtual_channel/virtual_channel.c
@@ -27,9 +27,16 @@
 #include <string.h>
 #include "printk.h"
 #include "virtual_channel.h"
+#include "semphr.h"
 
 static size_t g_virtualChannelCount = 0;
 static VirtualChannel g_virtualChannels[MAX_VIRTUAL_CHANNELS];
+static xSemaphoreHandle vchan_mutex = NULL;
+
+void init_virtual_channels(void)
+{
+        vchan_mutex = xSemaphoreCreateMutex();
+}
 
 VirtualChannel* get_virtual_channel(size_t id)
 {
@@ -60,22 +67,26 @@ int create_virtual_channel(const ChannelConfig chCfg)
          * Here we actually try to create a new channel.  But only if we
          * have the room for it.
          */
-        if (g_virtualChannelCount >= MAX_VIRTUAL_CHANNELS) {
-                pr_error_int_msg("[vchan] Limit reached: ",
-                                 g_virtualChannelCount);
-                return INVALID_VIRTUAL_CHANNEL;
+        int new_channel_id = INVALID_VIRTUAL_CHANNEL;
+
+        xSemaphoreTake(vchan_mutex, portMAX_DELAY);
+        if (g_virtualChannelCount < MAX_VIRTUAL_CHANNELS) {
+                VirtualChannel * channel = g_virtualChannels + g_virtualChannelCount;
+                channel->config = chCfg;
+                channel->currentValue = 0;
+                configChanged();
+                new_channel_id = g_virtualChannelCount++;
         }
-
-        VirtualChannel * channel = g_virtualChannels + g_virtualChannelCount;
-        channel->config = chCfg;
-        channel->currentValue = 0;
-        configChanged();
-
-        return g_virtualChannelCount++;
+        else {
+                pr_error_int_msg("[vchan] Limit reached: ", g_virtualChannelCount);
+        }
+        xSemaphoreGive(vchan_mutex);
+        return new_channel_id;
 }
 
 void set_virtual_channel_value(size_t id, float value)
 {
+        pr_info_float_msg("Set virtual channel ", value);
         if (id < g_virtualChannelCount)
                 g_virtualChannels[id].currentValue = value;
 }
@@ -109,3 +120,4 @@ int get_virtual_channel_high_sample_rate(void)
 
         return sr;
 }
+

--- a/test/json_api_files/set_vchan.json
+++ b/test/json_api_files/set_vchan.json
@@ -1,0 +1,1 @@
+{"setVChan":{"nm":"Foobar", val:1234.5}}

--- a/test/json_api_files/set_vchan_meta.json
+++ b/test/json_api_files/set_vchan_meta.json
@@ -1,0 +1,1 @@
+{"setVChan":{"nm":"Foobar", val:1234.5, "ut":"units", "min":0.5, "max":10.5, "prec":3}}

--- a/test/loggerApi_test.cpp
+++ b/test/loggerApi_test.cpp
@@ -19,6 +19,13 @@
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <fstream>
+#include <stdio.h>
+#include <stdlib.h>
+#include <streambuf>
+#include <string.h>
+#include <string>
+#include <stdio.h>
 #include "FreeRTOS.h"
 #include "api.h"
 #include "auto_logger.h"
@@ -46,13 +53,7 @@
 #include "task_testing.h"
 #include "units.h"
 #include "versionInfo.h"
-#include <fstream>
-#include <stdio.h>
-#include <stdlib.h>
-#include <streambuf>
-#include <string.h>
-#include <string>
-#include <stdio.h>
+#include "virtual_channel.h"
 
 #define JSON_TOKENS 10000
 #define FILE_PREFIX string("json_api_files/")
@@ -1807,4 +1808,39 @@ void LoggerApiTest::testSetCameraControlCfg()
         CPPUNIT_ASSERT_EQUAL(false, cfg->stop.greater_than);
 
         assertGenericResponse(response, "setCamCtrlCfg", API_SUCCESS);
+}
+
+void LoggerApiTest::test_set_vchan(string filename)
+{
+        char *response = processApiGeneric("set_vchan.json");
+        int channel_id = find_virtual_channel("Foobar");
+        VirtualChannel *vc = get_virtual_channel(channel_id);
+        CPPUNIT_ASSERT_EQUAL(string("Foo"), (string)(String)vc->config.label);
+        CPPUNIT_ASSERT_EQUAL(string(""), (string)(String)vc->config.units);
+        CPPUNIT_ASSERT_EQUAL((float)DEFAULT_VIRTUAL_CHANNEL_MINVAL, (float)vc->config.min);
+        CPPUNIT_ASSERT_EQUAL((float)DEFAULT_VIRTUAL_CHANNEL_MAXVAL, (float)vc->config.max);
+        CPPUNIT_ASSERT_EQUAL((float)DEFAULT_VIRTUAL_CHANNEL_PRECISION, (float)vc->config.precision);
+
+        float val = get_virtual_channel_value(channel_id);
+        CPPUNIT_ASSERT_EQUAL((float)1234.5, val);
+
+        assertGenericResponse(response, "setVChan", API_SUCCESS);
+}
+
+void LoggerApiTest::test_set_vchan_meta(string filename)
+{
+        char *response = processApiGeneric("set_vchan_meta.json");
+
+        int channel_id = find_virtual_channel("Foobar");
+        VirtualChannel *vc = get_virtual_channel(channel_id);
+        CPPUNIT_ASSERT_EQUAL(string("Foo"), (string)(String)vc->config.label);
+        CPPUNIT_ASSERT_EQUAL(string(""), (string)(String)vc->config.units);
+        CPPUNIT_ASSERT_EQUAL((float)0.5, (float)vc->config.min);
+        CPPUNIT_ASSERT_EQUAL((float)10.5, (float)vc->config.max);
+        CPPUNIT_ASSERT_EQUAL((int)3, (int)vc->config.precision);
+
+        float val = get_virtual_channel_value(channel_id);
+        CPPUNIT_ASSERT_EQUAL((float)1234.5, val);
+
+        assertGenericResponse(response, "setVChan", API_SUCCESS);
 }

--- a/test/loggerApi_test.cpp
+++ b/test/loggerApi_test.cpp
@@ -180,6 +180,11 @@ void LoggerApiTest::setUp()
         lapstats_config_changed();
 }
 
+void LoggerApiTest::tearDown()
+{
+        reset_virtual_channels();
+}
+
 void LoggerApiTest::populateChannelConfig(ChannelConfig *cfg, const int i, const int splRt)
 {
         sprintf(cfg->label, "testName_%d", i);
@@ -1810,12 +1815,17 @@ void LoggerApiTest::testSetCameraControlCfg()
         assertGenericResponse(response, "setCamCtrlCfg", API_SUCCESS);
 }
 
-void LoggerApiTest::test_set_vchan(string filename)
+void LoggerApiTest::test_set_vchan()
 {
-        char *response = processApiGeneric("set_vchan.json");
+        test_set_vchan_file("set_vchan.json");
+}
+
+void LoggerApiTest::test_set_vchan_file(string filename)
+{
+        char *response = processApiGeneric(filename);
         int channel_id = find_virtual_channel("Foobar");
         VirtualChannel *vc = get_virtual_channel(channel_id);
-        CPPUNIT_ASSERT_EQUAL(string("Foo"), (string)(String)vc->config.label);
+        CPPUNIT_ASSERT_EQUAL(string("Foobar"), (string)(String)vc->config.label);
         CPPUNIT_ASSERT_EQUAL(string(""), (string)(String)vc->config.units);
         CPPUNIT_ASSERT_EQUAL((float)DEFAULT_VIRTUAL_CHANNEL_MINVAL, (float)vc->config.min);
         CPPUNIT_ASSERT_EQUAL((float)DEFAULT_VIRTUAL_CHANNEL_MAXVAL, (float)vc->config.max);
@@ -1827,14 +1837,19 @@ void LoggerApiTest::test_set_vchan(string filename)
         assertGenericResponse(response, "setVChan", API_SUCCESS);
 }
 
-void LoggerApiTest::test_set_vchan_meta(string filename)
+void LoggerApiTest::test_set_vchan_meta()
 {
-        char *response = processApiGeneric("set_vchan_meta.json");
+        test_set_vchan_meta_file("set_vchan_meta.json");
+}
+
+void LoggerApiTest::test_set_vchan_meta_file(string filename)
+{
+        char *response = processApiGeneric(filename);
 
         int channel_id = find_virtual_channel("Foobar");
         VirtualChannel *vc = get_virtual_channel(channel_id);
-        CPPUNIT_ASSERT_EQUAL(string("Foo"), (string)(String)vc->config.label);
-        CPPUNIT_ASSERT_EQUAL(string(""), (string)(String)vc->config.units);
+        CPPUNIT_ASSERT_EQUAL(string("Foobar"), (string)(String)vc->config.label);
+        CPPUNIT_ASSERT_EQUAL(string("units"), (string)(String)vc->config.units);
         CPPUNIT_ASSERT_EQUAL((float)0.5, (float)vc->config.min);
         CPPUNIT_ASSERT_EQUAL((float)10.5, (float)vc->config.max);
         CPPUNIT_ASSERT_EQUAL((int)3, (int)vc->config.precision);

--- a/test/loggerApi_test.h
+++ b/test/loggerApi_test.h
@@ -94,6 +94,8 @@ class LoggerApiTest : public CppUnit::TestFixture
         CPPUNIT_TEST( testSetAutoLoggerCfg );
         CPPUNIT_TEST( testGetCameraControlCfgDefault );
         CPPUNIT_TEST( testSetCameraControlCfg );
+        CPPUNIT_TEST( test_set_vchan );
+        CPPUNIT_TEST( test_set_vchan_meta );
 
         CPPUNIT_TEST_SUITE_END();
 
@@ -102,6 +104,7 @@ public:
         int findAndReplace(string & source, const string find, const string replace);
         string readFile(string filename);
         void setUp();
+        void tearDown();
 
         void setActiveTrack();
         void setActiveTrackSectors();
@@ -165,6 +168,9 @@ public:
         void testSetAutoLoggerCfg();
         void testGetCameraControlCfgDefault();
         void testSetCameraControlCfg();
+        void test_set_vchan();
+        void test_set_vchan_meta();
+
 
 private:
         void testSetScriptFile(string filename);
@@ -205,8 +211,8 @@ private:
         void check_can_mapping_config(Object &json, CANMapping *mapping);
         void check_channel_config(Object &json_cfg, ChannelConfig *cfg);
         void testChannelConfig(ChannelConfig *chCfg, string expNm, string expUt, unsigned short sr);
-        void test_set_vchan(string filename);
-        void test_set_vchan_meta(string filename);
+        void test_set_vchan_file(string filename);
+        void test_set_vchan_meta_file(string filename);
 };
 
 

--- a/test/loggerApi_test.h
+++ b/test/loggerApi_test.h
@@ -205,6 +205,8 @@ private:
         void check_can_mapping_config(Object &json, CANMapping *mapping);
         void check_channel_config(Object &json_cfg, ChannelConfig *cfg);
         void testChannelConfig(ChannelConfig *chCfg, string expNm, string expUt, unsigned short sr);
+        void test_set_vchan(string filename);
+        void test_set_vchan_meta(string filename);
 };
 
 


### PR DESCRIPTION
Implement feature to set / create a virtual channel via the API. This will facilitate allowing Podium to push "reverse telemetry' to RaceCapture, for purposes of providing real-time timing and scoring data, plus other information as needed. 