### PR TITLE
add API functions to tx/rx can from app. resolves #1103

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * CAN: Set factory default CAN baud rate to 500K for CAN1, and 1MB for remaning CAN bus networks. 
 * Lua: Add function to retrieve GPS X,Y,Z velocity to lua binding
 * Lua: Add hex formatting to string format function
+* API: Add txCan / rxCan for sending / receiving CAN messages directly from the RaceCapture app
 
 = 2.18.0=
 * IMU: Enable GSumPctMax and GSumMax channels to act as performance indicators within session

--- a/include/CAN/CAN_aux_filterqueue.h
+++ b/include/CAN/CAN_aux_filterqueue.h
@@ -19,32 +19,41 @@
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef INCLUDE_CAN_CAN_AUX_QUEUE_H_
-#define INCLUDE_CAN_CAN_AUX_QUEUE_H_
+#ifndef INCLUDE_CAN_CAN_AUX_FILTERQUEUE_H_
+#define INCLUDE_CAN_CAN_AUX_FILTERQUEUE_H_
+
 #include "CAN.h"
 #include <stddef.h>
 
-#define CAN_AUX_QUEUE_LENGTH 5
+#define CAN_AUX_FILTERQUEUE_LENGTH 10
 
 /**
  * Initializes the CAN aux message queues
  */
-bool CAN_aux_queue_init(void);
+bool CAN_aux_filterqueue_init(void);
 
 /**
- * Puts a CAN message into the Auxiliary CAN message queue
+ * Configure the CAN aux filterqueue
+ * @param the can bus to filter
+ * @param the low ID range, inclusive
+ * @param the high ID range, inclusive
+ */
+void CAN_aux_filterqueue_configure(uint8_t can_bus, uint32_t low_id_range, uint32_t high_id_range);
+
+/**
+ * Puts a CAN message into the Auxiliary CAN message filterqueue
  * @param msg the CAN message to put
  * @return true if the message was successfully added
  */
-bool CAN_aux_queue_put_msg(CAN_msg * can_msg);
+bool CAN_aux_filterqueue_put_msg(CAN_msg * can_msg);
 
 /**
- * Gets a CAN message from the Auxiliary CAN message queue
+ * Gets a CAN message from the Auxiliary CAN message filterqueue
  * @param can_bus the CAN bus to retrieve from
  * @param msg the CAN message to populate
  * @param timeout to wait in ms
  * @return true if the message was successfully retrieved
  */
-bool CAN_aux_queue_get_msg(uint8_t can_bus, CAN_msg * can_msg, size_t timeout_ms);
+bool CAN_aux_filterqueue_get_msg(CAN_msg * can_msg, size_t timeout_ms);
 
 #endif /* INCLUDE_CAN_CAN_AUX_QUEUE_H_ */

--- a/include/CAN/CAN_aux_filterqueue.h
+++ b/include/CAN/CAN_aux_filterqueue.h
@@ -26,6 +26,7 @@
 #include <stddef.h>
 
 #define CAN_AUX_FILTERQUEUE_LENGTH 10
+#define CAN_AUX_MAX_FILTERQUEUE_POLL 100
 
 /**
  * Initializes the CAN aux message queues

--- a/include/logger/loggerApi.h
+++ b/include/logger/loggerApi.h
@@ -67,6 +67,8 @@ CPP_GUARD_BEGIN
 	API_METHOD("setTrackCfg", api_setTrackConfig)			\
 	API_METHOD("setWifiCfg", api_set_wifi_cfg)			\
 	API_METHOD("sysReset", api_systemReset)				\
+	API_METHOD("txCan", api_tx_can) \
+	API_METHOD("rxCan", api_rx_can) \
 
 
 #if VIRTUAL_CHANNEL_SUPPORT == 1
@@ -261,6 +263,9 @@ int api_set_camera_control_cfg(struct Serial *serial, const jsmntok_t *json);
 int api_set_virtual_channel_value(struct Serial *serial, const jsmntok_t *json);
 #endif
 
+/* CAN bus tx/rx */
+int api_tx_can(struct Serial *serial, const jsmntok_t *json);
+int api_rx_can(struct Serial *serial, const jsmntok_t *json);
 CPP_GUARD_END
 
 #endif /* LOGGERAPI_H_ */

