### PR TITLE
Fix OFFSET minimum calculation when in bit mode

### DIFF
--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -1514,12 +1514,12 @@ static void set_can_mapping(const jsmntok_t *json_mapping, CANMapping *mapping)
 
         jsmn_exists_set_val_uint8(json_mapping, "offset", &mapping->offset, NULL);
         /* rail to maximum CAN mapping offset */
-        mapping->offset = MIN(mapping->offset, MAX_CAN_MAPPING_OFFSET_BYTES * (mapping->bit_mode ? 8 : 1));
+        mapping->offset = MIN(mapping->offset, (mapping->bit_mode ? ((MAX_CAN_MAPPING_OFFSET_BYTES+1) * 8) -1 : MAX_CAN_MAPPING_OFFSET_BYTES));
 
         jsmn_exists_set_val_uint8(json_mapping, "len", &mapping->length, NULL);
         /* rail to maximum CAN mapping length */
         mapping->length = MIN(mapping->length, MAX_CAN_MAPPING_LENGTH_BYTES * (mapping->bit_mode ? 8 : 1));
-
+        
         jsmn_exists_set_val_uint8(json_mapping, "bus", &mapping->can_channel, filter_can_bus_channel);
 
         jsmn_exists_set_val_int(json_mapping, "id", &mapping->can_id);

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -1519,7 +1519,7 @@ static void set_can_mapping(const jsmntok_t *json_mapping, CANMapping *mapping)
         jsmn_exists_set_val_uint8(json_mapping, "len", &mapping->length, NULL);
         /* rail to maximum CAN mapping length */
         mapping->length = MIN(mapping->length, MAX_CAN_MAPPING_LENGTH_BYTES * (mapping->bit_mode ? 8 : 1));
-        
+
         jsmn_exists_set_val_uint8(json_mapping, "bus", &mapping->can_channel, filter_can_bus_channel);
 
         jsmn_exists_set_val_int(json_mapping, "id", &mapping->can_id);


### PR DESCRIPTION
When in bit mode you should be able to select bits beyond 56 (7*8). This change fixes the calculation of what the max should be in bit mode which is 63.