### PR TITLE
added special case to catch 10Hz pulse on 25Hz sampleRate: resolves Issue #1022

### DIFF
--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -844,7 +844,14 @@ LoggerConfig * getWorkingLoggerConfig()
 
 bool should_sample(const int sample_rate, const int max_rate)
 {
-        return sample_rate == 0 ? false : sample_rate % max_rate == 0;
+	if (sample_rate == 0 ) return false;
+
+        if (sample_rate % max_rate == 0 ) return true;
+
+	if (max_rate == SAMPLE_25HZ )
+		return sample_rate % SAMPLE_10Hz;
+
+	return false;
 }
 
 

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -849,7 +849,7 @@ bool should_sample(const int sample_rate, const int max_rate)
         if (sample_rate % max_rate == 0 ) return true;
 
 	if (max_rate == SAMPLE_25Hz )
-		return sample_rate % SAMPLE_10Hz;
+		return sample_rate % SAMPLE_10Hz == 0;
 
 	return false;
 }

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -848,7 +848,7 @@ bool should_sample(const int sample_rate, const int max_rate)
 
         if (sample_rate % max_rate == 0 ) return true;
 
-	if (max_rate == SAMPLE_25HZ )
+	if (max_rate == SAMPLE_25Hz )
 		return sample_rate % SAMPLE_10Hz;
 
 	return false;

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -844,10 +844,15 @@ LoggerConfig * getWorkingLoggerConfig()
 
 bool should_sample(const int sample_rate, const int max_rate)
 {
-	if (sample_rate == 0 ) return false;
+	if (sample_rate == SAMPLE_DISABLED) return false;
 
         if (sample_rate % max_rate == 0 ) return true;
 
+	/* this clause is to make 10Hz samples trigger when running at max_rate 
+	 * 25Hz.  Without this, 10Hz samples are only output at 5Hz, due to 25 not
+	 * being divisible by 10.  This is not an issue for any other combo of available 
+	 * sample rates.
+	 */
 	if (max_rate == SAMPLE_25Hz )
 		return sample_rate % SAMPLE_10Hz == 0;
 

--- a/src/logger/loggerTaskEx.c
+++ b/src/logger/loggerTaskEx.c
@@ -228,7 +228,7 @@ void loggerTaskEx(void *params)
                  * Ensure we refresh the internal sensors at either the
                  * logging rate or at least at background sample rate
                  */
-                if ((is_logging && currentTicks % loggingSampleRate == 0) ||
+                if ((is_logging && should_sample( currentTicks, loggingSampleRate ) ||
                     (currentTicks % BACKGROUND_SAMPLE_RATE == 0))
                         doBackgroundSampling();
 

--- a/src/logger/loggerTaskEx.c
+++ b/src/logger/loggerTaskEx.c
@@ -228,7 +228,7 @@ void loggerTaskEx(void *params)
                  * Ensure we refresh the internal sensors at either the
                  * logging rate or at least at background sample rate
                  */
-                if ((is_logging && should_sample( currentTicks, loggingSampleRate ) ||
+                if ((is_logging && should_sample(currentTicks, loggingSampleRate)) ||
                     (currentTicks % BACKGROUND_SAMPLE_RATE == 0))
                         doBackgroundSampling();
 


### PR DESCRIPTION
This catches the missing 10Hz samples.  The only downside is that it generates 10Hz output when running at 25Hz, even if there are no 10Hz sources.  However, since the GPS is usually 10Hz,  few will notice.