--- a/platform/mk2/config.mk
+++ b/platform/mk2/config.mk
@@ -81,6 +81,7 @@ $(RCP_SRC)/CAN/CAN.c \
 $(RCP_SRC)/CAN/CAN_task.c \
 $(RCP_SRC)/CAN/CAN_dispatcher.c \
 $(RCP_SRC)/CAN/CAN_aux_queue.c \
+$(RCP_SRC)/CAN/CAN_aux_filterqueue.c \
 $(RCP_SRC)/CAN/can_mapping.c \
 $(RCP_SRC)/CAN/can_channels.c \
 $(RCP_SRC)/GPIO/GPIO.c \

--- a/platform/mk3/config.mk
+++ b/platform/mk3/config.mk
@@ -80,6 +80,7 @@ $(RCP_SRC)/CAN/CAN.c \
 $(RCP_SRC)/CAN/CAN_task.c \
 $(RCP_SRC)/CAN/CAN_dispatcher.c \
 $(RCP_SRC)/CAN/CAN_aux_queue.c \
+$(RCP_SRC)/CAN/CAN_aux_filterqueue.c \
 $(RCP_SRC)/CAN/can_mapping.c \
 $(RCP_SRC)/CAN/can_channels.c \
 $(RCP_SRC)/GPIO/GPIO.c \

--- a/platform/rct_mk2/config.mk
+++ b/platform/rct_mk2/config.mk
@@ -79,6 +79,7 @@ $(RCP_SRC)/CAN/CAN.c \
 $(RCP_SRC)/CAN/CAN_task.c \
 $(RCP_SRC)/CAN/CAN_dispatcher.c \
 $(RCP_SRC)/CAN/CAN_aux_queue.c \
+$(RCP_SRC)/CAN/CAN_aux_filterqueue.c \
 $(RCP_SRC)/CAN/can_mapping.c \
 $(RCP_SRC)/CAN/can_channels.c \
 $(RCP_SRC)/GPIO/GPIO.c \

--- a/src/CAN/CAN_aux_filterqueue.c
+++ b/src/CAN/CAN_aux_filterqueue.c
@@ -1,0 +1,72 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "CAN_aux_queue.h"
+#include "capabilities.h"
+#include "printk.h"
+#include "taskUtil.h"
+
+
+#define _LOG_PFX "[CAN AUX FILTERQUEUE] "
+static xQueueHandle can_aux_filterqueue = NULL;
+static uint8_t can_bus = 0;
+static uint32_t low_id_range = 0;
+static uint32_t high_id_range = 0;
+
+bool CAN_aux_filterqueue_init(void)
+{
+        can_aux_filterqueue = xQueueCreate(CAN_AUX_FILTERQUEUE_LENGTH, sizeof(CAN_msg));
+        if (! can_aux_filterqueue) {
+                pr_error_int_msg(_LOG_PFX "Failed to alloc CAN aux filterqueue with size ", CAN_AUX_FILTERQUEUE_LENGTH);
+                return false;
+        }
+        return true;
+}
+
+void CAN_aux_filterqueue_configure(uint8_t new_can_bus, uint32_t new_low_id_range, uint32_t new_high_id_range)
+{
+        can_bus = new_can_bus;
+        low_id_range = new_low_id_range;
+        high_id_range = new_high_id_range;
+}
+
+bool CAN_aux_filterqueue_put_msg(CAN_msg * can_msg)
+{
+        /* match on configured CAN bus */
+        if (can_msg->can_bus != can_bus)
+                return false;
+
+        /* check if in range and if filter is enabled (low and high range > 0)*/
+        if (!(can_msg->addressValue >= low_id_range && can_msg->addressValue <= high_id_range))
+                return false;
+
+        /* add to queue with no delay */
+        if (pdTRUE == xQueueSend(can_aux_filterqueue, can_msg, 0))
+                return true;
+        return false;
+}
+
+bool CAN_aux_filterqueue_get_msg(CAN_msg * can_msg, size_t timeout_ms)
+{
+        if (pdTRUE == xQueueReceive(can_aux_filterqueue, can_msg, msToTicks(timeout_ms)))
+                return true;
+
+        return false;
+}

