### PR TITLE
P/brent/logging status

### DIFF
--- a/include/logger/api_event.h
+++ b/include/logger/api_event.h
@@ -34,7 +34,8 @@ enum ApiEventType {
         ApiEventType_Alertmessage,
         ApiEventType_AlertmsgAck,
         ApiEventType_AlertmsgReply,
-        ApiEventType_ButtonState
+        ApiEventType_ButtonState,
+        ApiEventType_LoggerStatus
 };
 
 struct alertmessage {

--- a/include/logger/loggerApi.h
+++ b/include/logger/loggerApi.h
@@ -87,13 +87,10 @@ CPP_GUARD_BEGIN
 #define GPS_API_METHODS
 #endif
 
-#if SDCARD_SUPPORT
-#define AUTOLOGGING_METHODS                                     \
-    API_METHOD("getSdLogCtrlCfg", api_get_auto_logger_cfg)     \
-    API_METHOD("setSdLogCtrlCfg", api_set_auto_logger_cfg)
-#else
-#define AUTOLOGGING_METHODS
-#endif
+#define AUTOLOGGING_METHODS                                    \
+        API_METHOD("getSdLogCtrlCfg", api_get_auto_logger_cfg) \
+        API_METHOD("setSdLogCtrlCfg", api_set_auto_logger_cfg) \
+
 
 #if CAMERA_CONTROL  > 0
 #define CAMERA_CONTROL_METHODS                                  \
@@ -180,6 +177,7 @@ int api_flashConfig(struct Serial *serial, const jsmntok_t *json);
 int api_getVersion(struct Serial *serial, const jsmntok_t *json);
 int api_getCapabilities(struct Serial *serial, const jsmntok_t *json);
 int api_getStatus(struct Serial *serial, const jsmntok_t *json);
+int api_send_logging_status(struct Serial* serial);
 int api_systemReset(struct Serial *serial, const jsmntok_t *json);
 int api_factoryReset(struct Serial *serial, const jsmntok_t *json);
 int api_sampleData(struct Serial *serial, const jsmntok_t *json);
@@ -249,10 +247,8 @@ int api_set_telemetry(struct Serial *serial, const jsmntok_t *json);
 /* Volatile setter of active Track */
 int api_set_active_track(struct Serial *serial, const jsmntok_t *json);
 
-#if SDCARD_SUPPORT
 int api_get_auto_logger_cfg(struct Serial *serial, const jsmntok_t *json);
 int api_set_auto_logger_cfg(struct Serial *serial, const jsmntok_t *json);
-#endif
 
 #if CAMERA_CONTROL
 int api_get_camera_control_cfg(struct Serial *serial, const jsmntok_t *json);

--- a/include/logger/loggerConfig.h
+++ b/include/logger/loggerConfig.h
@@ -596,9 +596,7 @@ typedef struct _LoggerConfig {
 
         struct logging_config logging_cfg;
 
-#if SDCARD_SUPPORT
         struct auto_logger_config auto_logger_cfg;
-#endif
 
 #if CAMERA_CONTROL
         struct camera_control_config camera_control_cfg;

--- a/src/logger/api_event.c
+++ b/src/logger/api_event.c
@@ -91,6 +91,8 @@ bool api_event_destroy_callback(const int handle)
 
 void process_api_event(const struct api_event * api_event, struct Serial * serial)
 {
+        /* Dispatch API messages to connected devices */
+
         /* Only try to send if our Serial device is connected */
         if (!serial_is_connected(serial))
                 return;
@@ -117,6 +119,11 @@ void process_api_event(const struct api_event * api_event, struct Serial * seria
                 api_send_button_state(serial, &api_event->data.butt_state);
                 put_crlf(serial);
                 break;
+        case ApiEventType_LoggerStatus:
+                api_send_logging_status(serial);
+                put_crlf(serial);
+                break;
+
         default:
                 pr_warning_int_msg(LOG_PFX "Unknown ApiEvent type ", api_event->type);
                 break;

--- a/src/logger/logger.c
+++ b/src/logger/logger.c
@@ -22,6 +22,7 @@
 
 #include "logger.h"
 #include "dateTime.h"
+#include "api_event.h"
 
 static logging_status_t g_logging_status = LOGGING_STATUS_IDLE;
 static int g_logging_since = 0;
@@ -29,6 +30,13 @@ static int g_logging_since = 0;
 void logging_set_status(logging_status_t status)
 {
         g_logging_status = status;
+
+        /* Broadcast logging state to connected clients */
+        struct api_event event;
+        event.source = NULL; /* not coming from any serial source */
+        event.type = ApiEventType_LoggerStatus;
+        /* Broadcast to active connections */
+        api_event_process_callbacks(&event);
 }
 
 logging_status_t logging_get_status( void )

--- a/src/logger/logger.c
+++ b/src/logger/logger.c
@@ -29,14 +29,15 @@ static int g_logging_since = 0;
 
 void logging_set_status(logging_status_t status)
 {
+        if (status != g_logging_status) {
+                /* Broadcast logging state to connected clients */
+                struct api_event event;
+                event.source = NULL; /* not coming from any serial source */
+                event.type = ApiEventType_LoggerStatus;
+                /* Broadcast to active connections */
+                api_event_process_callbacks(&event);
+        }
         g_logging_status = status;
-
-        /* Broadcast logging state to connected clients */
-        struct api_event event;
-        event.source = NULL; /* not coming from any serial source */
-        event.type = ApiEventType_LoggerStatus;
-        /* Broadcast to active connections */
-        api_event_process_callbacks(&event);
 }
 
 logging_status_t logging_get_status( void )

--- a/src/logger/loggerApi.c
+++ b/src/logger/loggerApi.c
@@ -275,18 +275,26 @@ static void get_bt_status(struct Serial* serial, const bool more)
 #if BLUETOOTH_SUPPORT
         json_objStartString(serial, "bt");
         json_int(serial, "init", (int)bt_get_status(), 0);
-        json_objEnd(serial, 1);
+        json_objEnd(serial, more);
 #endif
 }
 
 static void get_logging_status(struct Serial* serial, const bool more)
 {
-#if SDCARD_SUPPORT
         json_objStartString(serial, "logging");
         json_int(serial, "status", (int)logging_get_status(), 1);
         json_int(serial, "dur", logging_active_time(), 0);
-        json_objEnd(serial, 1);
-#endif
+        json_objEnd(serial, more);
+}
+
+int api_send_logging_status(struct Serial* serial)
+{
+        json_objStart(serial);
+        json_objStartString(serial, "status");
+        get_logging_status(serial, false);
+        json_objEnd(serial, false);
+        json_objEnd(serial, false);
+        return API_SUCCESS_NO_RETURN;
 }
 
 int api_getStatus(struct Serial *serial, const jsmntok_t *json)
@@ -2193,7 +2201,6 @@ int api_set_active_track(struct Serial *serial, const jsmntok_t *json)
         return API_SUCCESS;
 }
 
-#if SDCARD_SUPPORT
 int api_get_auto_logger_cfg(struct Serial *serial, const jsmntok_t *json)
 {
         struct auto_logger_config* cfg =
@@ -2214,7 +2221,6 @@ int api_set_auto_logger_cfg(struct Serial *serial, const jsmntok_t *json)
         return auto_logger_set_config(cfg, json) ?
                API_SUCCESS : API_ERROR_UNSPECIFIED;
 }
-#endif
 
 #if CAMERA_CONTROL
 int api_get_camera_control_cfg(struct Serial *serial, const jsmntok_t *json)

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -151,7 +151,7 @@ char filterPwmLoggingMode(int config)
 }
 #endif
 
-#if GPIO_CHANNELS > 1
+#if GPIO_CHANNELS > 0
 GPIOConfig * getGPIOConfigChannel(int channel)
 {
         GPIOConfig *c = NULL;

--- a/src/logger/loggerConfig.c
+++ b/src/logger/loggerConfig.c
@@ -151,7 +151,7 @@ char filterPwmLoggingMode(int config)
 }
 #endif
 
-#if GPIO_CHANNELS > 0
+#if GPIO_CHANNELS > 1
 GPIOConfig * getGPIOConfigChannel(int channel)
 {
         GPIOConfig *c = NULL;
@@ -773,9 +773,9 @@ void reset_logger_config(void)
         resetConnectivityConfig(&lc->ConnectivityConfigs);
         reset_logging_config(&lc->logging_cfg);
 
-#if SDCARD_SUPPORT
+
         auto_logger_reset_config(&lc->auto_logger_cfg);
-#endif
+
 
 #if CAMERA_CONTROL
         camera_control_reset_config(&lc->camera_control_cfg);

--- a/src/logger/loggerTaskEx.c
+++ b/src/logger/loggerTaskEx.c
@@ -92,11 +92,18 @@ void configChanged()
 void startLogging()
 {
         g_loggingShouldRun = 1;
+
+#if SDCARD_SUPPORT == 0
+        logging_set_status(LOGGING_STATUS_WRITING);
+#endif
 }
 
 void stopLogging()
 {
         g_loggingShouldRun = 0;
+#if SDCARD_SUPPORT == 0
+        logging_set_status(LOGGING_STATUS_IDLE);
+#endif
 }
 
 static void logging_started()
@@ -187,9 +194,7 @@ void loggerTaskEx(void *params)
         camera_control_init(&loggerConfig->camera_control_cfg);
 #endif
 
-#if SDCARD_SUPPORT
         auto_logger_init(&loggerConfig->auto_logger_cfg);
-#endif
 
         while (1) {
                 xSemaphoreTake(onTick, portMAX_DELAY);

--- a/src/logger/loggerTaskEx.c
+++ b/src/logger/loggerTaskEx.c
@@ -91,19 +91,23 @@ void configChanged()
 
 void startLogging()
 {
-        g_loggingShouldRun = 1;
 
 #if SDCARD_SUPPORT == 0
-        logging_set_status(LOGGING_STATUS_WRITING);
+        if (!g_loggingShouldRun) {
+                logging_set_status(LOGGING_STATUS_WRITING);
+        }
 #endif
+        g_loggingShouldRun = 1;
 }
 
 void stopLogging()
 {
-        g_loggingShouldRun = 0;
 #if SDCARD_SUPPORT == 0
-        logging_set_status(LOGGING_STATUS_IDLE);
+        if (g_loggingShouldRun) {
+                logging_set_status(LOGGING_STATUS_IDLE);
+        }
 #endif
+        g_loggingShouldRun = 0;
 }
 
 static void logging_started()

--- a/src/logger/loggerTaskEx.c
+++ b/src/logger/loggerTaskEx.c
@@ -92,22 +92,18 @@ void configChanged()
 void startLogging()
 {
 
-#if SDCARD_SUPPORT == 0
-        if (!g_loggingShouldRun) {
-                logging_set_status(LOGGING_STATUS_WRITING);
-        }
-#endif
         g_loggingShouldRun = 1;
+#if SDCARD_SUPPORT == 0
+        logging_set_status(LOGGING_STATUS_WRITING);
+#endif
 }
 
 void stopLogging()
 {
-#if SDCARD_SUPPORT == 0
-        if (g_loggingShouldRun) {
-                logging_set_status(LOGGING_STATUS_IDLE);
-        }
-#endif
         g_loggingShouldRun = 0;
+#if SDCARD_SUPPORT == 0
+        logging_set_status(LOGGING_STATUS_IDLE);
+#endif
 }
 
 static void logging_started()

--- a/src/system/flags.c
+++ b/src/system/flags.c
@@ -95,9 +95,7 @@ static const char* feature_flags[] = {
         FEATURE_FLAG("wifi")
 #endif
 
-#if SDCARD_SUPPORT
         FEATURE_FLAG("sd")
-#endif
 
 #if CAMERA_CONTROL
         FEATURE_FLAG("camctl")


### PR DESCRIPTION
This allows the current firmware to broadcast logging start/stop messages when the Automatic Control mechanism is triggered. 

The point is to allow the app to start/stop logging synchronized with the Automatic Control feature - which can also control cameras.  This will allow us to make video + data files that are more precisely synchronized.

https://user-images.githubusercontent.com/3267533/183531817-0f7720e5-1337-48ab-94f5-aa658fdcd994.mp4


