### PR TITLE
test: add test to validate distance calculation

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -134,6 +134,7 @@ build/rcp_base/%.o: ../%.c
 
 T_SRC = \
 $(GPS_DIR)/geoTriggerTest.cpp \
+$(GPS_DIR)/geo_point.cpp \
 $(GPS_DIR)/gps_test.cpp \
 $(LAP_STATS_DIR)/LapStatsTest.cpp \
 $(UTIL_DIR)/numtoa_test.cpp \

--- a/test/gps/geo_point.cpp
+++ b/test/gps/geo_point.cpp
@@ -1,0 +1,48 @@
+/**
+ * Race Capture Pro Firmware
+ *
+ * Copyright Autosport Labs Inc.
+ *
+ * This file is part of the Race Capture Pro fimrware suite
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should have received a copy of the GNU
+ * General Public License along with this code. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: stieg
+ */
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <geopoint.h>
+
+class GeoPointUnitTest : public CppUnit::TestFixture
+{
+        CPPUNIT_TEST_SUITE( GeoPointUnitTest );
+        CPPUNIT_TEST( testDistPythagDistance );
+        CPPUNIT_TEST_SUITE_END();
+
+public:
+        void setUp();
+        void tearDown();
+        void testDistPythagDistance();
+};
+
+void GeoPointUnitTest::setUp() {}
+void GeoPointUnitTest::tearDown() {}
+
+void GeoPointUnitTest::testDistPythagDistance()
+{
+        const GeoPoint gp1 = { 43.074859, -89.386336 }; // 100 State
+        const GeoPoint gp2 = { 43.075255, -89.385590 }; // ~75 Meters from 100 State
+        const float result = distPythag(&gp1, &gp2);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(75.0, result, 0.1);
+}
+
+// Registers the fixture into the 'registry'
+CPPUNIT_TEST_SUITE_REGISTRATION( GeoPointUnitTest );


### PR DESCRIPTION
When reviewing my code for a presentation I thought that I might have
a bug in my distance calculation and thus wanted to validate that it
was there and needed fixing or that it was not and learn where I was
wrong. Turns out there is no bug when compared to an extermal tool
using a the Haversine method to calculate the distance. The only
concerning bit is that our calculation is off by about 0.5 meters at
75 meters distance.