--- a/src/CAN/CAN_aux_filterqueue.c
+++ b/src/CAN/CAN_aux_filterqueue.c
@@ -18,7 +18,7 @@
  * have received a copy of the GNU General Public License along with
  * this code. If not, see <http://www.gnu.org/licenses/>.
  */
-#include "CAN_aux_queue.h"
+#include "CAN_aux_filterqueue.h"
 #include "capabilities.h"
 #include "printk.h"
 #include "taskUtil.h"

--- a/src/CAN/CAN_aux_queue.c
+++ b/src/CAN/CAN_aux_queue.c
@@ -24,8 +24,7 @@
 #include "taskUtil.h"
 
 
-#define _LOG_PFX "[CAN AUX] "
-#define CAN_AUX_QUEUE_LENGTH 5
+#define _LOG_PFX "[CAN AUX QUEUE] "
 static xQueueHandle can_aux_queue[CAN_CHANNELS] = {0};
 
 bool CAN_aux_queue_init(void)
@@ -40,16 +39,15 @@ bool CAN_aux_queue_init(void)
         return true;
 }
 
-bool CAN_aux_queue_put_msg(CAN_msg * can_msg, size_t timeout_ms)
+bool CAN_aux_queue_put_msg(CAN_msg * can_msg)
 {
         uint8_t can_bus = can_msg->can_bus;
         if (can_bus >= CAN_CHANNELS)
                 return false;
 
-        if (pdTRUE == xQueueSend(can_aux_queue[can_bus], can_msg, msToTicks(timeout_ms)))
+        /* add to queue with no delay */
+        if (pdTRUE == xQueueSend(can_aux_queue[can_bus], can_msg, 0))
                 return true;
-
-        pr_debug("Failed to add CAN message to Auxiliary Queue\r\n");
         return false;
 }
 
@@ -57,6 +55,5 @@ bool CAN_aux_queue_get_msg(uint8_t can_bus, CAN_msg * can_msg, size_t timeout_ms
 {
         if (pdTRUE == xQueueReceive(can_aux_queue[can_bus], can_msg, msToTicks(timeout_ms)))
                 return true;
-
         return false;
 }

--- a/src/CAN/CAN_task.c
+++ b/src/CAN/CAN_task.c
@@ -53,8 +53,8 @@ static void CAN_task(void *parameters)
 
 #if CAN_AUX_QUEUE_SUPPORT == 1
         CAN_aux_queue_init();
-        CAN_aux_filterqueue_init();
 #endif
+        CAN_aux_filterqueue_init();
         while(1) {
                 uint16_t enabled_mapping_count = 0;
                 uint16_t enabled_obd2_pids_count = 0;
@@ -87,8 +87,8 @@ static void CAN_task(void *parameters)
 
 #if CAN_AUX_QUEUE_SUPPORT == 1
                                 CAN_aux_queue_put_msg(&msg);
-                                CAN_aux_filterqueue_put_msg(&msg);
 #endif
+                                CAN_aux_filterqueue_put_msg(&msg);
                         }
                         if (oc->enabled)
                                 sequence_next_obd2_query(oc, enabled_obd2_pids_count);

--- a/src/CAN/CAN_task.c
+++ b/src/CAN/CAN_task.c
@@ -36,6 +36,7 @@
 #include "can_mapping.h"
 #include "can_channels.h"
 #include "CAN_aux_queue.h"
+#include "CAN_aux_filterqueue.h"
 #include "CAN_dispatcher.h"
 
 #define _LOG_PFX                        "[CAN_Task] "
@@ -52,6 +53,7 @@ static void CAN_task(void *parameters)
 
 #if CAN_AUX_QUEUE_SUPPORT == 1
         CAN_aux_queue_init();
+        CAN_aux_filterqueue_init();
 #endif
         while(1) {
                 uint16_t enabled_mapping_count = 0;
@@ -84,7 +86,8 @@ static void CAN_task(void *parameters)
                                 can_dispatch_message(&msg);
 
 #if CAN_AUX_QUEUE_SUPPORT == 1
-                                CAN_aux_queue_put_msg(&msg, 0);
+                                CAN_aux_queue_put_msg(&msg);
+                                CAN_aux_filterqueue_put_msg(&msg);
 #endif
                         }
                         if (oc->enabled)

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -2286,6 +2286,7 @@ int api_set_virtual_channel_value(struct Serial *serial, const jsmntok_t *json)
         set_virtual_channel_value(channel_id, channel_value);
         return API_SUCCESS;
 }
