### PR TITLE
fix edge case where firmware may crash if GPS data does not change

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+= 2.18.5 =
+* Fix edge case where firmware may crash if GPS data does not change while interpolating points
+
 = 2.18.4 =
 * Enable pit-to-car alert message CAN bus broadcast for app-based telemetry
 

--- a/src/lap_stats/lap_stats.c
+++ b/src/lap_stats/lap_stats.c
@@ -851,7 +851,7 @@ void lapstats_processUpdate(GpsSnapshot *gps_snapshot)
 
         for (size_t i = 0; i < interval_count; i++) {
                 /* Linearly interpolate longitude from latitude */
-                float interp_lon = lon1 + (interp_lat - lat1) * ((lon2 - lon1) / (lat2 - lat1));
+                float interp_lon = lat2 == lat1 ? lon2 : lon1 + (interp_lat - lat1) * ((lon2 - lon1) / (lat2 - lat1));
 
                 /* Update current GPS snapshot with interpolated values */
                 gps_snapshot->sample.point.latitude = interp_lat;

--- a/src/lap_stats/lap_stats.c
+++ b/src/lap_stats/lap_stats.c
@@ -804,22 +804,14 @@ void lapstats_processUpdate(GpsSnapshot *gps_snapshot)
         /**
          * Evenly split up difference in latitiude into intervals
          */
-        float lat_interval = fabsf(lat2 - lat1) / (float)interval_count;
-        if (lat1 > lat2)
-                /* Account for reverse direction */
-                lat_interval = -lat_interval;
-
+        float lat_interval = (lat2 - lat1) / (float)interval_count;
         /* Set the starting interpolated latitude */
         float interp_lat = lat1;
 
         /**
          * Evenly split up difference in longitude into intervals
          */
-        float lon_interval = fabsf(lon2 - lon1) / (float)interval_count;
-        if (lon1 > lon2)
-                /* Account for reverse direction */
-                lon_interval = -lon_interval;
-
+        float lon_interval = (lon2 - lon1) / (float)interval_count;
         /* Set the starting interpolated longitude */
         float interp_lon = lon1;
 
@@ -832,11 +824,7 @@ void lapstats_processUpdate(GpsSnapshot *gps_snapshot)
         float speed2 = gps_snapshot->sample.speed;
 
         /* evenly split up changes in speed based on the interval */
-        float speed_interval = fabsf(speed2 - speed1)/ (float)interval_count;
-        if (speed1 > speed2)
-                /* Account for reverse direction */
-                speed_interval = -speed_interval;
-
+        float speed_interval = (speed2 - speed1)/ (float)interval_count;
         /* Set the starting speed */
         float interp_speed = speed1;
 

--- a/src/lap_stats/lap_stats.c
+++ b/src/lap_stats/lap_stats.c
@@ -796,21 +796,17 @@ void lapstats_processUpdate(GpsSnapshot *gps_snapshot)
          * Set up interpolation for GPS Points
          * ============================================
          */
-        float lat1 = gps_snapshot->previousPoint.latitude;
-        float lon1 = gps_snapshot->previousPoint.longitude;
-        float lat2 = gps_snapshot->sample.point.latitude;
-        float lon2 = gps_snapshot->sample.point.longitude;
 
-        /**
-         * Evenly split up difference in latitiude into intervals
-         */
+        /* Evenly split up difference in latitiude into intervals */
+        float lat1 = gps_snapshot->previousPoint.latitude;
+        float lat2 = gps_snapshot->sample.point.latitude;
         float lat_interval = (lat2 - lat1) / (float)interval_count;
         /* Set the starting interpolated latitude */
         float interp_lat = lat1;
 
-        /**
-         * Evenly split up difference in longitude into intervals
-         */
+        /* Evenly split up difference in longitude into intervals */
+        float lon1 = gps_snapshot->previousPoint.longitude;
+        float lon2 = gps_snapshot->sample.point.longitude;
         float lon_interval = (lon2 - lon1) / (float)interval_count;
         /* Set the starting interpolated longitude */
         float interp_lon = lon1;
@@ -820,10 +816,9 @@ void lapstats_processUpdate(GpsSnapshot *gps_snapshot)
          * Set up interpolation for Speed
          * ============================================
          */
+        /* evenly split up changes in speed based on the interval */
         float speed1 = gps_snapshot->previous_speed;
         float speed2 = gps_snapshot->sample.speed;
-
-        /* evenly split up changes in speed based on the interval */
         float speed_interval = (speed2 - speed1)/ (float)interval_count;
         /* Set the starting speed */
         float interp_speed = speed1;


### PR DESCRIPTION
We automatically interpolate GPS data if the sample rate is < 10Hz. This was originally done due to PodiumConnect receiving 1Hz GPS data from some AIM systems, and sometimes the start/finish point would be missed. 

There's an edge case if the latitude data does not change from point-to-point where a zero division error can occur. 

This fix just assigns the next longitude value during the interpolation if the latitude does not change. 