+#endif
 
 int api_tx_can(struct Serial *serial, const jsmntok_t *json)
 /**
@@ -2352,7 +2353,7 @@ int api_rx_can(struct Serial *serial, const jsmntok_t *json)
 
         CAN_msg can_msg;
         size_t count = 0;
-        while (CAN_aux_filterqueue_get_msg(&can_msg, 0) && count < 100) {
+        while (CAN_aux_filterqueue_get_msg(&can_msg, 0) && count < CAN_AUX_MAX_FILTERQUEUE_POLL) {
                 if (count > 0)
                         serial_write_c(serial, ',');
                 json_objStart(serial);
@@ -2371,4 +2372,3 @@ int api_rx_can(struct Serial *serial, const jsmntok_t *json)
 
         return API_SUCCESS_NO_RETURN;
 }
-#endif

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -2364,6 +2364,7 @@ int api_rx_can(struct Serial *serial, const jsmntok_t *json)
                         json_arrayElementInt(serial, can_msg.data[i], i < can_msg.dataLength - 1);
                 }
                 json_arrayEnd(serial, false);
+                json_objEnd(serial, false);
                 count++;
         }
         json_arrayEnd(serial, false);

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -26,6 +26,7 @@
 #include "capabilities.h"
 #include "cellular.h"
 #include "CAN.h"
+#include "CAN_aux_filterqueue.h"
 #include "cellular_api_status_keys.h"
 #include "channel_config.h"
 #include "constants.h"
@@ -2277,12 +2278,97 @@ int api_set_virtual_channel_value(struct Serial *serial, const jsmntok_t *json)
         }
 
         if (channel_id == INVALID_VIRTUAL_CHANNEL) {
-                pr_error_str_msg("Could not make virtual channel ", channel_name);
+                pr_error_str_msg(_LOG_PFX "Could not make virtual channel ", channel_name);
                 //could not make a virutal channel
                 return API_ERROR_SEVERE;
         }
 
         set_virtual_channel_value(channel_id, channel_value);
         return API_SUCCESS;
+}
+
+int api_tx_can(struct Serial *serial, const jsmntok_t *json)
+/**
+ * Transmit a CAN message
+ *  {"txCan": {"id": 12345, "bus": 0, "ext": true, "timeout": 100, "data":[1,2,3,4,5,6,7,8]}}
+ **/
+{
+        uint32_t id;
+        uint8_t bus;
+        bool ext;
+
+        const jsmntok_t *data_tok = jsmn_find_node(json, "data");
+        data_tok = jsmn_find_node_type(data_tok, JSMN_ARRAY);
+
+        if(! (jsmn_exists_set_val_uint32(json, "id", &id) && jsmn_exists_set_val_uint8(json, "bus", &bus, NULL) && jsmn_exists_set_val_bool(json, "ext", &ext) && data_tok)) {
+                pr_error(_LOG_PFX "txCan failed - missing parameters\r\n");
+                return API_ERROR_SEVERE;
+        }
+
+        /* set an optional timeout */
+        uint32_t timeout = 0;
+        jsmn_exists_set_val_uint32(json,"timeout", &timeout);
+
+        CAN_msg msg;
+        msg.addressValue = id;
+        msg.isExtendedAddress = ext;
+
+        /* rail data_length to max length for CAN bus */
+        msg.dataLength = MIN(CAN_MSG_SIZE, data_tok->size);
+        for (size_t i = 0; i < msg.dataLength; i++) {
+                data_tok++;
+                jsmn_trimData(data_tok);
+                msg.data[i] = atoi(data_tok->data);
+        }
+        pr_info_int_msg("sizeof can msg ", sizeof(CAN_msg));
+        return (CAN_tx_msg(bus, &msg, timeout) ? API_SUCCESS : API_ERROR_UNSPECIFIED);
+}
+
+int api_rx_can(struct Serial *serial, const jsmntok_t *json)
+/**
+ * Receive CAN messages, or configure filter for receving
+ * Configure filter: {"rxCan": {"bus": 1, "lowid": 41474, "highid": 41574}}
+ * Poll available messages: {"rxCan": null}
+ * Response: {"rxCan":{"msg":[{"bus":1,"id":41474,"data":[28,12,52,85,85,1,0,1]]}}
+ **/
+{
+        uint8_t can_bus = 0;
+        uint32_t low_id_range = 0;
+        uint32_t high_id_range= 0;
+
+        jsmn_exists_set_val_uint8(json, "bus", &can_bus, NULL);
+        jsmn_exists_set_val_uint32(json, "lowid", &low_id_range);
+        jsmn_exists_set_val_uint32(json, "highid", &high_id_range);
+
+        /* perform configuration and exit */
+        if (low_id_range && high_id_range) {
+                CAN_aux_filterqueue_configure(can_bus, low_id_range, high_id_range);
+                return API_SUCCESS;
+        }
+
+        json_objStart(serial);
+        json_objStartString(serial, "rxCan");
+        json_arrayStart(serial, "msg");
+
+        CAN_msg can_msg;
+        size_t count = 0;
+        while (CAN_aux_filterqueue_get_msg(&can_msg, 0) && count < 100) {
+                if (count > 0)
+                        serial_write_c(serial, ',');
+                json_objStart(serial);
+                json_uint(serial, "bus", can_msg.can_bus, true);
+                json_uint(serial, "id", can_msg.addressValue, true);
+                json_arrayStart(serial, "data");
+                for (size_t i = 0; i < can_msg.dataLength; i++) {
+                        json_arrayElementInt(serial, can_msg.data[i], i < can_msg.dataLength - 1);
+                }
+                json_arrayEnd(serial, false);
+                count++;
+        }
+        json_arrayEnd(serial, false);
+        json_objEnd(serial, false);
+        json_objEnd(serial, false);
+
+        return API_SUCCESS_NO_RETURN;
 }
 #endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -256,6 +256,7 @@ mock_gps_device.c \
 mock_serial.c \
 mock_uart.c \
 mock_usb_comm.c \
+mock_CAN_aux_filterqueue.c \
 
 SIM_C_SRC = \
 $(RCP_SRC)/devices/cellular_api_status_keys.c \

--- a/test/mock_CAN_aux_filterqueue.c
+++ b/test/mock_CAN_aux_filterqueue.c
@@ -1,0 +1,41 @@
+/*
+ * Race Capture Firmware
+ *
+ * Copyright (C) 2016 Autosport Labs
+ *
+ * This file is part of the Race Capture firmware suite
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should
+ * have received a copy of the GNU General Public License along with
+ * this code. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "CAN_aux_filterqueue.h"
+#include "capabilities.h"
+
+bool CAN_aux_filterqueue_init(void)
+{
+        return true;
+}
+
+void CAN_aux_filterqueue_configure(uint8_t new_can_bus, uint32_t new_low_id_range, uint32_t new_high_id_range)
+{
+}
+
+bool CAN_aux_filterqueue_put_msg(CAN_msg * can_msg)
+{
+        return false;
+}
+
+bool CAN_aux_filterqueue_get_msg(CAN_msg * can_msg, size_t timeout_ms)
+{
+        return false;
+}


### PR DESCRIPTION
This adds the ability to send or receive CAN messages from the API that the RC app uses. 

This will allow the app to create views under Setup to customize TireX, AnalogX2, future ShiftX, etc. 

APIs added:
send CAN message: {"txCan": {"id": 123, "bus": 1, "ext": false, "timeout": 50, "data":[1,2,3,4,5,6,7,8]}}

configure CAN rx filter: {"rxCan": {"bus": 1, "lowid": 41474, "highid": 41574}}

request current CAN messages: {"rxCan": null}

response message (may have mulitple CAN messages): {"rxCan":{"msg":[{"bus":1,"id":41474,"data":[28,12,52,85,85,1,0,1]]}}
